### PR TITLE
feat: migrated support statuses to new ones

### DIFF
--- a/apps/admin/_handlers/statistics/innovation-per-organisation-unit.handler.spec.ts
+++ b/apps/admin/_handlers/statistics/innovation-per-organisation-unit.handler.spec.ts
@@ -5,9 +5,7 @@ import { StatisticsService } from '../../_services/statistics.service';
 
 describe('Actions To Review Statistics Handler Suite', () => {
   // const testsHelper = new TestsHelper();
-  const expected = {
-    COMPLETE: randNumber()
-  };
+  const expected = { CLOSED: randNumber() };
   const mock = jest
     .spyOn(StatisticsService.prototype, 'getOrganisationUnitInnovationCounters')
     .mockResolvedValue(expected);

--- a/apps/admin/_services/organisations.service.spec.ts
+++ b/apps/admin/_services/organisations.service.spec.ts
@@ -175,11 +175,11 @@ describe('Admin / _services / organisations service suite', () => {
       });
     });
 
-    describe.each([InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED])(
+    describe.each([InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.WAITING])(
       '%s supports of unit',
       status => {
         const support = scenario.users.johnInnovator.innovations.johnInnovation.supports.supportByHealthOrgAiUnit;
-        it('should complete the support', async () => {
+        it('should close the support', async () => {
           //prepare support
           await em.getRepository(InnovationSupportEntity).update({ id: support.id }, { status: status });
 
@@ -190,7 +190,7 @@ describe('Admin / _services / organisations service suite', () => {
             .where('support.id = :supportId', { supportId: support.id })
             .getOne();
 
-          expect(dbSupport?.status).toBe(InnovationSupportStatusEnum.COMPLETE);
+          expect(dbSupport?.status).toBe(InnovationSupportStatusEnum.CLOSED);
         });
 
         it('should clear all related notifications', async () => {

--- a/apps/admin/_services/organisations.service.ts
+++ b/apps/admin/_services/organisations.service.ts
@@ -78,28 +78,22 @@ export class OrganisationsService extends BaseService {
         .getRawMany()
     ).map(ur => ({ id: ur.userId as string, identityId: ur.identityId as string }));
 
-    // only want to clear actions with these statuses
-    const actionStatusToClear = [InnovationTaskStatusEnum.OPEN];
-
     //get id of actions to clear issued by the unit users
-    const actionsToClear = (
+    const tasksToClear = (
       await em
         .createQueryBuilder(InnovationTaskEntity, 'action')
         .leftJoinAndSelect('action.innovationSupport', 'support')
         .leftJoinAndSelect('support.organisationUnit', 'unit')
         .where('unit.id = :unitId', { unitId })
-        .andWhere('action.status IN (:...actionStatusToClear)', { actionStatusToClear })
+        .andWhere('action.status = :openTaskStatus', { openTaskStatus: InnovationTaskStatusEnum.OPEN })
         .getMany()
     ).map(a => a.id);
 
     //only want to complete the support of innovations with these statuses
-    const supportStatusToComplete = [
-      InnovationSupportStatusEnum.ENGAGING,
-      InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED
-    ];
+    const supportStatusToComplete = [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.WAITING];
 
     //get supports to complete
-    const supportsToComplete = await em
+    const supportsToClose = await em
       .createQueryBuilder(InnovationSupportEntity, 'support')
       .leftJoinAndSelect('support.organisationUnit', 'unit')
       .leftJoinAndSelect('support.innovation', 'innovation')
@@ -108,7 +102,7 @@ export class OrganisationsService extends BaseService {
       .andWhere('support.status IN (:...supportStatusToComplete)', { supportStatusToComplete })
       .getMany();
 
-    const contexts = [...actionsToClear, ...supportsToComplete.map(s => s.id)];
+    const contexts = [...tasksToClear, ...supportsToClose.map(s => s.id)];
 
     let notificationsToMarkAsRead: NotificationEntity[] = [];
 
@@ -128,24 +122,22 @@ export class OrganisationsService extends BaseService {
       await transaction.update(OrganisationUnitEntity, { id: unitId }, { inactivatedAt: now });
 
       // Clear actions issued by unit
-      if (actionsToClear.length > 0) {
+      if (tasksToClear.length > 0) {
         await transaction.update(
           InnovationTaskEntity,
-          { id: In(actionsToClear) },
+          { id: In(tasksToClear) },
           { status: InnovationTaskStatusEnum.CANCELLED }
         );
       }
 
-      // Complete supports of unit
-      if (supportsToComplete.length > 0) {
-        const supportIds = supportsToComplete.map(s => s.id);
+      // Close supports of unit
+      if (supportsToClose.length > 0) {
+        const supportIds = supportsToClose.map(s => s.id);
 
         await transaction.update(
           InnovationSupportEntity,
           { id: In(supportIds) },
-          {
-            status: InnovationSupportStatusEnum.COMPLETE
-          }
+          { status: InnovationSupportStatusEnum.CLOSED }
         );
 
         await transaction
@@ -195,7 +187,7 @@ export class OrganisationsService extends BaseService {
         await transaction.update(OrganisationEntity, { id: organisationId }, { inactivatedAt: now });
       }
 
-      for (const support of supportsToComplete) {
+      for (const support of supportsToClose) {
         await this.domainService.innovations.addSupportLog(
           transaction,
           { id: domainContext.id, roleId: domainContext.currentRole.id },

--- a/apps/admin/_services/statistics.service.spec.ts
+++ b/apps/admin/_services/statistics.service.spec.ts
@@ -1,13 +1,11 @@
-
 import { TestsHelper } from '@admin/shared/tests';
 
-import { container } from '../_config';
-import SYMBOLS from './symbols';
-import type { EntityManager } from 'typeorm';
-import type { StatisticsService } from './statistics.service';
-import { InnovationSupportEntity, OrganisationUnitEntity } from '@admin/shared/entities';
+import { InnovationEntity, InnovationSupportEntity, OrganisationUnitEntity } from '@admin/shared/entities';
 import { InnovationSupportStatusEnum } from '@admin/shared/enums';
-import { InnovationEntity } from '@admin/shared/entities';
+import type { EntityManager } from 'typeorm';
+import { container } from '../_config';
+import type { StatisticsService } from './statistics.service';
+import SYMBOLS from './symbols';
 
 describe('Admin / _services / announcements service suite', () => {
   let sut: StatisticsService;
@@ -33,39 +31,47 @@ describe('Admin / _services / announcements service suite', () => {
 
   describe('getOrganisationUnitInnovationCounters', () => {
     it('should return the count of innovations in each support status for the given organisation unit', async () => {
-      const resultBefore = await sut.getOrganisationUnitInnovationCounters(scenario.organisations.healthOrg.organisationUnits.healthOrgUnit.id, undefined, em)
+      const resultBefore = await sut.getOrganisationUnitInnovationCounters(
+        scenario.organisations.healthOrg.organisationUnits.healthOrgUnit.id,
+        undefined,
+        em
+      );
 
-      expect(resultBefore).toMatchObject({ ENGAGING: 4 })
+      expect(resultBefore).toMatchObject({ ENGAGING: 4 });
 
       await em.getRepository(InnovationSupportEntity).save({
         status: InnovationSupportStatusEnum.ENGAGING,
         innovation: InnovationEntity.new({ id: scenario.users.adamInnovator.innovations.adamInnovationEmpty.id }),
-        organisationUnit: OrganisationUnitEntity.new({ id: scenario.organisations.healthOrg.organisationUnits.healthOrgUnit.id })
-      })
+        organisationUnit: OrganisationUnitEntity.new({
+          id: scenario.organisations.healthOrg.organisationUnits.healthOrgUnit.id
+        })
+      });
 
-      const result = await sut.getOrganisationUnitInnovationCounters(scenario.organisations.healthOrg.organisationUnits.healthOrgUnit.id, undefined, em)
+      const result = await sut.getOrganisationUnitInnovationCounters(
+        scenario.organisations.healthOrg.organisationUnits.healthOrgUnit.id,
+        undefined,
+        em
+      );
 
-      expect(result).toMatchObject({ ENGAGING: 5 })
-    })
+      expect(result).toMatchObject({ ENGAGING: 5 });
+    });
 
     it('should return the count of innovations in each ongoing support status for the given organisation unit', async () => {
       await em.getRepository(InnovationSupportEntity).save({
         status: InnovationSupportStatusEnum.UNASSIGNED,
         innovation: InnovationEntity.new({ id: scenario.users.adamInnovator.innovations.adamInnovationEmpty.id }),
-        organisationUnit: OrganisationUnitEntity.new({ id: scenario.organisations.healthOrg.organisationUnits.healthOrgUnit.id })
-      })
+        organisationUnit: OrganisationUnitEntity.new({
+          id: scenario.organisations.healthOrg.organisationUnits.healthOrgUnit.id
+        })
+      });
 
-      await em.getRepository(InnovationSupportEntity).save({
-        status: InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED,
-        innovation: InnovationEntity.new({ id: scenario.users.johnInnovator.innovations.johnInnovationEmpty.id }),
-        organisationUnit: OrganisationUnitEntity.new({ id: scenario.organisations.healthOrg.organisationUnits.healthOrgUnit.id })
-      })
+      const result = await sut.getOrganisationUnitInnovationCounters(
+        scenario.organisations.healthOrg.organisationUnits.healthOrgUnit.id,
+        true,
+        em
+      );
 
-      const result = await sut.getOrganisationUnitInnovationCounters(scenario.organisations.healthOrg.organisationUnits.healthOrgUnit.id, true, em)
-
-      expect(result).toMatchObject({ ENGAGING: 4, FURTHER_INFO_REQUIRED: 1 })
-
-    })
+      expect(result).toMatchObject({ ENGAGING: 4 });
+    });
   });
-
 });

--- a/apps/admin/_services/statistics.service.ts
+++ b/apps/admin/_services/statistics.service.ts
@@ -2,8 +2,8 @@ import { injectable } from 'inversify';
 
 import { InnovationEntity } from '@admin/shared/entities';
 import { InnovationSupportStatusEnum } from '@admin/shared/enums';
-import { BaseService } from './base.service';
 import type { EntityManager } from 'typeorm';
+import { BaseService } from './base.service';
 
 @injectable()
 export class StatisticsService extends BaseService {
@@ -14,7 +14,7 @@ export class StatisticsService extends BaseService {
    *       might or might not be relevant to distinguish them.
    *
    * @param organisationUnitId the organisation unit
-   * @param onlyOpen if true, only returns the number of innovations with open statuses (ENGAGING, FURTHER_INFO_REQUIRED)
+   * @param onlyOpen if true, only returns the number of innovations with open statuses (ENGAGING)
    * @returns dictionary of status and number of innovations
    */
   async getOrganisationUnitInnovationCounters(
@@ -35,9 +35,7 @@ export class StatisticsService extends BaseService {
       });
 
     if (onlyOpen) {
-      query.andWhere('supports.status IN (:...statuses)', {
-        statuses: [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED]
-      });
+      query.andWhere('supports.status = :engageStatus', { engageStatus: InnovationSupportStatusEnum.ENGAGING });
     }
 
     query.groupBy('supports.status');
@@ -47,9 +45,12 @@ export class StatisticsService extends BaseService {
         count: number;
         status: InnovationSupportStatusEnum;
       }>()
-    ).reduce((acc, cur) => {
-      acc[cur.status] = cur.count;
-      return acc;
-    }, {} as { [k in InnovationSupportStatusEnum]?: number });
+    ).reduce(
+      (acc, cur) => {
+        acc[cur.status] = cur.count;
+        return acc;
+      },
+      {} as { [k in InnovationSupportStatusEnum]?: number }
+    );
   }
 }

--- a/apps/admin/v1-organisation-unit-statistics/index.spec.ts
+++ b/apps/admin/v1-organisation-unit-statistics/index.spec.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
   await testsHelper.init();
 });
 
-const expected = { COMPLETE: randNumber() };
+const expected = { CLOSED: randNumber() };
 const mock = jest
   .spyOn(StatisticsService.prototype, 'getOrganisationUnitInnovationCounters')
   .mockResolvedValue(expected);

--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -1517,19 +1517,16 @@ paths:
                   type: string
                   enum:
                     - ENGAGING
-                    - COMPLETE
+                    - CLOSED
               - type: array
                 items:
                   type: string
                   enum:
                     - UNASSIGNED
-                    - FURTHER_INFO_REQUIRED
-                    - WAITING
-                    - NOT_YET
                     - ENGAGING
+                    - WAITING
                     - UNSUITABLE
-                    - WITHDRAWN
-                    - COMPLETE
+                    - CLOSED
         - name: groupedStatuses
           in: query
           required: false
@@ -2984,12 +2981,11 @@ paths:
                 status:
                   type: string
                   enum:
+                    - UNASSIGNED
                     - ENGAGING
-                    - FURTHER_INFO_REQUIRED
                     - WAITING
-                    - NOT_YET
                     - UNSUITABLE
-                    - COMPLETE
+                    - CLOSED
                 message:
                   type: string
                   maxLength: 400
@@ -3100,12 +3096,11 @@ paths:
                 status:
                   type: string
                   enum:
+                    - UNASSIGNED
                     - ENGAGING
-                    - FURTHER_INFO_REQUIRED
                     - WAITING
-                    - NOT_YET
                     - UNSUITABLE
-                    - COMPLETE
+                    - CLOSED
                 message:
                   type: string
                   maxLength: 400
@@ -3191,13 +3186,10 @@ paths:
                           type: string
                           enum:
                             - UNASSIGNED
-                            - FURTHER_INFO_REQUIRED
-                            - WAITING
-                            - NOT_YET
                             - ENGAGING
+                            - WAITING
                             - UNSUITABLE
-                            - WITHDRAWN
-                            - COMPLETE
+                            - CLOSED
                         start:
                           type: string
                         end:
@@ -3366,13 +3358,10 @@ paths:
                           type: string
                           enum:
                             - UNASSIGNED
-                            - FURTHER_INFO_REQUIRED
-                            - WAITING
-                            - NOT_YET
                             - ENGAGING
+                            - WAITING
                             - UNSUITABLE
-                            - WITHDRAWN
-                            - COMPLETE
+                            - CLOSED
                         message:
                           type: string
                         title:

--- a/apps/innovations/_services/innovation-assessments.service.spec.ts
+++ b/apps/innovations/_services/innovation-assessments.service.spec.ts
@@ -308,7 +308,7 @@ describe('Innovation Assessments Suite', () => {
       await em.update(
         InnovationSupportEntity,
         { innovation: { id: innovationWithAssessment.id } },
-        { status: InnovationSupportStatusEnum.COMPLETE }
+        { status: InnovationSupportStatusEnum.CLOSED }
       );
       const innovationReassessment = await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
@@ -359,7 +359,7 @@ describe('Innovation Assessments Suite', () => {
         await em.update(
           InnovationSupportEntity,
           { innovation: { id: innovationWithAssessment.id } },
-          { status: InnovationSupportStatusEnum.COMPLETE }
+          { status: InnovationSupportStatusEnum.CLOSED }
         );
         const innovationReassessment = await sut.createInnovationReassessment(
           DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),

--- a/apps/innovations/_services/innovation-assessments.service.ts
+++ b/apps/innovations/_services/innovation-assessments.service.ts
@@ -405,9 +405,7 @@ export class InnovationAssessmentsService extends BaseService {
       .andWhere('innovation.status = :innovationStatus', {
         innovationStatus: InnovationStatusEnum.IN_PROGRESS
       })
-      .andWhere('supports.status IN (:...supportStatus)', {
-        supportStatus: [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED]
-      })
+      .andWhere('supports.status = :engagingStatus', { engagingStatus: InnovationSupportStatusEnum.ENGAGING })
       .getCount();
     if (hasOngoingSupports > 0) {
       throw new UnprocessableEntityError(InnovationErrorsEnum.INNOVATION_CANNOT_REQUEST_REASSESSMENT);

--- a/apps/innovations/_services/innovation-tasks.service.ts
+++ b/apps/innovations/_services/innovation-tasks.service.ts
@@ -160,10 +160,7 @@ export class InnovationTasksService extends BaseService {
 
       if (domainContext.currentRole.role === ServiceRoleEnum.ACCESSOR) {
         query.andWhere('accessorSupports.status IN (:...accessorSupportsSupportStatuses01)', {
-          accessorSupportsSupportStatuses01: [
-            InnovationSupportStatusEnum.ENGAGING,
-            InnovationSupportStatusEnum.COMPLETE
-          ]
+          accessorSupportsSupportStatuses01: [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.CLOSED]
         });
         // query.andWhere('accessorSupports.organisation_unit_id = :organisationUnitId ', { organisationUnitId: user.organisationUnitId });
       }

--- a/apps/innovations/_services/innovations.service.ts
+++ b/apps/innovations/_services/innovations.service.ts
@@ -264,10 +264,7 @@ export class InnovationsService extends BaseService {
 
       if (domainContext.currentRole.role === ServiceRoleEnum.ACCESSOR) {
         innovationFetchQuery.andWhere('accessorSupports.status IN (:...accessorSupportsSupportStatuses01)', {
-          accessorSupportsSupportStatuses01: [
-            InnovationSupportStatusEnum.ENGAGING,
-            InnovationSupportStatusEnum.COMPLETE
-          ]
+          accessorSupportsSupportStatuses01: [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.CLOSED]
         });
       }
 

--- a/apps/innovations/_services/statistics.service.ts
+++ b/apps/innovations/_services/statistics.service.ts
@@ -133,9 +133,7 @@ export class StatisticsService extends BaseService {
       .innerJoin('innovationSupport.organisationUnit', 'organisationUnit')
       .where('innovation.id = :innovationId', { innovationId })
       .andWhere('organisationUnit.id = :organisationUnit', { organisationUnit })
-      .andWhere('innovationSupport.status IN (:...status)', {
-        status: [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED]
-      })
+      .andWhere('innovationSupport.status = :engagingStatus', { engagingStatus: InnovationSupportStatusEnum.ENGAGING })
       .getOne();
 
     const supportStartedAt = innovationSupport?.updatedAt;

--- a/apps/innovations/v1-innovation-support-change-request/index.ts
+++ b/apps/innovations/v1-innovation-support-change-request/index.ts
@@ -9,6 +9,7 @@ import type { CustomContextType } from '@innovations/shared/types';
 
 import { container } from '../_config';
 
+import { InnovationSupportStatusEnum } from '@innovations/shared/enums';
 import type { InnovationSupportsService } from '../_services/innovation-supports.service';
 import SYMBOLS from '../_services/symbols';
 import type { ResponseDTO } from './transformation.dtos';
@@ -82,7 +83,7 @@ export default openApi(
               properties: {
                 status: {
                   type: 'string',
-                  enum: ['ENGAGING', 'FURTHER_INFO_REQUIRED', 'WAITING', 'NOT_YET', 'UNSUITABLE', 'COMPLETE']
+                  enum: Object.values(InnovationSupportStatusEnum)
                 },
                 message: {
                   type: 'string',

--- a/apps/innovations/v1-innovation-support-change-request/validation.schemas.ts
+++ b/apps/innovations/v1-innovation-support-change-request/validation.schemas.ts
@@ -20,7 +20,7 @@ export type BodyType = {
 export const BodySchema = Joi.object<BodyType>({
   status: Joi.string()
     .valid(...Object.values(InnovationSupportStatusEnum))
-    .disallow(InnovationSupportStatusEnum.UNASSIGNED, InnovationSupportStatusEnum.WITHDRAWN)
+    .disallow(InnovationSupportStatusEnum.UNASSIGNED)
     .required(),
   message: Joi.string().max(TEXTAREA_LENGTH_LIMIT.xl).trim().required()
 }).required();

--- a/apps/innovations/v1-innovation-support-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-create/index.spec.ts
@@ -42,7 +42,8 @@ describe('v1-innovation-support-change-request Suite', () => {
         })
         .setBody<BodyType>({
           message: randText(),
-          status: InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED
+          status: InnovationSupportStatusEnum.ENGAGING,
+          accessors: [{ id: randUuid(), userRoleId: randUuid() }]
         })
         .call<ResponseDTO>(azureFunction);
 
@@ -69,7 +70,8 @@ describe('v1-innovation-support-change-request Suite', () => {
         })
         .setBody<BodyType>({
           message: randText(),
-          status: InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED
+          status: InnovationSupportStatusEnum.ENGAGING,
+          accessors: [{ id: randUuid(), userRoleId: randUuid() }]
         })
         .call<ErrorResponseType>(azureFunction);
 

--- a/apps/innovations/v1-innovation-support-create/validation.schemas.ts
+++ b/apps/innovations/v1-innovation-support-create/validation.schemas.ts
@@ -19,11 +19,9 @@ export const BodySchema = Joi.object<BodyType>({
   status: Joi.string()
     .valid(
       InnovationSupportStatusEnum.ENGAGING,
-      InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED,
       InnovationSupportStatusEnum.WAITING,
-      InnovationSupportStatusEnum.NOT_YET,
       InnovationSupportStatusEnum.UNSUITABLE,
-      InnovationSupportStatusEnum.COMPLETE
+      InnovationSupportStatusEnum.CLOSED
     )
     .required(),
   message: Joi.string().max(TEXTAREA_LENGTH_LIMIT.xl).trim().required(),

--- a/apps/innovations/v1-innovation-support-update/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-update/index.spec.ts
@@ -42,7 +42,7 @@ describe('v1-innovation-support-update', () => {
         })
         .setBody<BodyType>({
           message: randText(),
-          status: InnovationSupportStatusEnum.NOT_YET
+          status: InnovationSupportStatusEnum.WAITING
         })
         .call<never>(azureFunction);
 
@@ -70,7 +70,7 @@ describe('v1-innovation-support-update', () => {
         })
         .setBody<BodyType>({
           message: randText(),
-          status: InnovationSupportStatusEnum.NOT_YET
+          status: InnovationSupportStatusEnum.WAITING
         })
         .call<ErrorResponseType>(azureFunction);
 

--- a/apps/innovations/v1-innovation-support-update/index.ts
+++ b/apps/innovations/v1-innovation-support-update/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { ServiceRoleEnum } from '@innovations/shared/enums';
+import { InnovationSupportStatusEnum, ServiceRoleEnum } from '@innovations/shared/enums';
 import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -85,7 +85,7 @@ export default openApi(
               properties: {
                 status: {
                   type: 'string',
-                  enum: ['ENGAGING', 'FURTHER_INFO_REQUIRED', 'WAITING', 'NOT_YET', 'UNSUITABLE', 'COMPLETE']
+                  enum: Object.values(InnovationSupportStatusEnum)
                 },
                 message: {
                   type: 'string',

--- a/apps/innovations/v1-innovation-support-update/validation.schemas.ts
+++ b/apps/innovations/v1-innovation-support-update/validation.schemas.ts
@@ -21,11 +21,9 @@ export const BodySchema = Joi.object<BodyType>({
   status: Joi.string()
     .valid(
       InnovationSupportStatusEnum.ENGAGING,
-      InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED,
       InnovationSupportStatusEnum.WAITING,
-      InnovationSupportStatusEnum.NOT_YET,
       InnovationSupportStatusEnum.UNSUITABLE,
-      InnovationSupportStatusEnum.COMPLETE
+      InnovationSupportStatusEnum.CLOSED
     )
     .required(),
   message: Joi.string().max(TEXTAREA_LENGTH_LIMIT.xl).trim().required(),

--- a/apps/innovations/v1-innovation-supports-list/index.spec.ts
+++ b/apps/innovations/v1-innovation-supports-list/index.spec.ts
@@ -28,7 +28,7 @@ beforeAll(async () => {
 const expected = [
   {
     id: randUuid(),
-    status: InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED,
+    status: InnovationSupportStatusEnum.WAITING,
     organisation: {
       id: randUuid(),
       name: randCompanyName(),

--- a/apps/innovations/v1-innovations-list/index.spec.ts
+++ b/apps/innovations/v1-innovations-list/index.spec.ts
@@ -79,7 +79,7 @@ const expected = {
       supports: [
         {
           id: randUuid(),
-          status: InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED,
+          status: InnovationSupportStatusEnum.WAITING,
           updatedAt: randPastDate(),
           organisation: {
             id: randUuid(),

--- a/apps/innovations/v1-innovations-list/validation.schemas.ts
+++ b/apps/innovations/v1-innovations-list/validation.schemas.ts
@@ -85,7 +85,7 @@ export const QueryParamsSchema = JoiHelper.PaginationJoiSchema({
       is: 'ACCESSOR',
       then: JoiHelper.AppCustomJoi()
         .stringArray()
-        .items(Joi.string().valid(InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.COMPLETE))
+        .items(Joi.string().valid(InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.CLOSED))
         .optional(),
       otherwise: JoiHelper.AppCustomJoi()
         .stringArray()

--- a/apps/notifications/_handlers/innovation-support-status-change-request.handler.spec.ts
+++ b/apps/notifications/_handlers/innovation-support-status-change-request.handler.spec.ts
@@ -63,7 +63,7 @@ describe('Notifications / _handlers / innovation-support-status-change-request h
         params: {
           innovation_name: innovation.name,
           accessor_name: scenario.users.ingridAccessor.name,
-          proposed_status: 'completed',
+          proposed_status: 'closed',
           request_status_update_comment: requestComment,
           innovation_url: new UrlModel(ENV.webBaseTransactionalUrl)
             .addPath('accessor/innovations/:innovationId/support/:supportId')
@@ -105,7 +105,7 @@ describe('Notifications / _handlers / innovation-support-status-change-request h
         params: {
           innovation_name: innovation.name,
           accessor_name: 'user',
-          proposed_status: 'completed',
+          proposed_status: 'closed',
           request_status_update_comment: requestComment,
           innovation_url: new UrlModel(ENV.webBaseTransactionalUrl)
             .addPath('accessor/innovations/:innovationId/support/:supportId')

--- a/apps/notifications/_handlers/innovation-support-status-change-request.handler.spec.ts
+++ b/apps/notifications/_handlers/innovation-support-status-change-request.handler.spec.ts
@@ -1,12 +1,12 @@
-import { InnovationSupportStatusChangeRequestHandler } from './innovation-support-status-change-request.handler';
-import { CompleteScenarioType, MocksHelper, TestsHelper } from '@notifications/shared/tests';
-import { RecipientsService } from '../_services/recipients.service';
-import { DTOsHelper } from '@notifications/shared/tests/helpers/dtos.helper';
-import { InnovationSupportStatusEnum } from '@notifications/shared/enums';
 import { randText } from '@ngneat/falso';
-import { ENV, EmailTypeEnum } from '../_config';
+import { InnovationSupportStatusEnum } from '@notifications/shared/enums';
 import { UrlModel } from '@notifications/shared/models';
+import { CompleteScenarioType, MocksHelper, TestsHelper } from '@notifications/shared/tests';
+import { DTOsHelper } from '@notifications/shared/tests/helpers/dtos.helper';
 import type { InnovatorDomainContextType } from '@notifications/shared/types';
+import { ENV, EmailTypeEnum } from '../_config';
+import { RecipientsService } from '../_services/recipients.service';
+import { InnovationSupportStatusChangeRequestHandler } from './innovation-support-status-change-request.handler';
 
 describe('Notifications / _handlers / innovation-support-status-change-request handler suite', () => {
   let testsHelper: TestsHelper;
@@ -47,7 +47,7 @@ describe('Notifications / _handlers / innovation-support-status-change-request h
       {
         innovationId: innovation.id,
         supportId: innovation.supports.supportByHealthOrgUnit.id,
-        proposedStatus: InnovationSupportStatusEnum.COMPLETE,
+        proposedStatus: InnovationSupportStatusEnum.CLOSED,
         requestStatusUpdateComment: requestComment
       },
       MocksHelper.mockContext()
@@ -89,7 +89,7 @@ describe('Notifications / _handlers / innovation-support-status-change-request h
       {
         innovationId: innovation.id,
         supportId: innovation.supports.supportByHealthOrgUnit.id,
-        proposedStatus: InnovationSupportStatusEnum.COMPLETE,
+        proposedStatus: InnovationSupportStatusEnum.CLOSED,
         requestStatusUpdateComment: requestComment
       },
       MocksHelper.mockContext()
@@ -120,9 +120,7 @@ describe('Notifications / _handlers / innovation-support-status-change-request h
   });
 
   it('Should not send any email if QA is found', async () => {
-    jest
-      .spyOn(RecipientsService.prototype, 'organisationUnitsQualifyingAccessors')
-      .mockResolvedValueOnce([]);
+    jest.spyOn(RecipientsService.prototype, 'organisationUnitsQualifyingAccessors').mockResolvedValueOnce([]);
 
     handler = new InnovationSupportStatusChangeRequestHandler(
       {
@@ -136,7 +134,7 @@ describe('Notifications / _handlers / innovation-support-status-change-request h
       {
         innovationId: innovation.id,
         supportId: innovation.supports.supportByHealthOrgUnit.id,
-        proposedStatus: InnovationSupportStatusEnum.COMPLETE,
+        proposedStatus: InnovationSupportStatusEnum.CLOSED,
         requestStatusUpdateComment: requestComment
       },
       MocksHelper.mockContext()

--- a/apps/notifications/_handlers/innovation-support-status-update.handler.spec.ts
+++ b/apps/notifications/_handlers/innovation-support-status-update.handler.spec.ts
@@ -194,7 +194,7 @@ describe('Notifications / _handlers / innovation-support-status-update suite', (
             innovationId: innovation.id,
             innovationSupport: {
               id: support.id,
-              status: InnovationSupportStatusEnum.COMPLETE,
+              status: InnovationSupportStatusEnum.CLOSED,
               statusChanged: false,
               message: '',
               organisationUnitId:
@@ -212,7 +212,7 @@ describe('Notifications / _handlers / innovation-support-status-update suite', (
   });
 
   describe.each([
-    [InnovationSupportStatusEnum.COMPLETE, 'completed'],
+    [InnovationSupportStatusEnum.CLOSED, 'closed'],
     [InnovationSupportStatusEnum.UNSUITABLE, 'unsuitable'],
     [InnovationSupportStatusEnum.UNASSIGNED, 'unassigned'],
     [InnovationSupportStatusEnum.ENGAGING, 'engaging']
@@ -350,12 +350,7 @@ describe('Notifications / _handlers / innovation-support-status-update suite', (
     }
   );
 
-  describe.each([
-    [InnovationSupportStatusEnum.NOT_YET, 'not yet'],
-    [InnovationSupportStatusEnum.WAITING, 'waiting'],
-    [InnovationSupportStatusEnum.WITHDRAWN, 'withdrawn'],
-    [InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED, 'further info']
-  ])(
+  describe.each([[InnovationSupportStatusEnum.WAITING, 'waiting']])(
     'Innovation support status updated to %s',
     (supportStatus: InnovationSupportStatusEnum, statusEmailText: string) => {
       let innovation: CompleteScenarioType['users']['johnInnovator']['innovations']['johnInnovation'];

--- a/apps/notifications/_services/recipients.service.ts
+++ b/apps/notifications/_services/recipients.service.ts
@@ -767,9 +767,7 @@ export class RecipientsService extends BaseService {
 
       // only active supports
       .andWhere('innovation.status != :innovationStatus', { innovationStatus: InnovationStatusEnum.PAUSED })
-      .andWhere('supports.status IN (:...statuses)', {
-        statuses: [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED]
-      })
+      .andWhere('supports.status = :engagingStatus', { engagingStatus: InnovationSupportStatusEnum.ENGAGING })
 
       .andWhere('userRole.organisation_unit_id IS NOT NULL') // only A/QAs activity
       .andWhere('qas.role = :role', { role: ServiceRoleEnum.QUALIFYING_ACCESSOR }) // only notify QAs

--- a/libs/data-access/migrations/1695650061950-alter-support-status.ts
+++ b/libs/data-access/migrations/1695650061950-alter-support-status.ts
@@ -1,0 +1,71 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class alterSupportStatuses1695650061950 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Missing updating some tables such as innovation_support_log, activity log, ...
+    await queryRunner.query(`
+
+      -- Drop status constraint
+      ALTER TABLE innovation_support DROP CONSTRAINT CK_innovation_support_status;
+
+      -- Update to new statuses
+      UPDATE innovation_support
+      SET [status] =
+          CASE
+              WHEN [status] IN ('FURTHER_INFO_REQUIRED', 'NOT_YET') THEN 'WAITING'
+              WHEN [status] = 'COMPLETE' THEN 'CLOSED'
+          END
+      WHERE [status] IN ('FURTHER_INFO_REQUIRED', 'NOT_YET', 'COMPLETE');
+
+      -- Add status constraint with new statuses
+      ALTER TABLE innovation_support ADD CONSTRAINT "CK_innovation_support_status" CHECK( [status] IN ('UNASSIGNED', 'ENGAGING', 'WAITING', 'UNSUITABLE', 'CLOSED') );
+      ALTER TABLE innovation_support ADD CONSTRAINT "df_innovation_support_status" DEFAULT 'UNASSIGNED' FOR [status];
+
+      -- Drop unneeded views
+      DROP VIEW vw_system_state;
+      DROP VIEW vw_system_state_list_A_QA;
+      DROP VIEW vw_system_state_organisationlevel;
+      DROP VIEW last_support_status_view_entity;
+
+    `);
+
+    await queryRunner.query(`
+      -- Update view
+      CREATE OR ALTER VIEW [innovation_grouped_status_view_entity] AS
+      SELECT innovation.id,
+          CASE
+              WHEN innovation.status IN ('CREATED','PAUSED') THEN 'RECORD_NOT_SHARED'
+              WHEN innovation.status = 'NEEDS_ASSESSMENT' THEN 'NEEDS_ASSESSMENT'
+              WHEN innovation.status = 'WITHDRAWN' THEN 'WITHDRAWN'
+              WHEN innovation.status = 'WAITING_NEEDS_ASSESSMENT' THEN
+                  CASE WHEN innovation_reassessment_request.innovation_id IS NULL THEN 'AWAITING_NEEDS_ASSESSMENT' ELSE 'AWAITING_NEEDS_REASSESSMENT' END
+              WHEN innovation.status = 'IN_PROGRESS' THEN
+                  CASE
+                      WHEN innovation_had_support.innovation_id IS NULL THEN 'AWAITING_SUPPORT' ELSE
+                          CASE WHEN innovation_support_engaging.innovation_id IS NULL THEN 'NO_ACTIVE_SUPPORT' ELSE 'RECEIVING_SUPPORT' END
+                  END
+          END as grouped_status
+      FROM innovation
+      LEFT JOIN (
+          SELECT innovation_id
+          FROM innovation_reassessment_request
+          WHERE deleted_at IS NULL
+          GROUP BY innovation_id
+      ) as innovation_reassessment_request ON innovation_reassessment_request.innovation_id = innovation.id
+      LEFT JOIN (
+          SELECT innovation_id
+          FROM innovation_support
+          WHERE status = 'ENGAGING' AND deleted_at IS NULL
+          GROUP BY innovation_id
+      ) as innovation_support_engaging ON innovation_support_engaging.innovation_id = innovation.id
+      LEFT JOIN (
+          SELECT DISTINCT innovation_id
+          FROM innovation_support
+      ) as innovation_had_support ON innovation_had_support.innovation_id = innovation.id
+      WHERE innovation.deleted_at IS NULL OR (innovation.status = 'WITHDRAWN' AND innovation.deleted_at IS NOT NULL);
+
+    `);
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {}
+}

--- a/libs/shared/enums/innovation.enums.ts
+++ b/libs/shared/enums/innovation.enums.ts
@@ -35,13 +35,10 @@ export enum InnovationSectionStatusEnum {
 
 export enum InnovationSupportStatusEnum {
   UNASSIGNED = 'UNASSIGNED',
-  FURTHER_INFO_REQUIRED = 'FURTHER_INFO_REQUIRED',
-  WAITING = 'WAITING',
-  NOT_YET = 'NOT_YET',
   ENGAGING = 'ENGAGING',
+  WAITING = 'WAITING',
   UNSUITABLE = 'UNSUITABLE',
-  WITHDRAWN = 'WITHDRAWN',
-  COMPLETE = 'COMPLETE'
+  CLOSED = 'CLOSED'
 }
 
 export enum InnovationTransferStatusEnum {

--- a/libs/shared/helpers/translation.helper.ts
+++ b/libs/shared/helpers/translation.helper.ts
@@ -7,14 +7,11 @@ const TRANSLATIONS = {
     }
   },
   SUPPORT_STATUS: {
-    ENGAGING: 'Engaging',
-    FURTHER_INFO_REQUIRED: 'Further info',
-    COMPLETE: 'Completed',
-    WAITING: 'Waiting',
-    NOT_YET: 'Not yet',
     UNASSIGNED: 'Unassigned',
+    ENGAGING: 'Engaging',
+    WAITING: 'Waiting',
     UNSUITABLE: 'Unsuitable',
-    WITHDRAWN: 'Withdrawn'
+    CLOSED: 'Closed'
   },
   EVIDENCE_SUBMIT_TYPES: {
     CLINICAL_OR_CARE: 'Evidence of clinical or care outcomes',

--- a/libs/shared/services/auth/authorization-validation.model.ts
+++ b/libs/shared/services/auth/authorization-validation.model.ts
@@ -440,7 +440,7 @@ export class AuthorizationValidationModel {
       if (context.currentRole.role === ServiceRoleEnum.ACCESSOR) {
         query.innerJoin('innovation.innovationSupports', 'innovationSupports');
         query.andWhere('innovationSupports.status IN (:...supportStatuses)', {
-          supportStatuses: [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.COMPLETE]
+          supportStatuses: [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.CLOSED]
         });
         query.andWhere('innovationSupports.organisation_unit_id = :organisationUnitId ', {
           organisationUnitId: context.organisation.organisationUnit.id

--- a/libs/shared/tests/scenarios/complete-scenario.builder.ts
+++ b/libs/shared/tests/scenarios/complete-scenario.builder.ts
@@ -239,9 +239,9 @@ export class CompleteScenarioBuilder {
         .setAccessors([aliceQualifyingAccessor, jamieMadroxAccessor])
         .save();
 
-      // support on johnInnovation by HealthOrgAIUnit in status FURTHER_INFO
+      // support on johnInnovation by HealthOrgAIUnit in status WAITING
       const johnInnovationSupportByHealthOrgAIUnit = await new InnovationSupportBuilder(entityManager)
-        .setStatus(InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED)
+        .setStatus(InnovationSupportStatusEnum.WAITING)
         .setInnovation(johnInnovation.id)
         .setOrganisationUnit(healthOrgAiUnit.id)
         .save();
@@ -249,12 +249,12 @@ export class CompleteScenarioBuilder {
       await new InnovationSupportLogBuilder(entityManager)
         .setInnovation(johnInnovation.id)
         .setCreatedBy(aliceQualifyingAccessor, aliceQualifyingAccessor.roles['qaRole']!)
-        .setSupportStatus(InnovationSupportStatusEnum.FURTHER_INFO_REQUIRED)
+        .setSupportStatus(InnovationSupportStatusEnum.WAITING)
         .save();
       await new InnovationSupportLogBuilder(entityManager)
         .setInnovation(johnInnovation.id)
         .setCreatedBy(aliceQualifyingAccessor, aliceQualifyingAccessor.roles['qaRole']!)
-        .setSupportStatus(InnovationSupportStatusEnum.COMPLETE)
+        .setSupportStatus(InnovationSupportStatusEnum.CLOSED)
         .save();
 
       // support on johnInnovation by MedTechOrgUnit accessor (sam)


### PR DESCRIPTION
**Description:**
- Migrated old support statuses into the new ones.
- Created a migration to reflect the status changes in DB and removed unused views.
- Updated codebase to take into consideration the new statuses.
- Updated unit tests to account with the new statuses.

**Closes:**
- #150806
- #150807

**What is missing?**
- Which strategy to follow taking into consideration old support status that are now deprecated in the `notifications`, `activity_log` and `innovation_support_log` tables.