### PR TITLE
feat: return assigned accessors for waiting supports

### DIFF
--- a/apps/innovations/_services/innovation-supports.service.ts
+++ b/apps/innovations/_services/innovation-supports.service.ts
@@ -122,7 +122,11 @@ export class InnovationSupportsService extends BaseService {
 
     if (filters.fields.includes('engagingAccessors')) {
       const assignedAccessorsIds = innovationSupports
-        .filter(support => support.status === InnovationSupportStatusEnum.ENGAGING)
+        .filter(
+          support =>
+            support.status === InnovationSupportStatusEnum.ENGAGING ||
+            support.status === InnovationSupportStatusEnum.WAITING
+        )
         .flatMap(support => support.userRoles.filter(item => item.isActive).map(item => item.user.id));
 
       usersInfo = await this.domainService.users.getUsersList({ userIds: assignedAccessorsIds });


### PR DESCRIPTION
**Description:**
Now that the QA that changes the support status to WAITING is automatically assigned as the assigned accessor, we have to return this info.