### PR TITLE
fix: collaborator email was not being sent

### DIFF
--- a/apps/notifications/_handlers/account/account-creation.handler.ts
+++ b/apps/notifications/_handlers/account/account-creation.handler.ts
@@ -26,11 +26,11 @@ export class AccountCreationHandler extends BaseHandler<
   async run(): Promise<this> {
     // This is currently only accounting with innovator accounts creation.
     const recipient = await this.recipientsService.getUsersRecipient(this.requestUser.id, ServiceRoleEnum.INNOVATOR);
-    if (!recipient) {
+    const identityInfo = await this.recipientsService.usersIdentityInfo(this.requestUser.identityId);
+    if (!recipient || !identityInfo) {
       return this;
     }
-
-    const collaborations = await this.recipientsService.getUserCollaborations(this.requestUser.id, [
+    const collaborations = await this.recipientsService.getUserCollaborations(identityInfo.email, [
       InnovationExportRequestStatusEnum.PENDING
     ]);
 

--- a/apps/notifications/_services/recipients.service.spec.ts
+++ b/apps/notifications/_services/recipients.service.spec.ts
@@ -289,7 +289,7 @@ describe('Notifications / _services / recipients service suite', () => {
 
   describe('getUserCollaborations', () => {
     it('should return the collaborations of a user', async () => {
-      const collaborators = await sut.getUserCollaborations(scenario.users.janeInnovator.id);
+      const collaborators = await sut.getUserCollaborations(scenario.users.janeInnovator.email);
       expect(collaborators).toMatchObject([
         {
           collaborationId: scenario.users.johnInnovator.innovations.johnInnovation.collaborators.janeCollaborator.id,

--- a/apps/notifications/_services/recipients.service.ts
+++ b/apps/notifications/_services/recipients.service.ts
@@ -852,10 +852,10 @@ export class RecipientsService extends BaseService {
   }
 
   /**
-   * Get the collaboration invites of a user
+   * Get the collaboration invites of a user by email
    */
   async getUserCollaborations(
-    userId: string,
+    email: string,
     status?: InnovationExportRequestStatusEnum[],
     entityManager?: EntityManager
   ): Promise<{ collaborationId: string; status: string; innovationId: string; innovationName: string }[]> {
@@ -865,7 +865,7 @@ export class RecipientsService extends BaseService {
       .createQueryBuilder(InnovationCollaboratorEntity, 'collaborator')
       .select(['collaborator.id', 'collaborator.status', 'collaborator.invitedAt', 'innovation.id', 'innovation.name'])
       .innerJoin('collaborator.innovation', 'innovation')
-      .where('collaborator.user_id = :userId', { userId });
+      .where('collaborator.email = :email', { email });
 
     if (status?.length) {
       query.andWhere('collaborator.status IN (:...status)', { status });


### PR DESCRIPTION
- It wasn't being sent since collaboration invites for users that don't exist in the service have userId as null until they accept/reject the collaboration invite. To mitigate this, we have to search by email.