### PR TITLE
feat: add additional information to all-sections

### DIFF
--- a/apps/innovations/_services/innovation-sections.service.spec.ts
+++ b/apps/innovations/_services/innovation-sections.service.spec.ts
@@ -207,4 +207,33 @@ describe('Innovation Sections Suite', () => {
       // assert assuming if no error is thrown then the test is successful (for now)
     });
   });
+
+  describe('getSectionsInfoMap', () => {
+    it('should return all the sections info', async () => {
+      const allSectionsInfo = await sut.findAllSections(innovation.id);
+
+      expect(allSectionsInfo).toStrictEqual([
+        {
+          section: {
+            section: innovation.sections.INNOVATION_DESCRIPTION.section,
+            status: innovation.sections.INNOVATION_DESCRIPTION.status,
+            submittedAt: null,
+            submittedBy: { displayTag: 'Innovator', name: '[unknown user]' },
+            openTasksCount: 4
+          },
+          data: expect.any(Object)
+        },
+        {
+          section: {
+            section: innovation.sections.EVIDENCE_OF_EFFECTIVENESS.section,
+            status: innovation.sections.EVIDENCE_OF_EFFECTIVENESS.status,
+            submittedAt: null,
+            submittedBy: { displayTag: 'Innovator', name: '[unknown user]' },
+            openTasksCount: 0
+          },
+          data: expect.any(Object)
+        }
+      ]);
+    });
+  });
 });

--- a/apps/innovations/_services/innovation-sections.service.ts
+++ b/apps/innovations/_services/innovation-sections.service.ts
@@ -37,6 +37,14 @@ import type { EntityManager } from 'typeorm';
 import type { InnovationFileService } from './innovation-file.service';
 import SYMBOLS from './symbols';
 
+type SectionInfoType = {
+  section: CurrentCatalogTypes.InnovationSections;
+  status: InnovationSectionStatusEnum;
+  submittedAt: null | Date;
+  submittedBy?: { name: string; displayTag: string };
+  openTasksCount: number;
+};
+
 @injectable()
 export class InnovationSectionsService extends BaseService {
   constructor(
@@ -150,6 +158,11 @@ export class InnovationSectionsService extends BaseService {
     });
   }
 
+  /**
+   * This method could be revised, to use the getSectionsInfoMap (return + data)
+   * Change taskIds array, return only a counter that comes from getSectionsInfoMap
+   * Create a statistics counter that returns the taskIds ordered for FE to use (only being used on task-details)
+   */
   async getInnovationSectionInfo(
     domainContext: DomainContextType,
     innovationId: string,
@@ -161,10 +174,7 @@ export class InnovationSectionsService extends BaseService {
     section: CurrentCatalogTypes.InnovationSections;
     status: InnovationSectionStatusEnum;
     submittedAt: null | Date;
-    submittedBy: null | {
-      name: string;
-      isOwner?: boolean;
-    };
+    submittedBy: null | { name: string; displayTag: string };
     data: null | { [key: string]: any };
     tasksIds?: string[];
   }> {
@@ -245,7 +255,10 @@ export class InnovationSectionsService extends BaseService {
       submittedBy: dbSection?.submittedBy
         ? {
             name: submittedBy ?? 'unknown user',
-            ...(submittedBy && { isOwner: dbSection.submittedBy.id === innovation.owner?.id })
+            displayTag: this.domainService.users.getDisplayTag(ServiceRoleEnum.INNOVATOR, {
+              isOwner:
+                innovation.owner && dbSection.submittedBy ? innovation.owner.id === dbSection.submittedBy.id : undefined
+            })
           }
         : null,
       data: !sectionHidden ? sectionData : null,
@@ -459,9 +472,12 @@ export class InnovationSectionsService extends BaseService {
 
   async findAllSections(
     innovationId: string,
-    version?: DocumentType['version']
-  ): Promise<{ section: { section: string }; data: Record<string, any> }[]> {
-    const document = await this.getInnovationDocument(innovationId, version ?? CurrentDocumentConfig.version);
+    version?: DocumentType['version'],
+    entityManager?: EntityManager
+  ): Promise<{ section: SectionInfoType; data: Record<string, any> }[]> {
+    const em = entityManager ?? this.sqlConnection.manager;
+
+    const document = await this.getInnovationDocument(innovationId, version ?? CurrentDocumentConfig.version, em);
     const innovationSections = await Promise.all(
       this.getDocumentSections(document).map(async section => ({
         section: { section: section },
@@ -469,7 +485,26 @@ export class InnovationSectionsService extends BaseService {
       }))
     );
 
-    return innovationSections;
+    const sectionsInfoMap = await this.getSectionsInfoMap(innovationId, [], em);
+
+    const output: Awaited<ReturnType<InnovationSectionsService['findAllSections']>> = [];
+    for (const curSection of innovationSections) {
+      const sectionInfo = sectionsInfoMap.get(curSection.section.section);
+      if (sectionInfo) {
+        output.push({
+          data: curSection.data,
+          section: {
+            section: curSection.section.section,
+            status: sectionInfo.status,
+            submittedAt: sectionInfo.submittedAt,
+            submittedBy: sectionInfo.submittedBy,
+            openTasksCount: sectionInfo.openTasksCount
+          }
+        });
+      }
+    }
+
+    return output;
   }
 
   async createInnovationEvidence(
@@ -728,6 +763,64 @@ export class InnovationSectionsService extends BaseService {
       ...sectionData,
       ...(evidenceData && { evidences: evidenceData })
     };
+  }
+
+  private async getSectionsInfoMap(
+    innovationId: string,
+    sectionsKeys?: string[],
+    entityManager?: EntityManager
+  ): Promise<Map<string, SectionInfoType>> {
+    const em = entityManager ?? this.sqlConnection.manager;
+
+    const query = em
+      .createQueryBuilder(InnovationSectionEntity, 'section')
+      .select([
+        'section.id',
+        'section.section',
+        'section.status',
+        'section.submittedAt',
+        'submittedBy.id',
+        'submittedBy.identityId',
+        'submittedBy.status',
+        'innovation.id',
+        'owner.id',
+        'tasks.id'
+      ])
+      .leftJoin('section.submittedBy', 'submittedBy')
+      .innerJoin('section.innovation', 'innovation')
+      .leftJoin('innovation.owner', 'owner')
+      .leftJoin('section.tasks', 'tasks')
+      .where('section.innovation_id = :innovationId', { innovationId });
+
+    if (sectionsKeys?.length) {
+      query.andWhere('section.section IN (:...sectionsKeys)', { sectionsKeys });
+    }
+
+    const sections = await query.getMany();
+
+    const innovators = sections
+      .filter(s => s.submittedBy && s.submittedBy.status !== UserStatusEnum.DELETED)
+      .map(s => s.submittedBy?.identityId)
+      .filter((id): id is string => !!id);
+    const users = await this.identityService.getUsersMap(innovators);
+
+    return new Map(
+      sections.map(s => [
+        s.section,
+        {
+          section: s.section,
+          status: s.status,
+          submittedAt: s.submittedAt,
+          submittedBy: {
+            name: users.get(s.submittedBy?.identityId ?? '')?.displayName ?? '[unknown user]',
+            displayTag: this.domainService.users.getDisplayTag(ServiceRoleEnum.INNOVATOR, {
+              isOwner: s.innovation.owner && s.submittedBy ? s.innovation.owner.id === s.submittedBy.id : undefined
+            })
+          },
+          openTasksCount: s.tasks.length ?? 0
+        }
+      ])
+    );
   }
 
   private getDocumentSections<T extends DocumentType>(document: T): Exclude<keyof T, 'version' | 'evidences'>[] {

--- a/apps/innovations/_services/innovation-tasks.service.ts
+++ b/apps/innovations/_services/innovation-tasks.service.ts
@@ -474,7 +474,7 @@ export class InnovationTasksService extends BaseService {
       is => is.organisationUnit.id === domainContext.organisation?.organisationUnit?.id
     );
 
-    let taskCounter = (await innovationSection.tasks).length;
+    let taskCounter = innovationSection.tasks?.length ?? 0;
     const displayId =
       CurrentDocumentConfig.InnovationSectionAliasEnum[data.section] +
       (++taskCounter).toString().slice(-2).padStart(2, '0');

--- a/apps/innovations/v1-innovation-all-sections-list/index.spec.ts
+++ b/apps/innovations/v1-innovation-all-sections-list/index.spec.ts
@@ -1,3 +1,4 @@
+import { InnovationSectionStatusEnum } from '@innovations/shared/enums';
 import { AzureHttpTriggerBuilder, TestsHelper } from '@innovations/shared/tests';
 import type { TestUserType } from '@innovations/shared/tests/builders/user.builder';
 import type { ErrorResponseType } from '@innovations/shared/types';
@@ -19,7 +20,17 @@ beforeAll(async () => {
   await testsHelper.init();
 });
 
-const expected = [{ section: { section: 'INNOVATION_DESCRIPTION' }, data: { description: 'test description' } }];
+const expected: Awaited<ReturnType<InnovationSectionsService['findAllSections']>> = [
+  {
+    section: {
+      section: 'INNOVATION_DESCRIPTION',
+      openTasksCount: 0,
+      status: InnovationSectionStatusEnum.DRAFT,
+      submittedAt: null
+    },
+    data: { description: 'test description' }
+  }
+];
 const mock = jest.spyOn(InnovationSectionsService.prototype, 'findAllSections').mockResolvedValue(expected);
 
 afterEach(() => {

--- a/apps/innovations/v1-innovation-all-sections-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-all-sections-list/transformation.dtos.ts
@@ -1,4 +1,12 @@
+import type { InnovationSectionStatusEnum } from '@innovations/shared/enums';
+
 export type ResponseDTO = {
-  section: { section: string };
+  section: {
+    section: string;
+    status: InnovationSectionStatusEnum;
+    submittedAt: null | Date;
+    submittedBy?: { name: string; displayTag: string };
+    openTasksCount: number;
+  };
   data: Record<string, any>;
 }[];

--- a/apps/innovations/v1-innovation-section-info/index.spec.ts
+++ b/apps/innovations/v1-innovation-section-info/index.spec.ts
@@ -30,9 +30,7 @@ const expected = {
   section: 'INNOVATION_DESCRIPTION' as const,
   status: InnovationSectionStatusEnum.DRAFT,
   submittedAt: randPastDate(),
-  submittedBy: {
-    name: randFileName()
-  },
+  submittedBy: { name: randFileName(), displayTag: 'Innovator' },
   data: { key: 'value' }
 };
 const mock = jest.spyOn(InnovationSectionsService.prototype, 'getInnovationSectionInfo').mockResolvedValue(expected);

--- a/apps/innovations/v1-innovation-section-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-section-info/transformation.dtos.ts
@@ -6,10 +6,7 @@ export type ResponseDTO = {
   section: CurrentCatalogTypes.InnovationSections;
   status: InnovationSectionStatusEnum;
   submittedAt: null | Date;
-  submittedBy: null | {
-    name: string;
-    isOwner?: boolean;
-  };
+  submittedBy: null | { name: string; displayTag: string };
   data: null | { [key: string]: any };
   tasksIds?: string[];
 };

--- a/libs/shared/entities/innovation/innovation-section.entity.ts
+++ b/libs/shared/entities/innovation/innovation-section.entity.ts
@@ -53,10 +53,10 @@ export class InnovationSectionEntity extends BaseEntity {
   files: InnovationFileLegacyEntity[];
 
   @OneToMany(() => InnovationTaskEntity, record => record.innovationSection, {
-    lazy: true,
+    lazy: false,
     cascade: ['insert', 'update']
   })
-  tasks: Promise<InnovationTaskEntity[]>;
+  tasks: InnovationTaskEntity[];
 
   static new(data: Partial<InnovationSectionEntity>): InnovationSectionEntity {
     const instance = new InnovationSectionEntity();


### PR DESCRIPTION
Added additional info to `all-sections` to prevent multiple request to `section-info` on the new feature of show all questions/answers of innovation IR.