### PR TITLE
Update Dev Container: Add Azure Tools, port forwarding and force AMD64

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+# need to ensure AMD64 is used because Azure Functions won't run properly on ARM64 
+FROM --platform=amd64 mcr.microsoft.com/devcontainers/base:jammy

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,10 +16,14 @@
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+	"forwardPorts": [7071, 7072, 7073, 7074],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "npm install"
+	"postCreateCommand": "npm i -g azure-functions-core-tools@4 --unsafe-perm true && npm install",
+
+	"remoteEnv": {
+		"FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT" : "1"
+	}
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,11 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "Ubuntu",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"build": { "dockerfile": "Dockerfile" },
+	// Using Dockefile reference above to specify the platform as Azure Functions won't run properly on ARM64 
+	// See https://github.com/docker/roadmap/issues/384
+	// "image": "mcr.microsoft.com/devcontainers/base:jammy",	
+
 	"runArgs": ["--add-host=host.docker.internal:host-gateway"],
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {


### PR DESCRIPTION
A few changes to make it easier to use the dev container:
 - Install Azure Functions Core Tools as part of the post create command
 - Add the port forwarding to the initial config 
  > not strictly needed as VS Code Dev Container magic seems to automatically forward ports when something attaches to one)
 -  specify the AMD64 dev container image 
 > because Azure Functions won't run on ARM64, at least not in Docker on a Mac M1 - [see this issue](https://github.com/docker/roadmap/issues/384)