### PR TITLE
feat: change paused status to archived

### DIFF
--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -1767,7 +1767,6 @@ paths:
                     - IN_PROGRESS
                     - WITHDRAWN
                     - COMPLETE
-                    - PAUSED
                     - ARCHIVED
         - name: engagingOrganisations
           in: query

--- a/apps/innovations/_services/innovations.service.spec.ts
+++ b/apps/innovations/_services/innovations.service.spec.ts
@@ -437,11 +437,12 @@ describe('Innovations / _services / innovations suite', () => {
 
       const dbInnovation = await em
         .createQueryBuilder(InnovationEntity, 'innovation')
-        .select(['innovation.status'])
+        .select(['innovation.status', 'innovation.archivedStatus'])
         .where('innovation.id = :innovationId', { innovationId: innovation.id })
         .getOne();
 
       expect(dbInnovation?.status).toBe(InnovationStatusEnum.ARCHIVED);
+      expect(dbInnovation?.archivedStatus).toBe(innovation.status);
     });
 
     it('should cancel all open tasks', async () => {

--- a/apps/innovations/_services/innovations.service.ts
+++ b/apps/innovations/_services/innovations.service.ts
@@ -265,7 +265,7 @@ export class InnovationsService extends BaseService {
       await transaction.update(
         InnovationEntity,
         { id: innovationId },
-        { status: InnovationStatusEnum.ARCHIVED, statusUpdatedAt: archivedAt, updatedBy: domainContext.id }
+        { archivedStatus: () => 'status', status: InnovationStatusEnum.ARCHIVED, statusUpdatedAt: archivedAt, updatedBy: domainContext.id }
       );
 
       const supportLogs = [];

--- a/apps/innovations/v1-innovation-reassessment-request-create/index.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/index.ts
@@ -32,7 +32,7 @@ class V1InnovationReassessmentRequestCreate {
         .setInnovation(params.innovationId)
         .checkInnovatorType()
         .checkInnovation({
-          status: [InnovationStatusEnum.IN_PROGRESS, InnovationStatusEnum.PAUSED]
+          status: [InnovationStatusEnum.IN_PROGRESS, InnovationStatusEnum.ARCHIVED]
         })
         .verify();
       const domainContext = auth.getContext();

--- a/libs/data-access/migrations/1706720380014-migrate-paused-status-to-archived.ts
+++ b/libs/data-access/migrations/1706720380014-migrate-paused-status-to-archived.ts
@@ -11,7 +11,7 @@ export class migratePausedStatusToArchived1706720380014 implements MigrationInte
                   COALESCE(archive_snapshot, '{}'),
                   '$.archivedAt', CONVERT(VARCHAR, i.status_updated_at)
               ),
-              '$.roles', JSON_QUERY('[]')
+              '$.assignedAccessors', JSON_QUERY('[]')
           ),
           '$.status', (
               CASE

--- a/libs/data-access/migrations/1706720380014-migrate-paused-status-to-archived.ts
+++ b/libs/data-access/migrations/1706720380014-migrate-paused-status-to-archived.ts
@@ -1,0 +1,83 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class migratePausedStatusToArchived1706720380014 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      -- Change all support status from paused innovations to closed and update the archive_snapshot
+      UPDATE innovation_support
+          SET status = 'CLOSED', archive_snapshot = JSON_MODIFY(
+          JSON_MODIFY(
+              JSON_MODIFY(
+                  COALESCE(archive_snapshot, '{}'),
+                  '$.archivedAt', CONVERT(VARCHAR, i.status_updated_at)
+              ),
+              '$.roles', JSON_QUERY('[]')
+          ),
+          '$.status', (
+              CASE
+                  WHEN s.status = 'UNASSIGNED' THEN 'ENGAGING'
+                  ELSE s.status
+              END
+              )
+          )
+          FROM innovation_support s
+          INNER JOIN innovation i ON i.id = s.innovation_id
+          WHERE i.status = 'PAUSED' AND s.[status] != 'CLOSED';
+
+      -- Update all paused innovations to archived
+      UPDATE innovation
+          SET status = 'ARCHIVED'
+          WHERE status = 'PAUSED';
+
+      -- Remove PAUSED from the innovation status constraint
+      ALTER TABLE "innovation" DROP CONSTRAINT "CK_innovation_status";
+      ALTER TABLE "innovation" ADD CONSTRAINT "CK_innovation_status" CHECK ([status] IN (
+          'CREATED',
+          'WAITING_NEEDS_ASSESSMENT',
+          'NEEDS_ASSESSMENT',
+          'IN_PROGRESS',
+          'WITHDRAWN',
+          'COMPLETE',
+          'ARCHIVED'
+      ));
+    `);
+
+    // Remove PAUSED status and add ARCHIVED
+    await queryRunner.query(`
+    CREATE OR ALTER VIEW [innovation_grouped_status_view_entity] AS
+      SELECT innovation.id,
+          CASE
+              WHEN innovation.status IN ('CREATED') THEN 'RECORD_NOT_SHARED' -- Removed Paused
+              WHEN innovation.status = 'NEEDS_ASSESSMENT' THEN 'NEEDS_ASSESSMENT'
+              WHEN innovation.status = 'WITHDRAWN' THEN 'WITHDRAWN'
+              WHEN innovation.status = 'ARCHIVED' THEN 'ARCHIVED' -- Added
+              WHEN innovation.status = 'WAITING_NEEDS_ASSESSMENT' THEN
+                  CASE WHEN innovation_reassessment_request.innovation_id IS NULL THEN 'AWAITING_NEEDS_ASSESSMENT' ELSE 'AWAITING_NEEDS_REASSESSMENT' END
+              WHEN innovation.status = 'IN_PROGRESS' THEN
+                  CASE
+                      WHEN innovation_had_support.innovation_id IS NULL THEN 'AWAITING_SUPPORT' ELSE
+                          CASE WHEN innovation_support_engaging.innovation_id IS NULL THEN 'NO_ACTIVE_SUPPORT' ELSE 'RECEIVING_SUPPORT' END
+                  END
+          END as grouped_status
+      FROM innovation
+      LEFT JOIN (
+          SELECT innovation_id
+          FROM innovation_reassessment_request
+          WHERE deleted_at IS NULL
+          GROUP BY innovation_id
+      ) as innovation_reassessment_request ON innovation_reassessment_request.innovation_id = innovation.id
+      LEFT JOIN (
+          SELECT innovation_id
+          FROM innovation_support
+          WHERE status = 'ENGAGING' AND deleted_at IS NULL
+          GROUP BY innovation_id
+      ) as innovation_support_engaging ON innovation_support_engaging.innovation_id = innovation.id
+      LEFT JOIN (
+          SELECT DISTINCT innovation_id
+          FROM innovation_support
+      ) as innovation_had_support ON innovation_had_support.innovation_id = innovation.id;
+    `);
+  }
+
+  public async down(): Promise<void> {}
+}

--- a/libs/shared/entities/innovation/innovation.entity.ts
+++ b/libs/shared/entities/innovation/innovation.entity.ts
@@ -39,6 +39,9 @@ export class InnovationEntity extends BaseEntity {
   @Column({ type: 'simple-enum', enum: InnovationStatusEnum, nullable: false })
   status: InnovationStatusEnum;
 
+  @Column({ name: 'archived_status', type: 'simple-enum', enum: InnovationStatusEnum, nullable: false })
+  archivedStatus: InnovationStatusEnum;
+
   @Column({ name: 'status_updated_at', type: 'datetime2' })
   statusUpdatedAt: Date;
 

--- a/libs/shared/enums/innovation.enums.ts
+++ b/libs/shared/enums/innovation.enums.ts
@@ -6,7 +6,6 @@ export enum InnovationStatusEnum {
   // NEEDS_ASSESSMENT_REVIEW = 'NEEDS_ASSESSMENT_REVIEW', // Not it use nowadays.
   WITHDRAWN = 'WITHDRAWN',
   COMPLETE = 'COMPLETE',
-  PAUSED = 'PAUSED',
   ARCHIVED = 'ARCHIVED'
 }
 


### PR DESCRIPTION
Closes [AB#161348](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/161348).

**Description:**
- Changed all support status from paused innovations to closed and updated the archive_snapshot.
- Update the status from paused innovations to archived.
- Remove the paused status from the innovation status constraint.
- Update `innovation_grouped_status_view_entity` to account with archived status and remove paused status.
- Added new field `archived_status` to `innovation` to aid with queries related with innovation lists.