### PR TITLE
fix: archive snapshot was saving userId instead of roleID

### DIFF
--- a/apps/innovations/_services/innovations.service.spec.ts
+++ b/apps/innovations/_services/innovations.service.spec.ts
@@ -493,7 +493,7 @@ describe('Innovations / _services / innovations suite', () => {
         expect(support.archiveSnapshot).toMatchObject({
           archivedAt: expect.any(String),
           status: previousSupport.status,
-          assignedAccessors: previousSupport.userRoles.map(r => r.user.id)
+          assignedAccessors: previousSupport.userRoles.map(r => r.id)
         });
       }
     });

--- a/apps/innovations/_services/innovations.service.ts
+++ b/apps/innovations/_services/innovations.service.ts
@@ -262,7 +262,7 @@ export class InnovationsService extends BaseService {
         support.archiveSnapshot = {
           archivedAt,
           status: support.status,
-          assignedAccessors: support.userRoles.map(r => r.user.id)
+          assignedAccessors: support.userRoles.map(r => r.id)
         };
 
         support.userRoles = [];


### PR DESCRIPTION
**Description:**
During the archival process, the `archive_snapshot` was saving the `userId` instead of `roleId`, making the reassessment process to fail when there was the "revival" of assigned accessors for innovations in `WAITING` status.