### PR TITLE
Task/161796 block endpoints related with support summary

### DIFF
--- a/apps/innovations/v1-innovation-support-logs-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-logs-create/index.spec.ts
@@ -78,4 +78,23 @@ describe('v1-innovation-support-logs-create Suite', () => {
       expect(result.status).toBe(status);
     });
   });
+
+  it.each([['QA', scenario.users.aliceQualifyingAccessor, undefined]])(
+    'access with user %s should give conflict in the archive',
+    async (_role: string, user: TestUserType, roleKey?: string) => {
+      const result = await new AzureHttpTriggerBuilder()
+        .setAuth(user, roleKey)
+        .setParams<ParamsType>({
+          innovationId: scenario.users.johnInnovator.innovations.johnInnovationArchived.id
+        })
+        .setBody<BodyType>({
+          description: randText(),
+          organisationUnits: [],
+          type: InnovationSupportLogTypeEnum.ACCESSOR_SUGGESTION
+        })
+        .call<ErrorResponseType>(azureFunction);
+
+      expect(result.status).toBe(409);
+    }
+  );
 });

--- a/apps/innovations/v1-innovation-support-logs-create/index.ts
+++ b/apps/innovations/v1-innovation-support-logs-create/index.ts
@@ -30,7 +30,7 @@ class V1InnovationsSupportLogCreate {
         .setInnovation(params.innovationId)
         .checkAccessorType({ organisationRole: [ServiceRoleEnum.QUALIFYING_ACCESSOR] })
         .checkInnovation()
-        .checkArchivedStatus()
+        .checkNotArchived()
         .verify();
       const domainContext = auth.getContext();
 

--- a/apps/innovations/v1-innovation-support-logs-create/index.ts
+++ b/apps/innovations/v1-innovation-support-logs-create/index.ts
@@ -30,6 +30,7 @@ class V1InnovationsSupportLogCreate {
         .setInnovation(params.innovationId)
         .checkAccessorType({ organisationRole: [ServiceRoleEnum.QUALIFYING_ACCESSOR] })
         .checkInnovation()
+        .checkArchivedStatus()
         .verify();
       const domainContext = auth.getContext();
 

--- a/apps/innovations/v1-innovation-support-summary-progress-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-summary-progress-create/index.spec.ts
@@ -71,5 +71,20 @@ describe('v1-innovation-support-summary-progress-create', () => {
 
       expect(result.status).toBe(status);
     });
+
+    it.each([
+      ['QA', scenario.users.aliceQualifyingAccessor, undefined],
+      ['A', scenario.users.jamieMadroxAccessor, 'healthAccessorRole'],
+    ])('access with user %s should give conflict in the archive', async (_role: string, user: TestUserType, roleKey?: string) => {
+      const result = await new AzureHttpTriggerBuilder()
+        .setAuth(user, roleKey)
+        .setParams<ParamsType>({
+          innovationId: scenario.users.johnInnovator.innovations.johnInnovationArchived.id
+        })
+        .setBody<BodyType>({ description: randText(), title: randText() })
+        .call<ErrorResponseType>(azureFunction);
+
+      expect(result.status).toBe(409);
+    });
   });
 });

--- a/apps/innovations/v1-innovation-support-summary-progress-create/index.ts
+++ b/apps/innovations/v1-innovation-support-summary-progress-create/index.ts
@@ -28,7 +28,7 @@ class V1InnovationSupportSummaryProgressCreate {
         .setInnovation(params.innovationId)
         .checkAccessorType()
         .checkInnovation()
-        .checkArchivedStatus()
+        .checkNotArchived()
         .verify();
 
       await innovationSupportsService.createProgressUpdate(auth.getContext(), params.innovationId, body);

--- a/apps/innovations/v1-innovation-support-summary-progress-create/index.ts
+++ b/apps/innovations/v1-innovation-support-summary-progress-create/index.ts
@@ -28,6 +28,7 @@ class V1InnovationSupportSummaryProgressCreate {
         .setInnovation(params.innovationId)
         .checkAccessorType()
         .checkInnovation()
+        .checkArchivedStatus()
         .verify();
 
       await innovationSupportsService.createProgressUpdate(auth.getContext(), params.innovationId, body);

--- a/apps/innovations/v1-innovation-support-summary-progress-delete/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-summary-progress-delete/index.spec.ts
@@ -66,4 +66,22 @@ describe('v1-innovation-support-summary-progress-delete', () => {
       expect(result.status).toBe(status);
     });
   });
+
+  it.each([
+    ['QA', scenario.users.aliceQualifyingAccessor, undefined],
+    ['A', scenario.users.jamieMadroxAccessor, 'healthAccessorRole']
+  ])(
+    'access with user %s should give conflict in the archive',
+    async (_role: string, user: TestUserType, roleKey?: string) => {
+      const result = await new AzureHttpTriggerBuilder()
+        .setAuth(user, roleKey)
+        .setParams<ParamsType>({
+          innovationId: scenario.users.johnInnovator.innovations.johnInnovationArchived.id,
+          progressId: randUuid()
+        })
+        .call<ErrorResponseType>(azureFunction);
+
+      expect(result.status).toBe(409);
+    }
+  );
 });

--- a/apps/innovations/v1-innovation-support-summary-progress-delete/index.ts
+++ b/apps/innovations/v1-innovation-support-summary-progress-delete/index.ts
@@ -27,7 +27,7 @@ class V1InnovationSupportSummaryProgressDelete {
         .setInnovation(params.innovationId)
         .checkAccessorType()
         .checkInnovation()
-        .checkArchivedStatus()
+        .checkNotArchived()
         .verify();
 
       await innovationSupportsService.deleteProgressUpdate(auth.getContext(), params.innovationId, params.progressId);

--- a/apps/innovations/v1-innovation-support-summary-progress-delete/index.ts
+++ b/apps/innovations/v1-innovation-support-summary-progress-delete/index.ts
@@ -27,6 +27,7 @@ class V1InnovationSupportSummaryProgressDelete {
         .setInnovation(params.innovationId)
         .checkAccessorType()
         .checkInnovation()
+        .checkArchivedStatus()
         .verify();
 
       await innovationSupportsService.deleteProgressUpdate(auth.getContext(), params.innovationId, params.progressId);

--- a/libs/shared/services/auth/authorization-validation.model.ts
+++ b/libs/shared/services/auth/authorization-validation.model.ts
@@ -7,7 +7,7 @@ import {
   InnovationSupportStatusEnum,
   ServiceRoleEnum
 } from '../../enums';
-import { ForbiddenError, UnprocessableEntityError } from '../../errors';
+import { ForbiddenError, UnprocessableEntityError,ConflictError } from '../../errors';
 import type { DomainContextType, DomainUserInfoType } from '../../types';
 import type { DomainService } from '../domain/domain.service';
 
@@ -27,6 +27,7 @@ export enum AuthErrorsEnum {
   AUTH_INNOVATION_UNAUTHORIZED = 'AUTH.0102',
   AUTH_INNOVATION_STATUS_NOT_ALLOWED = 'AUTH.0103',
   AUTH_INNOVATION_NOT_OWNER = 'AUTH.0104',
+  AUTH_INNOVATION_ARCHIVED_CONFLICT = 'AUTH.0105',
   AUTH_MISSING_ORGANISATION_UNIT_CONTEXT = 'AUTH.0201',
   AUTH_MISSING_ORGANISATION_CONTEXT = 'AUTH.0202',
   AUTH_MISSING_CURRENT_ROLE = 'AUTH.0203',
@@ -43,7 +44,8 @@ enum UserValidationKeys {
   checkInnovatorType = 'innovatorTypeValidation'
 }
 enum InnovationValidationKeys {
-  checkInnovation = 'innovationValidation'
+  checkInnovation = 'innovationValidation',
+  checkArchived = 'checkArchivedValidation'
 }
 
 export class AuthorizationValidationModel {
@@ -237,6 +239,35 @@ export class AuthorizationValidationModel {
     return null;
   }
 
+  checkArchivedStatus(config?: { whitelist: ServiceRoleEnum[] } | { blacklist: ServiceRoleEnum[] }): this {
+    this.innovationValidations.set(InnovationValidationKeys.checkArchived, () =>
+      this.innovationArchivedRulesValidation(config)
+    );
+    return this;
+  }
+  private innovationArchivedRulesValidation( config?: { whitelist: ServiceRoleEnum[] } | { blacklist: ServiceRoleEnum[] }): null | AuthErrorsEnum {
+    if (!this.innovation.data) {
+      return AuthErrorsEnum.AUTH_INNOVATION_UNAUTHORIZED;
+    }
+
+    const currentRole = this.getContext().currentRole.role;
+    if (this.innovation.data.status === InnovationStatusEnum.ARCHIVED) {
+      // If no config is defined it blocks everything if the status is archived.
+      if(!config) {
+        return AuthErrorsEnum.AUTH_INNOVATION_ARCHIVED_CONFLICT;
+      }
+      // If whitelist config is defined let's the whitelisted "pass" and blocks all the others.
+      if ('whitelist' in config) {
+        return config.whitelist.includes(currentRole) ? null : AuthErrorsEnum.AUTH_INNOVATION_ARCHIVED_CONFLICT;
+      }
+      // If blacklist config is defined blocks the blacklisted and allows the others.
+      if ('blacklist' in config) {
+        return config.blacklist.includes(currentRole) ? AuthErrorsEnum.AUTH_INNOVATION_ARCHIVED_CONFLICT : null;
+      }
+    }
+    return null;
+  }
+
   async verify(): Promise<this> {
     let validations: (null | AuthErrorsEnum)[] = [];
 
@@ -355,8 +386,11 @@ export class AuthorizationValidationModel {
       }
 
       this.innovationValidations.forEach(checkMethod => validations.push(checkMethod())); // This will run the validation itself and return the result to the array.
-      if (!validations.some(item => item === null)) {
+      if (validations.some(item => item !== null)) {
         const error = validations.find(item => item !== null) || AuthErrorsEnum.AUTH_USER_UNAUTHORIZED;
+        if(error === AuthErrorsEnum.AUTH_INNOVATION_ARCHIVED_CONFLICT) {
+          throw new ConflictError(error);
+        }
         throw new ForbiddenError(error);
       }
     }

--- a/libs/shared/tests/builders/innovation.builder.ts
+++ b/libs/shared/tests/builders/innovation.builder.ts
@@ -133,6 +133,9 @@ export class InnovationBuilder extends BaseBuilder {
 
   setStatus(status: InnovationStatusEnum): this {
     this.innovation.status = status;
+    if (status === InnovationStatusEnum.ARCHIVED) {
+      this.innovation.archivedStatus = InnovationStatusEnum.IN_PROGRESS;
+    }
     return this;
   }
 

--- a/libs/shared/tests/scenarios/complete-scenario.builder.ts
+++ b/libs/shared/tests/scenarios/complete-scenario.builder.ts
@@ -202,6 +202,13 @@ export class CompleteScenarioBuilder {
         .setStatus(InnovationStatusEnum.IN_PROGRESS)
         .save();
 
+      const johnInnovationArchived = await new InnovationBuilder(entityManager)
+        .setOwner(johnInnovator.id)
+        .setStatus(InnovationStatusEnum.ARCHIVED)
+        .shareWith([healthOrg, medTechOrg])
+        .addSection('INNOVATION_DESCRIPTION')
+        .save();
+
       // Jane Innovator specs:
       // Collaborator on jonhInnovation
       const janeInnovator = await new UserBuilder(entityManager)
@@ -280,6 +287,13 @@ export class CompleteScenarioBuilder {
         .setInnovation(johnInnovation.id)
         .setCreatedBy(aliceQualifyingAccessor, aliceQualifyingAccessor.roles['qaRole']!)
         .setSupportStatus(InnovationSupportStatusEnum.UNASSIGNED)
+        .save();
+
+      // Add a boilerplate support to the john archived innovation
+      await new InnovationSupportBuilder(entityManager)
+        .setStatus(InnovationSupportStatusEnum.CLOSED)
+        .setInnovation(johnInnovationArchived.id)
+        .setOrganisationUnit(healthOrgUnit.id)
         .save();
 
       // task on johnInnovation created by Alice (QA)
@@ -702,6 +716,7 @@ export class CompleteScenarioBuilder {
             roles: { innovatorRole: johnInnovator.roles['innovatorRole']! },
             innovations: {
               johnInnovationEmpty: johnInnovationEmpty,
+              johnInnovationArchived: johnInnovationArchived,
               johnInnovation: {
                 ...johnInnovation,
                 supports: {


### PR DESCRIPTION
**Description:**
Since archive now enables users to see what were before unavailable innovations is important to protect resources that can't be accessed while the innovation is archived. This commit introduces a new validation to archived status that enables this protection, it has three configurations:
- No config - blocks everything if the innovation is ARCHIVED
- Whitelist - allows the whitelisted roles and blocks everything else
- Blacklist - blocks roles in the blacklist and allows everything else

Limitations:
- If the validations become more granular like we should block
  collaborator but not owners, a new config should be created for this
  cases.

**Related tickets:**
- Closes task [AB#161796](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/161796).