### PR TITLE
add archived innovation rules to documents create/delete

### DIFF
--- a/apps/innovations/v1-innovation-file-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-file-create/index.spec.ts
@@ -56,6 +56,33 @@ describe('v1-innovation-file-create Suite', () => {
       expect(result.status).toBe(200);
       expect(mock).toHaveBeenCalledTimes(1);
     });
+
+    it('should create a file as innovator for archived innovations', async () => {
+      const result = await new AzureHttpTriggerBuilder()
+        .setAuth(scenario.users.johnInnovator)
+        .setParams<ParamsType>({ innovationId: scenario.users.johnInnovator.innovations.johnInnovationArchived.id })
+        .setBody<BodyType>(sampleBody)
+        .call<ResponseDTO>(azureFunction);
+
+      expect(result.body).toMatchObject(expected);
+      expect(result.status).toBe(200);
+      expect(mock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('409', () => {
+    it.each([['QA', scenario.users.aliceQualifyingAccessor, undefined]])(
+      'access with user %s should give conflict in the archive',
+      async (_role: string, user: TestUserType, roleKey?: string) => {
+        const result = await new AzureHttpTriggerBuilder()
+          .setAuth(user, roleKey)
+          .setParams<ParamsType>({ innovationId: scenario.users.johnInnovator.innovations.johnInnovationArchived.id })
+          .setBody<BodyType>(sampleBody)
+          .call<ResponseDTO>(azureFunction);
+
+        expect(result.status).toBe(409);
+      }
+    );
   });
 
   describe('Access', () => {

--- a/apps/innovations/v1-innovation-file-create/index.ts
+++ b/apps/innovations/v1-innovation-file-create/index.ts
@@ -9,6 +9,7 @@ import type { CustomContextType } from '@innovations/shared/types';
 
 import { container } from '../_config';
 
+import { ServiceRoleEnum } from '@innovations/shared/enums';
 import type { InnovationFileService } from '../_services/innovation-file.service';
 import SYMBOLS from '../_services/symbols';
 import type { ResponseDTO } from './transformation.dtos';
@@ -31,6 +32,7 @@ class V1InnovationFileCreate {
         .checkAccessorType()
         .checkAssessmentType()
         .checkInnovation()
+        .checkNotArchived({ whitelist: [ServiceRoleEnum.INNOVATOR] })
         .verify();
 
       const result = await innovationFilesService.createFile(

--- a/apps/innovations/v1-innovation-file-delete/index.spec.ts
+++ b/apps/innovations/v1-innovation-file-delete/index.spec.ts
@@ -44,6 +44,36 @@ describe('v1-innovation-file-delete Suite', () => {
       expect(result.status).toBe(204);
       expect(mock).toHaveBeenCalledTimes(1);
     });
+
+    it('should create a file as innovator for archived innovations', async () => {
+      const result = await new AzureHttpTriggerBuilder()
+        .setAuth(scenario.users.johnInnovator)
+        .setParams<ParamsType>({
+          innovationId: scenario.users.johnInnovator.innovations.johnInnovationArchived.id,
+          fileId: randUuid()
+        })
+        .call<never>(azureFunction);
+
+      expect(result.status).toBe(204);
+      expect(mock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('409', () => {
+    it.each([['QA', scenario.users.aliceQualifyingAccessor, undefined]])(
+      'access with user %s should give conflict in the archive',
+      async (_role: string, user: TestUserType, roleKey?: string) => {
+        const result = await new AzureHttpTriggerBuilder()
+          .setAuth(user, roleKey)
+          .setParams<ParamsType>({
+            innovationId: scenario.users.johnInnovator.innovations.johnInnovationArchived.id,
+            fileId: randUuid()
+          })
+          .call<never>(azureFunction);
+
+        expect(result.status).toBe(409);
+      }
+    );
   });
 
   describe('Access', () => {

--- a/apps/innovations/v1-innovation-file-delete/index.ts
+++ b/apps/innovations/v1-innovation-file-delete/index.ts
@@ -9,6 +9,7 @@ import type { CustomContextType } from '@innovations/shared/types';
 
 import { container } from '../_config';
 
+import { ServiceRoleEnum } from '@innovations/shared/enums';
 import type { InnovationFileService } from '../_services/innovation-file.service';
 import SYMBOLS from '../_services/symbols';
 import { ParamsSchema, ParamsType } from './validation.schemas';
@@ -29,6 +30,7 @@ class V1InnovationFileDelete {
         .checkAccessorType()
         .checkAssessmentType()
         .checkInnovation()
+        .checkNotArchived({ whitelist: [ServiceRoleEnum.INNOVATOR] })
         .verify();
 
       await innovationFilesService.deleteFile(auth.getContext(), params.fileId);


### PR DESCRIPTION
- added restrictions to documents create/delete for all roles on archived innovations
- allow innovators to create/delete section and evidence files for archived innovations

Closes: [AB#161947](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/161947)
Related: [AB#160860](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/160860)