### PR TITLE
Fix / Bug 14 on Archive bugs' document

### DIFF
--- a/apps/notifications/_config/notifications.config.ts
+++ b/apps/notifications/_config/notifications.config.ts
@@ -339,7 +339,6 @@ export const NOTIFICATIONS_CONFIG = {
             unitId: Joi.string().guid()
           })
         )
-        .min(1)
         .required()
     }).required()
   },


### PR DESCRIPTION
Fix regarding item 14 on the bug document for Archive, where an Innovation on 'IN_PROGRESS' status, but without accessors (i.e. 'Awaiting support') was not receiving notifications. This was due to affectedUsers being empty in that case, and its definition on notifications.config had '.min(1)', which was causing it to error out and not firing the notification.