### PR TITLE
story/161761 - hide documents uploaded after archive

### DIFF
--- a/apps/innovations/_services/innovation-supports.service.spec.ts
+++ b/apps/innovations/_services/innovation-supports.service.spec.ts
@@ -535,6 +535,7 @@ describe('Innovations / _services / innovation-supports suite', () => {
         .save();
 
       const unitInfo = await sut.getSupportSummaryUnitInfo(
+        DTOsHelper.getUserRequestContext(scenario.users.aliceQualifyingAccessor),
         innovation.id,
         scenario.organisations.healthOrg.organisationUnits.healthOrgAiUnit.id,
         em
@@ -612,6 +613,7 @@ describe('Innovations / _services / innovation-supports suite', () => {
     it("should throw NotFoundError when innovation doesn't exist", async () => {
       await expect(() =>
         sut.getSupportSummaryUnitInfo(
+          DTOsHelper.getUserRequestContext(scenario.users.aliceQualifyingAccessor),
           randUuid(),
           scenario.organisations.healthOrg.organisationUnits.healthOrgAiUnit.id,
           em

--- a/apps/innovations/_services/innovation-supports.service.ts
+++ b/apps/innovations/_services/innovation-supports.service.ts
@@ -826,6 +826,7 @@ export class InnovationSupportsService extends BaseService {
   }
 
   async getSupportSummaryUnitInfo(
+    domainContext: DomainContextType,
     innovationId: string,
     unitId: string,
     entityManager?: EntityManager
@@ -929,7 +930,7 @@ export class InnovationSupportsService extends BaseService {
           break;
         case InnovationSupportLogTypeEnum.PROGRESS_UPDATE:
           {
-            const file = await this.getProgressUpdateFile(innovationId, supportLog.id);
+            const file = await this.getProgressUpdateFile(domainContext, innovationId, supportLog.id);
 
             summary.push({
               ...defaultSummary,
@@ -1068,7 +1069,7 @@ export class InnovationSupportsService extends BaseService {
     }
 
     await connection.transaction(async transaction => {
-      const file = await this.getProgressUpdateFile(innovationId, progressId);
+      const file = await this.getProgressUpdateFile(domainContext, innovationId, progressId);
       if (file) {
         await this.innovationFileService.deleteFile(domainContext, file.id, transaction);
       }
@@ -1193,6 +1194,7 @@ export class InnovationSupportsService extends BaseService {
   }
 
   private async getProgressUpdateFile(
+    domainContext: DomainContextType,
     innovationId: string,
     progressId: string
   ): Promise<
@@ -1209,6 +1211,7 @@ export class InnovationSupportsService extends BaseService {
     | undefined
   > {
     const files = await this.innovationFileService.getFilesList(
+      domainContext,
       innovationId,
       { contextId: progressId },
       { skip: 0, take: 1, order: { createdAt: 'ASC' } }

--- a/apps/innovations/v1-innovation-files-list/index.ts
+++ b/apps/innovations/v1-innovation-files-list/index.ts
@@ -24,7 +24,7 @@ class V1InnovationFilesList {
     try {
       const params = JoiHelper.Validate<ParamsType>(ParamsSchema, request.params);
 
-      await authorizationService
+      const auth = await authorizationService
         .validate(context)
         .setInnovation(params.innovationId)
         .checkAssessmentType()
@@ -38,7 +38,11 @@ class V1InnovationFilesList {
 
       const { skip, take, order, ...filters } = queryParams;
 
-      const result = await innovationFileService.getFilesList(params.innovationId, filters, { skip, take, order });
+      const result = await innovationFileService.getFilesList(auth.getContext(), params.innovationId, filters, {
+        skip,
+        take,
+        order
+      });
 
       context.res = ResponseHelper.Ok<ResponseDTO>({
         count: result.count,

--- a/apps/innovations/v1-innovation-support-summary-unit-info/index.ts
+++ b/apps/innovations/v1-innovation-support-summary-unit-info/index.ts
@@ -24,7 +24,7 @@ class V1InnovationSupportSummaryUnitInfo {
     try {
       const params = JoiHelper.Validate<ParamsType>(ParamsSchema, request.params);
 
-      await authorizationService
+      const auth = await authorizationService
         .validate(context)
         .setInnovation(params.innovationId)
         .checkAssessmentType()
@@ -34,7 +34,11 @@ class V1InnovationSupportSummaryUnitInfo {
         .checkInnovation()
         .verify();
 
-      const result = await innovationSupportsService.getSupportSummaryUnitInfo(params.innovationId, params.unitId);
+      const result = await innovationSupportsService.getSupportSummaryUnitInfo(
+        auth.getContext(),
+        params.innovationId,
+        params.unitId
+      );
 
       context.res = ResponseHelper.Ok<ResponseDTO>(result);
       return;


### PR DESCRIPTION
Only share documents that were uploaded before the archive date (for A/QA/NA)

Closes: [AB#161761](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/161761)