### PR TITLE
Story/162020 update delete account rules for innovations

### DIFF
--- a/apps/users/.apim/swagger.yaml
+++ b/apps/users/.apim/swagger.yaml
@@ -374,20 +374,22 @@ paths:
                 reason:
                   type: string
                   maxLength: 2000
-                  nullable: true
+              required:
+                - reason
               additionalProperties: false
       responses:
-        "200":
+        "204":
           description: User deleted successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
         "400":
-          description: Bad request.
+          description: Bad Request
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not found
+        "500":
+          description: Internal server error
   /v1/me/innovations:
     get:
       description: Retrieves the user owned innovations.

--- a/apps/users/_services/users.service.spec.ts
+++ b/apps/users/_services/users.service.spec.ts
@@ -7,10 +7,14 @@ import {
   TermsOfUseEntity,
   TermsOfUseUserEntity,
   UserEntity,
-  UserPreferenceEntity
+  UserPreferenceEntity,
+  InnovationEntity,
+  UserRoleEntity,
+  NotificationUserEntity
 } from '@users/shared/entities';
 import {
   InnovationCollaboratorStatusEnum,
+  InnovationStatusEnum,
   NotifierTypeEnum,
   PhoneUserPreferenceEnum,
   ServiceRoleEnum,
@@ -23,6 +27,9 @@ import { TestsHelper } from '@users/shared/tests';
 import { EntityManager } from 'typeorm';
 import SYMBOLS from './symbols';
 import { UsersService } from './users.service';
+import { DTOsHelper } from '@users/shared/tests/helpers/dtos.helper';
+import { InnovationCollaboratorBuilder } from '@users/shared/tests/builders/innovation-collaborator.builder';
+import { NotificationBuilder } from '@users/shared/tests/builders/notification.builder';
 
 describe('Users / _services / users service suite', () => {
   let sut: UsersService;
@@ -415,6 +422,124 @@ describe('Users / _services / users service suite', () => {
       );
 
       expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('deleteUser()', () => {
+    const johnInnovator = scenario.users.johnInnovator;
+    const janeInnovator = scenario.users.janeInnovator;
+    const reason = randText();
+
+    it('should remove the user as the owner of innovations with pending transfers and send notification', async () => {
+      const innoWithTransfer = johnInnovator.innovations.johnInnovation;
+      await sut.deleteUser(DTOsHelper.getUserRequestContext(johnInnovator), { reason }, em);
+
+      const dbInnovation = await em
+        .createQueryBuilder(InnovationEntity, 'innovation')
+        .select(['innovation.id', 'innovation.status', 'owner.id', 'innovation.expires_at'])
+        .leftJoin('innovation.owner', 'owner')
+        .where('innovation.id = :innovationId', { innovationId: innoWithTransfer.id })
+        .getOneOrFail();
+
+      expect(dbInnovation.id).toBe(innoWithTransfer.id);
+      expect(dbInnovation.status).toBe(innoWithTransfer.status);
+      expect(dbInnovation.expires_at).toBeDefined();
+      expect(dbInnovation.owner).toBeNull();
+      expect(notifierSendSpy).toHaveBeenCalledWith(expect.anything(), NotifierTypeEnum.ACCOUNT_DELETION, {
+        innovations: [{ id: innoWithTransfer.id, name: innoWithTransfer.name, transferExpireDate: expect.anything() }]
+      });
+    });
+
+    it('should remove all collaborations from user', async () => {
+      await sut.deleteUser(DTOsHelper.getUserRequestContext(janeInnovator), { reason }, em);
+
+      const activeOrPendingCollaborations = await em
+        .createQueryBuilder(InnovationCollaboratorEntity, 'collaborator')
+        .where('collaborator.user_id = :userId', { userId: scenario.users.janeInnovator.id })
+        .andWhere('collaborator.status IN (:...status)', {
+          status: [InnovationCollaboratorStatusEnum.ACTIVE, InnovationCollaboratorStatusEnum.PENDING]
+        })
+        .getCount();
+
+      expect(activeOrPendingCollaborations).toBe(0);
+    });
+
+    describe('when innovations without pending transfers', () => {
+      it('should archive all innovations without pending transfers', async () => {
+        const innoWithoutTransfer = johnInnovator.innovations.johnInnovationEmpty;
+        await sut.deleteUser(DTOsHelper.getUserRequestContext(johnInnovator), { reason }, em);
+
+        const dbInnovation = await em
+          .createQueryBuilder(InnovationEntity, 'innovation')
+          .select(['innovation.id', 'innovation.status', 'innovation.expires_at'])
+          .where('innovation.id = :innovationId', { innovationId: innoWithoutTransfer.id })
+          .getOneOrFail();
+
+        expect(dbInnovation.id).toBe(innoWithoutTransfer.id);
+        expect(dbInnovation.status).toBe(InnovationStatusEnum.ARCHIVED);
+        expect(dbInnovation.expires_at).toBeNull();
+      });
+
+      it('should remove active and pending collaborators', async () => {
+        const innoWithoutTransfer = johnInnovator.innovations.johnInnovationEmpty;
+        await new InnovationCollaboratorBuilder(em)
+          .setUser(johnInnovator.id)
+          .setEmail(janeInnovator.email)
+          .setInnovation(innoWithoutTransfer.id)
+          .save();
+
+        await sut.deleteUser(DTOsHelper.getUserRequestContext(johnInnovator), { reason }, em);
+
+        const activeOrPendingCollaborators = await em
+          .createQueryBuilder(InnovationCollaboratorEntity, 'collaborator')
+          .where('collaborator.innovation_id = :innovationId', { innovationId: innoWithoutTransfer.id })
+          .andWhere('collaborator.status IN (:...status)', {
+            status: [InnovationCollaboratorStatusEnum.ACTIVE, InnovationCollaboratorStatusEnum.PENDING]
+          })
+          .getCount();
+
+        expect(activeOrPendingCollaborators).toBe(0);
+      });
+
+      it('should clear unread notifications', async () => {
+        const innoWithoutTransfer = johnInnovator.innovations.johnInnovationEmpty;
+        const notification = await new NotificationBuilder(em)
+          .addNotificationUser(johnInnovator)
+          .setInnovation(innoWithoutTransfer.id)
+          .setContext('SUPPORT', 'ST02_SUPPORT_STATUS_TO_OTHER', randUuid())
+          .save();
+
+        await sut.deleteUser(DTOsHelper.getUserRequestContext(johnInnovator), { reason }, em);
+
+        const dbNotification = await em.createQueryBuilder(NotificationUserEntity, 'userNotification')
+          .select(['userNotification.id', 'userNotification.deletedAt'])
+          .withDeleted()
+          .where('userNotification.notification_id = :notificationId', {notificationId: notification.id })
+          .getOneOrFail();
+
+        expect(dbNotification.deletedAt).toBeDefined();
+      });
+    });
+
+    it('should delete the user and associated roles', async () => {
+      await sut.deleteUser(DTOsHelper.getUserRequestContext(johnInnovator), { reason }, em);
+
+      const user = await em
+        .createQueryBuilder(UserEntity, 'user')
+        .select(['user.id', 'user.status', 'user.deleteReason'])
+        .where('user.id = :userId', { userId: johnInnovator.id })
+        .getOneOrFail();
+
+      const nActiveRoles = await em
+        .createQueryBuilder(UserRoleEntity, 'role')
+        .where('role.user_id = :userId', { userId: johnInnovator.id })
+        .andWhere('role.isActive = :active', { active: true })
+        .getCount();
+
+      expect(user.id).toBe(johnInnovator.id);
+      expect(user.status).toBe(UserStatusEnum.DELETED);
+      expect(user.deleteReason).toBe(reason);
+      expect(nActiveRoles).toBe(0);
     });
   });
 });

--- a/apps/users/_services/users.service.spec.ts
+++ b/apps/users/_services/users.service.spec.ts
@@ -55,7 +55,7 @@ describe('Users / _services / users service suite', () => {
     notifierSendSpy.mockReset();
   });
 
-  describe('getUserPendingInnoavtionTranfers', () => {
+  describe('getUserPendingInnovationTranfers', () => {
     it('should get all the pending innovation transfers to the user', async () => {
       const innovation = scenario.users.johnInnovator.innovations.johnInnovation;
       const otherInnovation = scenario.users.adamInnovator.innovations.adamInnovation;

--- a/apps/users/_services/users.service.ts
+++ b/apps/users/_services/users.service.ts
@@ -481,7 +481,7 @@ export class UsersService extends BaseService {
               : ''
           });
 
-          await this.sqlConnection.getRepository(InnovationEntity).update(
+          await transaction.getRepository(InnovationEntity).update(
             { id: dbInnovation.id },
             { updatedBy: dbUser.id, owner: null, expires_at: dbInnovation.expirationTransferDate }
           );

--- a/apps/users/_services/users.service.ts
+++ b/apps/users/_services/users.service.ts
@@ -3,6 +3,7 @@ import type { EntityManager } from 'typeorm';
 
 import {
   InnovationCollaboratorEntity,
+  InnovationEntity,
   InnovationTransferEntity,
   OrganisationEntity,
   TermsOfUseEntity,
@@ -23,10 +24,11 @@ import {
 } from '@users/shared/enums';
 import { NotFoundError, UnprocessableEntityError, UserErrorsEnum } from '@users/shared/errors';
 import type { PaginationQueryParamsType } from '@users/shared/helpers';
-import type { CacheConfigType, CacheService, IdentityProviderService, NotifierService } from '@users/shared/services';
+import type { CacheConfigType, CacheService, DomainService, IdentityProviderService, NotifierService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
 
 import { BaseService } from './base.service';
+import type { DomainContextType } from '@users/shared/types';
 
 @injectable()
 export class UsersService extends BaseService {
@@ -36,7 +38,8 @@ export class UsersService extends BaseService {
     @inject(SHARED_SYMBOLS.CacheService) cacheService: CacheService,
     @inject(SHARED_SYMBOLS.IdentityProviderService)
     private identityProviderService: IdentityProviderService,
-    @inject(SHARED_SYMBOLS.NotifierService) private notifierService: NotifierService
+    @inject(SHARED_SYMBOLS.NotifierService) private notifierService: NotifierService,
+    @inject(SHARED_SYMBOLS.DomainService) private domainService: DomainService
   ) {
     super();
     this.cache = cacheService.get('IdentityUserInfo');
@@ -424,5 +427,84 @@ export class UsersService extends BaseService {
     }));
 
     return data;
+  }
+
+  async deleteUser(domainContext: DomainContextType, data: { reason: string }, entityManager?: EntityManager): Promise<void> {
+    const em = entityManager ?? this.sqlConnection.manager;
+
+    const dbUser = await em
+      .createQueryBuilder(UserEntity, 'user')
+      .innerJoinAndSelect('user.serviceRoles', 'roles')
+      .where('user.id = :userId', { userId: domainContext.id })
+      .getOne();
+    if (!dbUser) {
+      throw new NotFoundError(UserErrorsEnum.USER_SQL_NOT_FOUND);
+    }
+
+    const user = await this.identityProviderService.getUserInfo(dbUser.identityId);
+    if (!user) {
+      throw new NotFoundError(UserErrorsEnum.USER_IDENTITY_PROVIDER_NOT_FOUND);
+    }
+
+    const innovationsWithPendingTransfer: { id: string; name: string; transferExpireDate: string }[] = [];
+
+    return em.transaction(async transaction => {
+      // If user has innovator role, deals with it's innovations.
+      const userInnovatorRole = dbUser.serviceRoles.find(item => item.role === ServiceRoleEnum.INNOVATOR);
+
+      if (userInnovatorRole) {
+        const dbInnovations = await this.domainService.innovations.getInnovationsByOwnerId(dbUser.id, transaction);
+
+        await this.domainService.innovations.bulkUpdateCollaboratorStatusByEmail(
+          transaction,
+          { id: dbUser.id, email: user.email },
+          { current: InnovationCollaboratorStatusEnum.PENDING, next: InnovationCollaboratorStatusEnum.DECLINED }
+        );
+        await this.domainService.innovations.bulkUpdateCollaboratorStatusByEmail(
+          transaction,
+          { id: dbUser.id, email: user.email },
+          { current: InnovationCollaboratorStatusEnum.ACTIVE, next: InnovationCollaboratorStatusEnum.LEFT }
+        );
+
+        await this.domainService.innovations.archiveInnovationsWithDeleteSideffects(
+          domainContext,
+          dbInnovations.filter(i => i.expirationTransferDate === null).map(i => ({ id: i.id, reason: data.reason })),
+          transaction
+        );
+
+        for (const dbInnovation of dbInnovations.filter(i => i.expirationTransferDate !== null)) {
+          innovationsWithPendingTransfer.push({
+            id: dbInnovation.id,
+            name: dbInnovation.name,
+            transferExpireDate: dbInnovation.expirationTransferDate
+              ? dbInnovation.expirationTransferDate.toDateString()
+              : ''
+          });
+
+          await this.sqlConnection.getRepository(InnovationEntity).update(
+            { id: dbInnovation.id },
+            { updatedBy: dbUser.id, owner: null, expires_at: dbInnovation.expirationTransferDate }
+          );
+        }
+
+        // Send notification to collaborators if there are innovations with pending transfer
+        if (innovationsWithPendingTransfer.length > 0) {
+          await this.notifierService.send(domainContext, NotifierTypeEnum.ACCOUNT_DELETION, {
+            innovations: innovationsWithPendingTransfer
+          });
+        }
+      }
+
+      await transaction.update(UserRoleEntity, { user: { id: dbUser.id } }, { isActive: false });
+
+      await transaction.update(
+        UserEntity,
+        { id: dbUser.id },
+        { deleteReason: data.reason, status: UserStatusEnum.DELETED }
+      );
+
+      // If all went well, deleted from B2C.
+      await this.identityProviderService.deleteUser(dbUser.identityId);
+    });
   }
 }

--- a/apps/users/v1-me-delete/index.spec.ts
+++ b/apps/users/v1-me-delete/index.spec.ts
@@ -1,6 +1,6 @@
 import azureFunction from '.';
 
-import { randUuid } from '@ngneat/falso';
+import { randText, randUuid } from '@ngneat/falso';
 import { NotFoundError, UserErrorsEnum } from '@users/shared/errors';
 import { DomainUsersService } from '@users/shared/services';
 import { AzureHttpTriggerBuilder, TestsHelper } from '@users/shared/tests';
@@ -30,14 +30,15 @@ afterEach(() => {
 });
 
 describe('v1-me-delete Suite', () => {
-  describe('200', () => {
+  describe('204', () => {
     it('should delete the user', async () => {
       const result = await new AzureHttpTriggerBuilder()
         .setAuth(scenario.users.johnInnovator)
+        .setBody({ reason: randText() })
         .call<never>(azureFunction);
 
-      expect(result.body).toStrictEqual(expected);
-      expect(result.status).toBe(200);
+      expect(result.status).toBe(204);
+      expect(result.body).toBeUndefined();
       expect(mock).toHaveBeenCalledTimes(1);
     });
   });
@@ -47,6 +48,7 @@ describe('v1-me-delete Suite', () => {
       mock.mockRejectedValueOnce(new NotFoundError(UserErrorsEnum.USER_SQL_NOT_FOUND));
       const res = await new AzureHttpTriggerBuilder()
         .setAuth(scenario.users.johnInnovator)
+        .setBody({ reason: randText() })
         .call<ErrorResponseType>(azureFunction);
       expect(res.status).toBe(404);
       expect(res.body.error).toBe(UserErrorsEnum.USER_SQL_NOT_FOUND);

--- a/apps/users/v1-me-delete/index.spec.ts
+++ b/apps/users/v1-me-delete/index.spec.ts
@@ -1,10 +1,10 @@
 import azureFunction from '.';
 
-import { randText, randUuid } from '@ngneat/falso';
+import { randText } from '@ngneat/falso';
 import { NotFoundError, UserErrorsEnum } from '@users/shared/errors';
-import { DomainUsersService } from '@users/shared/services';
 import { AzureHttpTriggerBuilder, TestsHelper } from '@users/shared/tests';
 import type { ErrorResponseType } from '@users/shared/types';
+import { UsersService } from '../_services/users.service';
 
 jest.mock('@users/shared/decorators', () => ({
   JwtDecoder: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
@@ -22,8 +22,7 @@ beforeAll(async () => {
   await testsHelper.init();
 });
 
-const expected = { id: randUuid() };
-const mock = jest.spyOn(DomainUsersService.prototype, 'deleteUser').mockResolvedValue(expected);
+const mock = jest.spyOn(UsersService.prototype, 'deleteUser').mockResolvedValue();
 
 afterEach(() => {
   jest.clearAllMocks();

--- a/apps/users/v1-me-delete/transformation.dtos.ts
+++ b/apps/users/v1-me-delete/transformation.dtos.ts
@@ -1,3 +1,0 @@
-export type ResponseDTO = {
-  id: string;
-};

--- a/apps/users/v1-me-delete/validation.schemas.ts
+++ b/apps/users/v1-me-delete/validation.schemas.ts
@@ -5,7 +5,6 @@ import { TEXTAREA_LENGTH_LIMIT } from '@users/shared/constants';
 export type BodyType = {
   reason: string;
 };
-
 export const BodySchema = Joi.object<BodyType>({
-  reason: Joi.string().max(TEXTAREA_LENGTH_LIMIT.xl).allow(null, '')
+  reason: Joi.string().max(TEXTAREA_LENGTH_LIMIT.xl).required()
 }).required();

--- a/libs/shared/services/domain/domain-users.service.ts
+++ b/libs/shared/services/domain/domain-users.service.ts
@@ -302,6 +302,9 @@ export class DomainUsersService {
     }
   }
 
+  /**
+   * @deprected this can be removed, just living it to not mess a current notification story.
+   */
   async deleteUser(
     domainContext: DomainContextType,
     userId: string,


### PR DESCRIPTION
**Context:**
Given the removal of the "Withdraw" and "Pause" functionalities from the service, it is imperative to eliminate any pending dependencies associated with these features. One such dependency involves the deletion of user accounts, which previously triggered the withdrawal of innovations associated with the user being deleted. This pull request aims to replace the withdrawal action with archiving, introducing different side-effects when archiving is combined with deletion.

**Changes:**
- Relocate the "delete user" functionality to the users service, as it is not utilised across multiple FAs.
- Adjust the `me-delete` endpoint to return a status code of 204 instead of 200, and update the corresponding Swagger documentation.
- Revise the rules for deleting user accounts and introduce unit tests for them.
- Convert `archiveInnovation` to a domain function since it is reused across FAs.

**Related tickets:**
- Closes [AB#162554](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/162554).