### PR TITLE
fix: block canDelete when inno is archived for support team

### DIFF
--- a/apps/innovations/_services/innovation-file.service.spec.ts
+++ b/apps/innovations/_services/innovation-file.service.spec.ts
@@ -694,6 +694,34 @@ describe('Services / Innovation File service suite', () => {
       }
     );
 
+    describe('When innovation is archived', () => {
+      beforeEach(async () => {
+        await em.update(InnovationEntity, { id: innovation.id }, { status: InnovationStatusEnum.ARCHIVED });
+      });
+
+      it('should allow delete if is from an innovator and is a section file', async () => {
+        const file = userMap.get('johnInnovator')!.file;
+        const result = await sut.getFileInfo(
+          DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
+          innovation.id,
+          file.id,
+          em
+        );
+        expect(result.canDelete).toBe(true);
+      });
+
+      it('should not allow deletion if is not an innovator', async () => {
+        const file = userMap.get('johnInnovator')!.file;
+        const result = await sut.getFileInfo(
+          DTOsHelper.getUserRequestContext(scenario.users.aliceQualifyingAccessor),
+          innovation.id,
+          file.id,
+          em
+        );
+        expect(result.canDelete).toBe(false);
+      });
+    });
+
     describe('As any role', () => {
       describe("when I request a file information about a file that doesn't exist", () => {
         it('should return a not found error', async () => {

--- a/apps/innovations/_services/innovation-file.service.ts
+++ b/apps/innovations/_services/innovation-file.service.ts
@@ -529,6 +529,10 @@ export class InnovationFileService extends BaseService {
     status: InnovationStatusEnum,
     type: InnovationFileContextTypeEnum
   ): boolean {
+    if (status === InnovationStatusEnum.ARCHIVED && requestUserRole.role !== ServiceRoleEnum.INNOVATOR) {
+      return false;
+    }
+
     switch (requestUserRole.role) {
       case ServiceRoleEnum.INNOVATOR:
         // Check if the innovation is archived and the file is not an innovation section before delete (other roles are checked in the auth but innovator was whitelisted)


### PR DESCRIPTION
**Related tickets:**
- Closes Bug 33 from bugs archive doc.