### PR TITLE
feat: archive innovations when transfer declined

### DIFF
--- a/apps/innovations/_services/innovation-transfer.service.spec.ts
+++ b/apps/innovations/_services/innovation-transfer.service.spec.ts
@@ -322,7 +322,7 @@ describe('Innovations / _services / innovation transfer suite', () => {
       expect(deleteCollabSpy).toHaveBeenCalled();
     });
 
-    it('should withdraw innovation without owner when changing transfer to DECLINED', async () => {
+    it('should archive innovation without owner when changing transfer to DECLINED', async () => {
       const dbInnovation = await em
         .createQueryBuilder(InnovationEntity, 'innovation')
         .where('innovation.id = :innovationId', {
@@ -334,7 +334,7 @@ describe('Innovations / _services / innovation transfer suite', () => {
         .spyOn(DomainInnovationsService.prototype, 'getInnovationInfo')
         .mockResolvedValueOnce({ ...dbInnovation, owner: null } as InnovationEntity);
 
-      const withdrawInnovationSpy = jest.spyOn(
+      const archiveInnovationSpy = jest.spyOn(
         DomainInnovationsService.prototype,
         'archiveInnovationsWithDeleteSideffects'
       );
@@ -348,7 +348,7 @@ describe('Innovations / _services / innovation transfer suite', () => {
       );
 
       expect(result.id).toBeDefined();
-      expect(withdrawInnovationSpy).toHaveBeenCalled();
+      expect(archiveInnovationSpy).toHaveBeenCalled();
     });
 
     it('should throw a not found error when the transfer is not found', async () => {

--- a/apps/innovations/_services/innovation-transfer.service.spec.ts
+++ b/apps/innovations/_services/innovation-transfer.service.spec.ts
@@ -322,7 +322,7 @@ describe('Innovations / _services / innovation transfer suite', () => {
       expect(deleteCollabSpy).toHaveBeenCalled();
     });
 
-    it('should withdraw innovation without owner when changing transfer to COMPLETED', async () => {
+    it('should withdraw innovation without owner when changing transfer to DECLINED', async () => {
       const dbInnovation = await em
         .createQueryBuilder(InnovationEntity, 'innovation')
         .where('innovation.id = :innovationId', {
@@ -334,13 +334,13 @@ describe('Innovations / _services / innovation transfer suite', () => {
         .spyOn(DomainInnovationsService.prototype, 'getInnovationInfo')
         .mockResolvedValueOnce({ ...dbInnovation, owner: null } as InnovationEntity);
 
-      const withdrawInnovationSpy = jest.spyOn(DomainInnovationsService.prototype, 'withdrawInnovations');
+      const withdrawInnovationSpy = jest.spyOn(
+        DomainInnovationsService.prototype,
+        'archiveInnovationsWithDeleteSideffects'
+      );
 
       const result = await sut.updateInnovationTransferStatus(
-        {
-          id: scenario.users.janeInnovator.id,
-          identityId: scenario.users.janeInnovator.identityId
-        },
+        { id: scenario.users.janeInnovator.id, identityId: scenario.users.janeInnovator.identityId },
         DTOsHelper.getUserRequestContext(scenario.users.janeInnovator),
         scenario.users.johnInnovator.innovations.johnInnovation.transfer.id,
         InnovationTransferStatusEnum.DECLINED,

--- a/libs/shared/services/domain/domain-innovations.service.ts
+++ b/libs/shared/services/domain/domain-innovations.service.ts
@@ -42,12 +42,7 @@ import {
   UnprocessableEntityError
 } from '../../errors';
 import { TranslationHelper } from '../../helpers';
-import type {
-  ActivitiesParamsType,
-  DomainContextType,
-  IdentityUserInfo,
-  SupportLogParams
-} from '../../types';
+import type { ActivitiesParamsType, DomainContextType, IdentityUserInfo, SupportLogParams } from '../../types';
 import type { IdentityProviderService } from '../integrations/identity-provider.service';
 import type { NotifierService } from '../integrations/notifier.service';
 import type { DomainUsersService } from './domain-users.service';
@@ -79,7 +74,7 @@ export class DomainInnovationsService {
     const dbInnovations = await em
       .createQueryBuilder(InnovationEntity, 'innovations')
       .select(['innovations.id', 'transfers.id', 'transfers.createdBy'])
-      .innerJoin('innovation.transfers', 'transfers', 'status = :status', {
+      .innerJoin('innovations.transfers', 'transfers', 'status = :status', {
         status: InnovationTransferStatusEnum.PENDING
       })
       .where('innovations.expires_at < :now', { now: new Date().toISOString() })

--- a/libs/shared/services/domain/domain-innovations.service.ts
+++ b/libs/shared/services/domain/domain-innovations.service.ts
@@ -46,11 +46,11 @@ import type {
   ActivitiesParamsType,
   DomainContextType,
   IdentityUserInfo,
-  InnovatorDomainContextType,
   SupportLogParams
 } from '../../types';
 import type { IdentityProviderService } from '../integrations/identity-provider.service';
 import type { NotifierService } from '../integrations/notifier.service';
+import type { DomainUsersService } from './domain-users.service';
 
 export class DomainInnovationsService {
   innovationRepository: Repository<InnovationEntity>;
@@ -60,7 +60,8 @@ export class DomainInnovationsService {
   constructor(
     private sqlConnection: DataSource,
     private identityProviderService: IdentityProviderService,
-    private notifierService: NotifierService
+    private notifierService: NotifierService,
+    private domainUsersService: DomainUsersService
   ) {
     this.innovationRepository = this.sqlConnection.getRepository(InnovationEntity);
     this.innovationSupportRepository = this.sqlConnection.getRepository(InnovationSupportEntity);
@@ -86,39 +87,13 @@ export class DomainInnovationsService {
 
     for (const innovation of dbInnovations) {
       if (innovation.transfers[0]) {
-        const userRole = await em
-          .createQueryBuilder(UserRoleEntity, 'userRole')
-          .select([
-            'userRole.id',
-            'user.id',
-            'user.identityId',
-            'organisation.id',
-            'organisation.name',
-            'organisation.acronym'
-          ])
-          .innerJoin('userRole.user', 'user')
-          .innerJoin('userRole.organisation', 'organisation')
-          .where('user_id = :userId', { userId: innovation.transfers[0].createdBy })
-          .andWhere('role = :innovatorRole', { innovatorRole: ServiceRoleEnum.INNOVATOR })
-          .getOne();
-
-        if (!userRole?.organisation) {
+        const domainContext = await this.domainUsersService.getInnovatorDomainContextByRoleId(
+          innovation.transfers[0].createdBy,
+          em
+        );
+        if (!domainContext) {
           return; // this will never happen
         }
-
-        const domainContext: InnovatorDomainContextType = {
-          id: userRole.user.id,
-          identityId: userRole.user.identityId,
-          organisation: {
-            id: userRole.organisation.id,
-            name: userRole.organisation.name,
-            acronym: userRole.organisation.acronym
-          },
-          currentRole: {
-            id: userRole.id,
-            role: ServiceRoleEnum.INNOVATOR
-          }
-        };
 
         await this.archiveInnovationsWithDeleteSideffects(
           domainContext,

--- a/libs/shared/services/domain/domain.service.ts
+++ b/libs/shared/services/domain/domain.service.ts
@@ -39,7 +39,12 @@ export class DomainService {
   ) {}
 
   setConnection(connection: DataSource): void {
-    this._innovations = new DomainInnovationsService(connection, this.identityProviderService, this.notifierService);
     this._users = new DomainUsersService(connection, this.identityProviderService);
+    this._innovations = new DomainInnovationsService(
+      connection,
+      this.identityProviderService,
+      this.notifierService,
+      this._users
+    );
   }
 }


### PR DESCRIPTION
When a transfer is declined from an innovation without owner is declined the innovation needs to be archived instead of withdrawn. This commit introduces that change.

**Related tickets:**
- Closes number 36 from archived document.