### PR TITLE
feat: save innovation archive reason

### DIFF
--- a/apps/innovations/_services/innovations.service.spec.ts
+++ b/apps/innovations/_services/innovations.service.spec.ts
@@ -417,12 +417,13 @@ describe('Innovations / _services / innovations suite', () => {
 
       const dbInnovation = await em
         .createQueryBuilder(InnovationEntity, 'innovation')
-        .select(['innovation.status', 'innovation.archivedStatus'])
+        .select(['innovation.status', 'innovation.archiveReason', 'innovation.archivedStatus'])
         .where('innovation.id = :innovationId', { innovationId: innovation.id })
-        .getOne();
+        .getOneOrFail();
 
-      expect(dbInnovation?.status).toBe(InnovationStatusEnum.ARCHIVED);
-      expect(dbInnovation?.archivedStatus).toBe(innovation.status);
+      expect(dbInnovation.status).toBe(InnovationStatusEnum.ARCHIVED);
+      expect(dbInnovation.archivedStatus).toBe(innovation.status);
+      expect(dbInnovation.archiveReason).toBe(message);
     });
 
     it('should cancel all open tasks', async () => {

--- a/libs/data-access/migrations/1708527845312-alter-innovation-withdraw-reason-to-archive-reason-migrations.ts
+++ b/libs/data-access/migrations/1708527845312-alter-innovation-withdraw-reason-to-archive-reason-migrations.ts
@@ -1,0 +1,11 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class alterInnovationWithdrawReasonWithArchiveReason1708527845312 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`exec sp_rename 'innovation.withdraw_reason', 'archive_reason', 'COLUMN'`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`exec sp_rename 'innovation.archive_reason', 'withdraw_reason', 'COLUMN'`);
+  }
+}

--- a/libs/shared/entities/innovation/innovation.entity.ts
+++ b/libs/shared/entities/innovation/innovation.entity.ts
@@ -69,8 +69,8 @@ export class InnovationEntity extends BaseEntity {
   @Column({ name: 'main_category', type: 'nvarchar', nullable: true })
   mainCategory: null | CurrentCatalogTypes.catalogCategory;
 
-  @Column({ name: 'withdraw_reason', type: 'nvarchar', nullable: true })
-  withdrawReason: null | string;
+  @Column({ name: 'archive_reason', type: 'nvarchar', nullable: true })
+  archiveReason: null | string;
 
   @ManyToOne(() => UserEntity, { nullable: true })
   @JoinColumn({ name: 'owner_id' })

--- a/libs/shared/services/domain/domain-innovations.service.ts
+++ b/libs/shared/services/domain/domain-innovations.service.ts
@@ -351,6 +351,7 @@ export class DomainInnovationsService {
           {
             archivedStatus: () => 'status',
             status: InnovationStatusEnum.ARCHIVED,
+            archiveReason: innovation.reason,
             statusUpdatedAt: archivedAt,
             updatedBy: domainContext.id,
             expires_at: null


### PR DESCRIPTION
**Description:**
Before the deprecation of stop sharing and withdrawn the reason of withdraw was saved in the field `withdrawReason` from innovations table. Since this functionality no longer exists, it is essential to rename the `withdrawReason` field to `archiveReason` and ensure that it is persisted when innovations are archived.