### PR TITLE
Task/162893 add upsert mfa

### DIFF
--- a/apps/users/.apim/swagger.yaml
+++ b/apps/users/.apim/swagger.yaml
@@ -417,6 +417,46 @@ paths:
                       type: string
         "400":
           description: Bad request
+  /v1/me/mfa:
+    put:
+      description: Upsert user MFA configuration
+      operationId: v1-me-mfa-upsert
+      tags:
+        - "[v1] Users"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - none
+                    - email
+                    - phone
+                phoneNumber:
+                  anyOf:
+                    - type: string
+                      maxLength: 20
+                      x-required: true
+              required:
+                - type
+              additionalProperties: false
+      responses:
+        "204":
+          description: MFA information upserted
+        "400":
+          description: Bad Request
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
   /v1/me/terms-of-use/accept:
     patch:
       description: Accept user terms of use
@@ -569,7 +609,6 @@ paths:
                       - RE01_EXPORT_REQUEST_SUBMITTED
                       - RE02_EXPORT_REQUEST_APPROVED
                       - RE03_EXPORT_REQUEST_REJECTED
-                      - WI01_INNOVATION_WITHDRAWN
                       - AI01_INNOVATION_ARCHIVED_TO_SELF
                       - AI02_INNOVATION_ARCHIVED_TO_COLLABORATORS
                       - AI03_INNOVATION_ARCHIVED_TO_ENGAGING_QA_A
@@ -773,7 +812,6 @@ paths:
                             - RE01_EXPORT_REQUEST_SUBMITTED
                             - RE02_EXPORT_REQUEST_APPROVED
                             - RE03_EXPORT_REQUEST_REJECTED
-                            - WI01_INNOVATION_WITHDRAWN
                             - AI01_INNOVATION_ARCHIVED_TO_SELF
                             - AI02_INNOVATION_ARCHIVED_TO_COLLABORATORS
                             - AI03_INNOVATION_ARCHIVED_TO_ENGAGING_QA_A

--- a/apps/users/_services/users.service.ts
+++ b/apps/users/_services/users.service.ts
@@ -522,4 +522,19 @@ export class UsersService extends BaseService {
       await this.identityProviderService.deleteUser(dbUser.identityId);
     });
   }
+
+  async upsertUserMfa(
+    domainContext: DomainContextType,
+    data: { type: 'none' } | { type: 'email' } | { type: 'phone'; phoneNumber: string }
+  ): Promise<void> {
+    const type = await this.identityProviderService.getMfaExtensionType(domainContext.identityId);
+
+    if (data.type === 'phone') {
+      await this.identityProviderService.upsertMfaPhoneNumber(domainContext.identityId, data.phoneNumber);
+    } else if (data.type === type) {
+      return;
+    }
+
+    await this.identityProviderService.updateMfaExtensionType(domainContext.identityId, data.type);
+  }
 }

--- a/apps/users/v1-me-mfa-upsert/function.json
+++ b/apps/users/v1-me-mfa-upsert/function.json
@@ -1,0 +1,13 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["put"],
+      "route": "v1/me/mfa"
+    },
+    { "type": "http", "direction": "out", "name": "res" }
+  ]
+}

--- a/apps/users/v1-me-mfa-upsert/index.spec.ts
+++ b/apps/users/v1-me-mfa-upsert/index.spec.ts
@@ -1,0 +1,71 @@
+import azureFunction from '.';
+
+import { randPhoneNumber } from '@ngneat/falso';
+import { AzureHttpTriggerBuilder, TestsHelper } from '@users/shared/tests';
+import type { TestUserType } from '@users/shared/tests/builders/user.builder';
+import type { ErrorResponseType } from '@users/shared/types';
+import { UsersService } from '../_services/users.service';
+import type { BodyType } from './validation.schemas';
+
+jest.mock('@users/shared/decorators', () => ({
+  JwtDecoder: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
+    return descriptor;
+  }),
+  Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
+    return descriptor;
+  })
+}));
+
+const testsHelper = new TestsHelper();
+const scenario = testsHelper.getCompleteScenario();
+
+beforeAll(async () => {
+  await testsHelper.init();
+});
+
+const mock = jest.spyOn(UsersService.prototype, 'upsertUserMfa').mockResolvedValue();
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('v1-me-mfa-upsert Suite', () => {
+  describe('204', () => {
+    it.each([['none'], ['email'], ['phone']])('should update the user mfa as to %s', async type => {
+      let body: BodyType;
+      if (type === 'phone') {
+        body = {
+          type,
+          phoneNumber: randPhoneNumber()
+        };
+      } else {
+        body = { type: type as 'none' | 'email' };
+      }
+
+      const result = await new AzureHttpTriggerBuilder()
+        .setAuth(scenario.users.johnInnovator)
+        .setBody<BodyType>(body)
+        .call<never>(azureFunction);
+
+      expect(result.status).toBe(204);
+      expect(mock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Access', () => {
+    it.each([
+      ['Admin', 403, scenario.users.allMighty],
+      ['QA', 403, scenario.users.aliceQualifyingAccessor],
+      ['A', 403, scenario.users.ingridAccessor],
+      ['NA', 403, scenario.users.paulNeedsAssessor],
+      ['Innovator', 204, scenario.users.johnInnovator]
+    ])('access with user %s should give %i', async (_role: string, status: number, user: TestUserType) => {
+      const result = await new AzureHttpTriggerBuilder()
+        .setAuth(user)
+        .setBody<BodyType>({ type: 'none' })
+        .call<ErrorResponseType>(azureFunction);
+
+      expect(result.status).toBe(status);
+    });
+  });
+});

--- a/apps/users/v1-me-mfa-upsert/index.ts
+++ b/apps/users/v1-me-mfa-upsert/index.ts
@@ -1,0 +1,53 @@
+import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
+import type { AzureFunction, HttpRequest } from '@azure/functions';
+
+import { JwtDecoder } from '@users/shared/decorators';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
+import type { AuthorizationService } from '@users/shared/services';
+import SHARED_SYMBOLS from '@users/shared/services/symbols';
+import type { CustomContextType } from '@users/shared/types';
+
+import { container } from '../_config';
+
+import SYMBOLS from '../_services/symbols';
+import type { UsersService } from '../_services/users.service';
+import { BodyType, BodySchema } from './validation.schemas';
+
+class V1MeMfaUpsert {
+  @JwtDecoder()
+  static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
+    const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
+    const usersService = container.get<UsersService>(SYMBOLS.UsersService);
+
+    try {
+      const body = JoiHelper.Validate<BodyType>(BodySchema, request.body);
+
+      const auth = await authorizationService.validate(context).checkInnovatorType().verify();
+
+      await usersService.upsertUserMfa(auth.getContext(), body);
+
+      context.res = ResponseHelper.NoContent();
+      return;
+    } catch (error) {
+      context.res = ResponseHelper.Error(context, error);
+      return;
+    }
+  }
+}
+
+export default openApi(V1MeMfaUpsert.httpTrigger as AzureFunction, '/v1/me/mfa', {
+  put: {
+    description: 'Upsert user MFA configuration',
+    operationId: 'v1-me-mfa-upsert',
+    tags: ['[v1] Users'],
+    requestBody: SwaggerHelper.bodyJ2S(BodySchema),
+    responses: {
+      204: { description: 'MFA information upserted' },
+      400: { description: 'Bad Request' },
+      401: { description: 'Unauthorized' },
+      403: { description: 'Forbidden' },
+      404: { description: 'Not Found' },
+      500: { description: 'Internal Server Error' }
+    }
+  }
+});

--- a/apps/users/v1-me-mfa-upsert/validation.schemas.ts
+++ b/apps/users/v1-me-mfa-upsert/validation.schemas.ts
@@ -1,0 +1,11 @@
+import Joi from 'joi';
+
+export type BodyType = { type: 'none' } | { type: 'email' } | { type: 'phone'; phoneNumber: string };
+export const BodySchema = Joi.object<BodyType>({
+  type: Joi.string().valid('none', 'email', 'phone').required(),
+  phoneNumber: Joi.alternatives().conditional('type', {
+    is: 'phone',
+    then: Joi.string().max(20).required(),
+    otherwise: Joi.forbidden()
+  })
+}).required();

--- a/libs/shared/services/integrations/identity-provider.service.ts
+++ b/libs/shared/services/integrations/identity-provider.service.ts
@@ -6,6 +6,7 @@ import {
   GenericErrorsEnum,
   InternalServerError,
   NotFoundError,
+  BadRequestError,
   ServiceUnavailableError,
   UserErrorsEnum
 } from '../../errors';
@@ -131,6 +132,8 @@ export class IdentityProviderService {
         return new NotFoundError(UserErrorsEnum.USER_IDENTITY_PROVIDER_NOT_FOUND);
       case 401:
         return new InternalServerError(GenericErrorsEnum.SERVICE_IDENTIY_UNAUTHORIZED);
+      case 400:
+        return new BadRequestError(GenericErrorsEnum.INVALID_PAYLOAD, { message });
       default:
         return new ServiceUnavailableError(GenericErrorsEnum.SERVICE_SQL_UNAVAILABLE, {
           details: { message }
@@ -472,7 +475,7 @@ export class IdentityProviderService {
         );
       }
     } catch (error: any) {
-      throw this.getError(error.response.status, error.response.data.message);
+      throw this.getError(error.response.status, error.response.data.error.message);
     }
   }
 }

--- a/libs/shared/services/integrations/identity-provider.service.ts
+++ b/libs/shared/services/integrations/identity-provider.service.ts
@@ -73,6 +73,11 @@ export class IdentityProviderService {
   };
   private sessionData: { token: string; expiresAt: number } = { token: '', expiresAt: 0 };
   private cache: CacheConfigType['IdentityUserInfo'];
+  private constants = {
+    // More info https://learn.microsoft.com/en-us/graph/api/resources/phoneauthenticationmethod?view=graph-rest-1.0#properties
+    mfa_mobile_id: '3179e48a-750b-4051-897c-87b9720928f7',
+    mfa_extension_key: `extension_${process.env['AD_EXTENSION_ID'] ?? ''}_mfaByPhoneOrEmail`
+  };
 
   constructor(
     @inject(SHARED_SYMBOLS.CacheService) cacheService: CacheService,
@@ -398,5 +403,76 @@ export class IdentityProviderService {
       });
 
     await this.cache.delete(identityId);
+  }
+
+  async getMfaExtensionType(identityId: string): Promise<'none' | 'email' | 'phone'> {
+    await this.verifyAccessToken();
+
+    const response = await axios
+      .get<any>(`https://graph.microsoft.com/v1.0/users/${identityId}?$select=${this.constants.mfa_extension_key}`, {
+        headers: { Authorization: `Bearer ${this.sessionData.token}` }
+      })
+      .catch(error => {
+        throw this.getError(error.response.status, error.response.data.message);
+      });
+
+    return response.data[this.constants.mfa_extension_key] ?? 'none';
+  }
+
+  async updateMfaExtensionType(identityId: string, type: 'none' | 'email' | 'phone'): Promise<void> {
+    await this.verifyAccessToken();
+
+    await axios
+      .patch<any>(
+        `https://graph.microsoft.com/v1.0/users/${identityId}`,
+        { [this.constants.mfa_extension_key]: type },
+        { headers: { Authorization: `Bearer ${this.sessionData.token}` } }
+      )
+      .catch(error => {
+        throw this.getError(error.response.status, error.response.data.message);
+      });
+  }
+
+  async getMfaPhoneNumber(identityId: string): Promise<string | null> {
+    await this.verifyAccessToken();
+
+    try {
+      const response = await axios.get<{ id: string; phoneNumber: string; phoneType: string; smsSignInState: string }>(
+        `https://graph.microsoft.com/v1.0/users/${identityId}/authentication/phoneMethods/${this.constants.mfa_mobile_id}`,
+        { headers: { Authorization: `Bearer ${this.sessionData.token}` } }
+      );
+      return response.data.phoneNumber;
+    } catch (error: any) {
+      // It means the user doesn't have a phone number created
+      if (error.response.status === 404) {
+        return null;
+      }
+      throw this.getError(error.response.status, error.response.data.message);
+    }
+  }
+
+  async upsertMfaPhoneNumber(identityId: string, phoneNumber: string): Promise<void> {
+    const curPhoneNumber = await this.getMfaPhoneNumber(identityId);
+
+    // No need to hit B2C if the user is trying to update to the same phone.
+    if (curPhoneNumber === phoneNumber) return;
+
+    try {
+      if (curPhoneNumber !== null) {
+        await axios.patch<any>(
+          `https://graph.microsoft.com/v1.0/users/${identityId}/authentication/phoneMethods/${this.constants.mfa_mobile_id}`,
+          { phoneNumber, phoneType: 'mobile' },
+          { headers: { Authorization: `Bearer ${this.sessionData.token}` } }
+        );
+      } else {
+        await axios.post<any>(
+          `https://graph.microsoft.com/v1.0/users/${identityId}/authentication/phoneMethods`,
+          { phoneNumber, phoneType: 'mobile' },
+          { headers: { Authorization: `Bearer ${this.sessionData.token}` } }
+        );
+      }
+    } catch (error: any) {
+      throw this.getError(error.response.status, error.response.data.message);
+    }
   }
 }


### PR DESCRIPTION
**Description:**
This pull request introduces a new endpoint, allowing users to manage their Multi-Factor Authentication (MFA) settings within their account preferences. With this, users gain the ability to:
- Enable MFA
- Disable MFA
- Modify existing MFA settings

Users are presented with three MFA options:
- `none`: Deactivates MFA entirely
- `email`: Activates MFA using the email registered in the B2C system
- `phone`: Requires users to supply a mobile phone number for MFA authentication.

**Diagram:**
![image](https://github.com/nhsengland/innovation-service-backend-api/assets/115171210/0675fd4a-ed9d-45a0-937f-7cf4901d856f)

**Related tickets:**
- Closes [AB#162893](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/162893).