### PR TITLE
fix archived innovations support can be updated

### DIFF
--- a/apps/innovations/v1-innovation-support-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-create/index.spec.ts
@@ -77,5 +77,23 @@ describe('v1-innovation-support-change-request Suite', () => {
 
       expect(result.status).toBe(status);
     });
+
+    it.each([['QA', 409, scenario.users.aliceQualifyingAccessor]])(
+      'access with user %s should give conflict if innovation is archived',
+      async (_role: string, status: number, user: TestUserType) => {
+        const result = await new AzureHttpTriggerBuilder()
+          .setAuth(user)
+          .setParams<ParamsType>({
+            innovationId: scenario.users.johnInnovator.innovations.johnInnovationArchived.id
+          })
+          .setBody<BodyType>({
+            message: randText(),
+            status: InnovationSupportStatusEnum.WAITING
+          })
+          .call<ErrorResponseType>(azureFunction);
+
+        expect(result.status).toBe(status);
+      }
+    );
   });
 });

--- a/apps/innovations/v1-innovation-support-create/index.ts
+++ b/apps/innovations/v1-innovation-support-create/index.ts
@@ -30,6 +30,7 @@ class V1InnovationSupportCreate {
         .setInnovation(params.innovationId)
         .checkAccessorType({ organisationRole: [ServiceRoleEnum.QUALIFYING_ACCESSOR] })
         .checkInnovation()
+        .checkNotArchived()
         .verify();
       const domainContext = auth.getContext();
 

--- a/apps/innovations/v1-innovation-support-update/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-update/index.spec.ts
@@ -77,4 +77,23 @@ describe('v1-innovation-support-update', () => {
       expect(result.status).toBe(status);
     });
   });
+
+  it.each([['QA', 409, scenario.users.aliceQualifyingAccessor]])(
+    'access with user %s should give conflict if innovation is archived',
+    async (_role: string, status: number, user: TestUserType) => {
+      const result = await new AzureHttpTriggerBuilder()
+        .setAuth(user)
+        .setParams<ParamsType>({
+          innovationId: scenario.users.johnInnovator.innovations.johnInnovationArchived.id,
+          supportId: randUuid()
+        })
+        .setBody<BodyType>({
+          message: randText(),
+          status: InnovationSupportStatusEnum.WAITING
+        })
+        .call<ErrorResponseType>(azureFunction);
+
+      expect(result.status).toBe(status);
+    }
+  );
 });

--- a/apps/innovations/v1-innovation-support-update/index.ts
+++ b/apps/innovations/v1-innovation-support-update/index.ts
@@ -30,6 +30,7 @@ class V1InnovationSupportUpdate {
         .setInnovation(params.innovationId)
         .checkAccessorType({ organisationRole: [ServiceRoleEnum.QUALIFYING_ACCESSOR] })
         .checkInnovation()
+        .checkNotArchived()
         .verify();
       const domainContext = auth.getContext();
 


### PR DESCRIPTION
Updated access control to disallow supports to be created/updated if innovation is archived.