### PR TITLE
Task/add archived status to get innovation info

### DIFF
--- a/apps/innovations/_services/innovations.service.ts
+++ b/apps/innovations/_services/innovations.service.ts
@@ -1691,6 +1691,7 @@ export class InnovationsService extends BaseService {
     description: null | string;
     version: string;
     status: InnovationStatusEnum;
+    archiveStatus?: InnovationStatusEnum;
     groupedStatus: InnovationGroupedStatusEnum;
     statusUpdatedAt: Date;
     submittedAt: null | Date;
@@ -1733,6 +1734,7 @@ export class InnovationsService extends BaseService {
         'innovation.description',
         'innovation.status',
         'innovation.statusUpdatedAt',
+        'innovation.archivedStatus',
         'innovation.lastAssessmentRequestAt',
         'innovation.countryName',
         'innovation.postcode',
@@ -1878,6 +1880,7 @@ export class InnovationsService extends BaseService {
       postCode: innovation.postcode,
       categories,
       otherCategoryDescription: documentData.otherCategoryDescription,
+      ...(innovation.archivedStatus ? { archiveStatus: innovation.archivedStatus } : {}),
       ...(innovation.owner && ownerPreferences
         ? {
             owner: {

--- a/apps/innovations/_services/innovations.service.ts
+++ b/apps/innovations/_services/innovations.service.ts
@@ -1691,7 +1691,7 @@ export class InnovationsService extends BaseService {
     description: null | string;
     version: string;
     status: InnovationStatusEnum;
-    archiveStatus?: InnovationStatusEnum;
+    archivedStatus?: InnovationStatusEnum;
     groupedStatus: InnovationGroupedStatusEnum;
     statusUpdatedAt: Date;
     submittedAt: null | Date;
@@ -1880,7 +1880,7 @@ export class InnovationsService extends BaseService {
       postCode: innovation.postcode,
       categories,
       otherCategoryDescription: documentData.otherCategoryDescription,
-      ...(innovation.archivedStatus ? { archiveStatus: innovation.archivedStatus } : {}),
+      ...(innovation.archivedStatus ? { archivedStatus: innovation.archivedStatus } : {}),
       ...(innovation.owner && ownerPreferences
         ? {
             owner: {

--- a/apps/innovations/v1-innovation-info/index.ts
+++ b/apps/innovations/v1-innovation-info/index.ts
@@ -52,7 +52,7 @@ class V1InnovationInfo {
         postCode: result.postCode,
         categories: result.categories,
         otherCategoryDescription: result.otherCategoryDescription,
-        archivedStatus: result.archiveStatus,
+        archivedStatus: result.archivedStatus,
         ...(result.owner === undefined
           ? {}
           : {

--- a/apps/innovations/v1-innovation-info/index.ts
+++ b/apps/innovations/v1-innovation-info/index.ts
@@ -52,7 +52,7 @@ class V1InnovationInfo {
         postCode: result.postCode,
         categories: result.categories,
         otherCategoryDescription: result.otherCategoryDescription,
-        archivedStatus: result.archivedStatus,
+        ...(result.archivedStatus ? { archivedStatus: result.archivedStatus } : {}),
         ...(result.owner === undefined
           ? {}
           : {

--- a/apps/innovations/v1-innovation-info/index.ts
+++ b/apps/innovations/v1-innovation-info/index.ts
@@ -36,7 +36,6 @@ class V1InnovationInfo {
         .setInnovation(params.innovationId)
         .checkInnovation()
         .verify();
-
       const domainContext = auth.getContext();
 
       const result = await innovationsService.getInnovationInfo(domainContext, params.innovationId, queryParams);
@@ -53,6 +52,7 @@ class V1InnovationInfo {
         postCode: result.postCode,
         categories: result.categories,
         otherCategoryDescription: result.otherCategoryDescription,
+        archivedStatus: result.archiveStatus,
         ...(result.owner === undefined
           ? {}
           : {

--- a/apps/innovations/v1-innovation-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-info/transformation.dtos.ts
@@ -12,6 +12,7 @@ export type ResponseDTO = {
   description: null | string;
   version: string;
   status: InnovationStatusEnum;
+  archivedStatus?: InnovationStatusEnum;
   groupedStatus: InnovationGroupedStatusEnum;
   statusUpdatedAt: Date;
   submittedAt: null | Date;

--- a/libs/shared/entities/innovation/innovation.entity.ts
+++ b/libs/shared/entities/innovation/innovation.entity.ts
@@ -39,8 +39,8 @@ export class InnovationEntity extends BaseEntity {
   @Column({ type: 'simple-enum', enum: InnovationStatusEnum, nullable: false })
   status: InnovationStatusEnum;
 
-  @Column({ name: 'archived_status', type: 'simple-enum', enum: InnovationStatusEnum, nullable: false })
-  archivedStatus: InnovationStatusEnum;
+  @Column({ name: 'archived_status', type: 'simple-enum', enum: InnovationStatusEnum, nullable: true })
+  archivedStatus: null | InnovationStatusEnum;
 
   @Column({ name: 'status_updated_at', type: 'datetime2' })
   statusUpdatedAt: Date;


### PR DESCRIPTION
**Description:**
By adding the new archive flow, some of the FE rules need access to the status that the innovation was before the archival process. To full-fill this requirement we send the archivedStatus in the innovation info payload when it exists.