### PR TITLE
feat: create progress update accept more levels

### DIFF
--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -3688,9 +3688,6 @@ paths:
             schema:
               type: object
               properties:
-                title:
-                  type: string
-                  maxLength: 100
                 description:
                   type: string
                   maxLength: 2000
@@ -3728,8 +3725,41 @@ paths:
                     - name
                     - file
                   additionalProperties: false
+                params:
+                  anyOf:
+                    - type: object
+                      properties:
+                        title:
+                          type: string
+                          maxLength: 100
+                      required:
+                        - title
+                      additionalProperties: false
+                    - type: object
+                      properties:
+                        categories:
+                          type: array
+                          items:
+                            type: string
+                            maxLength: 100
+                      required:
+                        - categories
+                      additionalProperties: false
+                    - type: object
+                      properties:
+                        category:
+                          type: string
+                          maxLength: 100
+                        subCategories:
+                          type: array
+                          items:
+                            type: string
+                            maxLength: 100
+                      required:
+                        - category
+                        - subCategories
+                      additionalProperties: false
               required:
-                - title
                 - description
               additionalProperties: false
       responses:

--- a/apps/innovations/_services/innovation-supports.service.spec.ts
+++ b/apps/innovations/_services/innovation-supports.service.spec.ts
@@ -568,7 +568,10 @@ describe('Innovations / _services / innovation-supports suite', () => {
             displayRole: TranslationHelper.translate(`SERVICE_ROLES.${jamieMadrox.roles.aiRole.role}`)
           },
           type: 'PROGRESS_UPDATE',
-          params: { title: progressUpdate.params?.title, message: progressUpdate.description }
+          params: {
+            title: progressUpdate.params && 'title' in progressUpdate.params ? progressUpdate.params.title : '',
+            message: progressUpdate.description
+          }
         },
         {
           id: statusUpdate.id,
@@ -981,7 +984,10 @@ describe('Innovations / _services / innovation-supports suite', () => {
 
     it('should create a support summary when a unit is engaging without a file', async () => {
       const domainContext = DTOsHelper.getUserRequestContext(scenario.users.aliceQualifyingAccessor, 'qaRole');
-      const data = { title: randText(), description: randText() };
+      const data: Parameters<InnovationSupportsService['createProgressUpdate']>[2] = {
+        description: randText(),
+        params: { title: randText() }
+      };
       const dbProgressId = randUuid();
 
       supportLogSpy.mockResolvedValue({ id: dbProgressId });
@@ -1006,7 +1012,7 @@ describe('Innovations / _services / innovation-supports suite', () => {
           description: data.description,
           supportStatus: scenario.users.johnInnovator.innovations.johnInnovation.supports.supportByHealthOrgUnit.status,
           unitId: domainContext.organisation?.organisationUnit?.id,
-          params: { title: data.title }
+          params: data.params
         }
       );
       expect(fileExists).toBe(0);
@@ -1015,8 +1021,7 @@ describe('Innovations / _services / innovation-supports suite', () => {
     it('should create a support summary when a unit is engaging with a file', async () => {
       const domainContext = DTOsHelper.getUserRequestContext(scenario.users.aliceQualifyingAccessor, 'qaRole');
       const dbProgressId = randUuid();
-      const data = {
-        title: randText(),
+      const data: Parameters<InnovationSupportsService['createProgressUpdate']>[2] = {
         description: randText(),
         document: {
           name: randFileName(),
@@ -1026,7 +1031,8 @@ describe('Innovations / _services / innovation-supports suite', () => {
             size: randNumber(),
             extension: randFileExt()
           }
-        }
+        },
+        params: { title: randText() }
       };
 
       supportLogSpy.mockResolvedValue({ id: dbProgressId });
@@ -1051,7 +1057,7 @@ describe('Innovations / _services / innovation-supports suite', () => {
           description: data.description,
           supportStatus: scenario.users.johnInnovator.innovations.johnInnovation.supports.supportByHealthOrgUnit.status,
           unitId: domainContext.organisation?.organisationUnit?.id,
-          params: { title: data.title }
+          params: data.params
         }
       );
       expect(fileExists).toBe(1);
@@ -1062,7 +1068,7 @@ describe('Innovations / _services / innovation-supports suite', () => {
         sut.createProgressUpdate(
           DTOsHelper.getUserRequestContext(scenario.users.allMighty),
           innovationId,
-          { title: randText(), description: randText() },
+          { description: randText(), params: { title: randText() } },
           em
         )
       ).rejects.toThrowError(new NotFoundError(OrganisationErrorsEnum.ORGANISATION_UNIT_NOT_FOUND));
@@ -1073,7 +1079,7 @@ describe('Innovations / _services / innovation-supports suite', () => {
         sut.createProgressUpdate(
           DTOsHelper.getUserRequestContext(scenario.users.samAccessor, 'accessorRole'),
           scenario.users.adamInnovator.innovations.adamInnovation.id,
-          { title: randText(), description: randText() },
+          { description: randText(), params: { title: randText() } },
           em
         )
       ).rejects.toThrowError(new NotFoundError(InnovationErrorsEnum.INNOVATION_SUPPORT_NOT_FOUND));
@@ -1090,7 +1096,7 @@ describe('Innovations / _services / innovation-supports suite', () => {
         sut.createProgressUpdate(
           DTOsHelper.getUserRequestContext(scenario.users.aliceQualifyingAccessor, 'qaRole'),
           innovationId,
-          { title: randText(), description: randText() },
+          { description: randText(), params: { title: randText() } },
           em
         )
       ).rejects.toThrowError(new UnprocessableEntityError(InnovationErrorsEnum.INNOVATION_SUPPORT_UNIT_NOT_ENGAGING));

--- a/apps/innovations/v1-innovation-support-summary-progress-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-summary-progress-create/index.spec.ts
@@ -6,6 +6,7 @@ import type { ErrorResponseType } from '@innovations/shared/types';
 import { randText } from '@ngneat/falso';
 import { InnovationSupportsService } from '../_services/innovation-supports.service';
 import type { BodyType, ParamsType } from './validation.schemas';
+import { GenericErrorsEnum } from '@innovations/shared/errors';
 
 jest.mock('@innovations/shared/decorators', () => ({
   JwtDecoder: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
@@ -30,22 +31,35 @@ afterEach(() => {
 });
 
 describe('v1-innovation-support-summary-progress-create', () => {
+  const innovationId = scenario.users.johnInnovator.innovations.johnInnovation.id;
   describe('201', () => {
-    it('should create an innovation support summary progress', async () => {
+    it.each([
+      ['simple', { title: randText() }],
+      ['one level', { categories: [randText()] }],
+      ['two level', { category: randText(), subCategories: [randText()] }]
+    ])('should create an innovation %s support summary progress', async (_type, params) => {
       const result = await new AzureHttpTriggerBuilder()
         .setAuth(scenario.users.aliceQualifyingAccessor)
-        .setParams<ParamsType>({
-          innovationId: scenario.users.johnInnovator.innovations.johnInnovation.id
-        })
-        .setBody<BodyType>({
-          description: randText(),
-          title: randText()
-        })
+        .setParams<ParamsType>({ innovationId })
+        .setBody<BodyType>({ description: randText(), params })
         .call<never>(azureFunction);
 
-      expect(result.body).toBeUndefined();
       expect(result.status).toBe(201);
+      expect(result.body).toBeUndefined();
       expect(mock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('400', () => {
+    it('should return a error when the params are invalid', async () => {
+      const result = await new AzureHttpTriggerBuilder()
+        .setAuth(scenario.users.aliceQualifyingAccessor)
+        .setParams<ParamsType>({ innovationId })
+        .setBody<BodyType>({ description: randText(), params: {} as any })
+        .call<ErrorResponseType>(azureFunction);
+
+      expect(result.body).toMatchObject({ error: GenericErrorsEnum.INVALID_PAYLOAD, message: 'Invalid request' });
+      expect(result.status).toBe(400);
     });
   });
 
@@ -60,12 +74,10 @@ describe('v1-innovation-support-summary-progress-create', () => {
     ])('access with user %s should give %i', async (_role: string, status: number, user: TestUserType) => {
       const result = await new AzureHttpTriggerBuilder()
         .setAuth(user)
-        .setParams<ParamsType>({
-          innovationId: scenario.users.johnInnovator.innovations.johnInnovation.id
-        })
+        .setParams<ParamsType>({ innovationId })
         .setBody<BodyType>({
           description: randText(),
-          title: randText()
+          params: { title: randText() }
         })
         .call<ErrorResponseType>(azureFunction);
 
@@ -74,17 +86,20 @@ describe('v1-innovation-support-summary-progress-create', () => {
 
     it.each([
       ['QA', scenario.users.aliceQualifyingAccessor, undefined],
-      ['A', scenario.users.jamieMadroxAccessor, 'healthAccessorRole'],
-    ])('access with user %s should give conflict in the archive', async (_role: string, user: TestUserType, roleKey?: string) => {
-      const result = await new AzureHttpTriggerBuilder()
-        .setAuth(user, roleKey)
-        .setParams<ParamsType>({
-          innovationId: scenario.users.johnInnovator.innovations.johnInnovationArchived.id
-        })
-        .setBody<BodyType>({ description: randText(), title: randText() })
-        .call<ErrorResponseType>(azureFunction);
+      ['A', scenario.users.jamieMadroxAccessor, 'healthAccessorRole']
+    ])(
+      'access with user %s should give conflict in the archive',
+      async (_role: string, user: TestUserType, roleKey?: string) => {
+        const result = await new AzureHttpTriggerBuilder()
+          .setAuth(user, roleKey)
+          .setParams<ParamsType>({
+            innovationId: scenario.users.johnInnovator.innovations.johnInnovationArchived.id
+          })
+          .setBody<BodyType>({ description: randText(), params: { title: randText() } })
+          .call<ErrorResponseType>(azureFunction);
 
-      expect(result.status).toBe(409);
-    });
+        expect(result.status).toBe(409);
+      }
+    );
   });
 });

--- a/apps/innovations/v1-innovation-support-summary-progress-create/validation.schemas.ts
+++ b/apps/innovations/v1-innovation-support-summary-progress-create/validation.schemas.ts
@@ -1,4 +1,6 @@
 import { TEXTAREA_LENGTH_LIMIT } from '@innovations/shared/constants';
+import { JoiHelper } from '@innovations/shared/helpers';
+import type { SupportLogProgressUpdate } from '@innovations/shared/types';
 import Joi from 'joi';
 import { InnovationFileSchema, InnovationFileType } from '../_types/innovation.types';
 
@@ -10,12 +12,19 @@ export const ParamsSchema = Joi.object<ParamsType>({
 });
 
 export type BodyType = {
-  title: string;
   description: string;
   document?: InnovationFileType;
+  params: SupportLogProgressUpdate['params'];
 };
 export const BodySchema = Joi.object<BodyType>({
-  title: Joi.string().max(100).required(),
   description: Joi.string().max(TEXTAREA_LENGTH_LIMIT.xl).required(),
-  document: InnovationFileSchema.optional()
+  document: InnovationFileSchema.optional(),
+  params: Joi.alternatives([
+    Joi.object({ title: Joi.string().max(100).required() }),
+    Joi.object({ categories: JoiHelper.AppCustomJoi().stringArray().items(Joi.string().max(100)).required() }),
+    Joi.object({
+      category: Joi.string().max(100).required(),
+      subCategories: JoiHelper.AppCustomJoi().stringArray().items(Joi.string().max(100)).required()
+    })
+  ])
 }).required();

--- a/libs/shared/entities/innovation/innovation-support-log.entity.ts
+++ b/libs/shared/entities/innovation/innovation-support-log.entity.ts
@@ -7,6 +7,7 @@ import { UserRoleEntity } from '../user/user-role.entity';
 import { InnovationEntity } from './innovation.entity';
 
 import { InnovationSupportLogTypeEnum, InnovationSupportStatusEnum } from '../../enums/innovation.enums';
+import type { SupportLogProgressUpdate } from 'libs/shared/types';
 
 @Entity('innovation_support_log')
 export class InnovationSupportLogEntity extends BaseEntity {
@@ -23,7 +24,7 @@ export class InnovationSupportLogEntity extends BaseEntity {
   description: string;
 
   @Column({ name: 'params', type: 'simple-json', nullable: true })
-  params: null | { title: string };
+  params: null | SupportLogProgressUpdate['params'];
 
   @ManyToOne(() => InnovationEntity, { nullable: false })
   @JoinColumn({ name: 'innovation_id' })

--- a/libs/shared/tests/builders/innovation-support-log.builder.ts
+++ b/libs/shared/tests/builders/innovation-support-log.builder.ts
@@ -4,7 +4,7 @@ import { InnovationSupportLogEntity } from '../../entities/innovation/innovation
 import { OrganisationUnitEntity } from '../../entities/organisation/organisation-unit.entity';
 import { UserRoleEntity } from '../../entities/user/user-role.entity';
 import { InnovationSupportLogTypeEnum, InnovationSupportStatusEnum } from '../../enums/innovation.enums';
-import type { RoleType } from '../../types';
+import type { RoleType, SupportLogProgressUpdate } from '../../types';
 import { BaseBuilder } from './base.builder';
 import type { TestUserType } from './user.builder';
 
@@ -15,7 +15,7 @@ export type TestInnovationSupportLogType = {
   innovationSupportStatus?: string;
   createdBy: string;
   createdAt: Date;
-  params?: { title?: string };
+  params?: SupportLogProgressUpdate['params'];
 };
 
 export class InnovationSupportLogBuilder extends BaseBuilder {

--- a/libs/shared/types/domain.types.ts
+++ b/libs/shared/types/domain.types.ts
@@ -370,8 +370,11 @@ export type SupportLogProgressUpdate = {
   type: InnovationSupportLogTypeEnum.PROGRESS_UPDATE;
   supportStatus: InnovationSupportStatusEnum;
   unitId: string;
-  params: { title: string };
+  params: SimpleProgressUpdateParams | OneLevelProgressUpdateParams | TwoLevelProgressUpdateParams;
 };
+type SimpleProgressUpdateParams = { title: string };
+type OneLevelProgressUpdateParams = { categories: string[] };
+type TwoLevelProgressUpdateParams = { category: string; subCategories: string[] };
 
 export type SupportLogAssessmentSuggestion = {
   type: InnovationSupportLogTypeEnum.ASSESSMENT_SUGGESTION;


### PR DESCRIPTION
**Description:**
By adding milestones to the progress updates there was a need to have different progress updates apart from the simple one. This are the one level and two levels that enables orgs to have a more personalised progress update creation.

This PR adds the functionality to have three different types of progress updates: _simple_, _one level_, and _two level_.

**Related tickets:**
- Closes: [AB#163597](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/163597).
- US: [AB#162909](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/162909).