### PR TITLE
task(AB#163598): get support summary info returns new levels

### DIFF
--- a/apps/innovations/_services/innovation-supports.service.ts
+++ b/apps/innovations/_services/innovation-supports.service.ts
@@ -962,16 +962,17 @@ export class InnovationSupportsService extends BaseService {
           {
             const file = await this.getProgressUpdateFile(domainContext, innovationId, supportLog.id);
 
-            summary.push({
-              ...defaultSummary,
-              type: 'PROGRESS_UPDATE',
-              params: {
-                // TODO: Handle this differently
-                title: supportLog.params && 'title' in supportLog.params ? supportLog.params.title : '', // will always exists in type PROGRESS_UPDATE
-                message: supportLog.description,
-                ...(file ? { file: { id: file.id, name: file.name, url: file.file.url } } : {})
-              }
-            });
+            if(supportLog.params) {
+              summary.push({
+                ...defaultSummary,
+                type: 'PROGRESS_UPDATE',
+                params: {
+                  message: supportLog.description,
+                  ...(supportLog.params),
+                  ...(file ? { file: { id: file.id, name: file.name, url: file.file.url } } : {})
+                }
+              });
+            }
           }
           break;
         case InnovationSupportLogTypeEnum.ASSESSMENT_SUGGESTION:

--- a/apps/innovations/_types/support.types.ts
+++ b/apps/innovations/_types/support.types.ts
@@ -1,4 +1,5 @@
 import type { InnovationSupportStatusEnum } from '@innovations/shared/enums';
+import type { SupportLogProgressUpdate } from '@innovations/shared/types';
 
 export type SupportSummaryUnitInfo = {
   id: string;
@@ -25,10 +26,9 @@ type SuggestedOrganisationData = {
 type ProgressUpdateData = {
   type: 'PROGRESS_UPDATE';
   params: {
-    title: string;
     message: string;
     file?: { id: string; name: string; url: string };
-  };
+  } & SupportLogProgressUpdate['params'];
 };
 
 type InnovationArchivedData = {

--- a/libs/shared/tests/builders/innovation-support-log.builder.ts
+++ b/libs/shared/tests/builders/innovation-support-log.builder.ts
@@ -52,7 +52,7 @@ export class InnovationSupportLogBuilder extends BaseBuilder {
     return this;
   }
 
-  setParams(params: { title?: string }): this {
+  setParams(params: SupportLogProgressUpdate['params']): this {
     this.supportLog.params = params;
     return this;
   }


### PR DESCRIPTION
**Description:**
Since we added two new types of progress updates on #238, the support summary unit info needs to return the information about it. This PR introduces that change.

**Related tickets:**
- Closes: [AB#163598](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/163598).
- US: [AB#162909](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/162909).