### PR TITLE
Task(AB#163601): allow create past progress update

### DIFF
--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -3759,6 +3759,9 @@ paths:
                         - category
                         - subCategories
                       additionalProperties: false
+                createdAt:
+                  type: string
+                  format: date-time
               required:
                 - description
               additionalProperties: false

--- a/apps/innovations/_services/innovation-supports.service.spec.ts
+++ b/apps/innovations/_services/innovation-supports.service.spec.ts
@@ -1121,7 +1121,7 @@ describe('Innovations / _services / innovation-supports suite', () => {
 
         await em
           .createQueryBuilder(InnovationSupportLogEntity, 'log')
-          .where('log.createdAt = :createdAt', { createdAt })
+          .where('log.createdAt <= :createdAt', { createdAt })
           .getOneOrFail();
       });
 

--- a/apps/innovations/_services/innovation-supports.service.spec.ts
+++ b/apps/innovations/_services/innovation-supports.service.spec.ts
@@ -1110,13 +1110,12 @@ describe('Innovations / _services / innovation-supports suite', () => {
 
       it('should create a progress update in the past', async () => {
         mock.mockResolvedValueOnce({ rule: 'checkIfSupportStatusAtDate', valid: true });
-        const createdAt = randPastDate();
-        createdAt.setHours(0, 0, 0, 0);
+        const createdAt = randPastDate().toISOString().split('T')[0]!;
 
         await sut.createProgressUpdate(
           DTOsHelper.getUserRequestContext(scenario.users.aliceQualifyingAccessor, 'qaRole'),
           innovationId,
-          { description: randText(), params: { title: randText() }, createdAt },
+          { description: randText(), params: { title: randText() }, createdAt: new Date(createdAt) },
           em
         );
 

--- a/apps/innovations/_services/innovation-supports.service.spec.ts
+++ b/apps/innovations/_services/innovation-supports.service.spec.ts
@@ -991,7 +991,7 @@ describe('Innovations / _services / innovation-supports suite', () => {
       };
       const dbProgressId = randUuid();
 
-      supportLogSpy.mockResolvedValue({ id: dbProgressId });
+      supportLogSpy.mockResolvedValueOnce({ id: dbProgressId });
 
       await sut.createProgressUpdate(domainContext, innovationId, data, em);
 
@@ -1036,7 +1036,7 @@ describe('Innovations / _services / innovation-supports suite', () => {
         params: { title: randText() }
       };
 
-      supportLogSpy.mockResolvedValue({ id: dbProgressId });
+      supportLogSpy.mockResolvedValueOnce({ id: dbProgressId });
 
       await sut.createProgressUpdate(domainContext, innovationId, data, em);
 
@@ -1110,12 +1110,12 @@ describe('Innovations / _services / innovation-supports suite', () => {
 
       it('should create a progress update in the past', async () => {
         mock.mockResolvedValueOnce({ rule: 'checkIfSupportStatusAtDate', valid: true });
-        const createdAt = randPastDate().toISOString().split('T')[0]!;
+        const createdAt = randPastDate();
 
         await sut.createProgressUpdate(
           DTOsHelper.getUserRequestContext(scenario.users.aliceQualifyingAccessor, 'qaRole'),
           innovationId,
-          { description: randText(), params: { title: randText() }, createdAt: new Date(createdAt) },
+          { description: randText(), params: { title: randText() }, createdAt },
           em
         );
 

--- a/apps/innovations/_services/validation.service.ts
+++ b/apps/innovations/_services/validation.service.ts
@@ -25,9 +25,7 @@ export class ValidationService extends BaseService {
       handler: this.checkIfSupportStatusAtDate.bind(this),
       joiDefinition: Joi.object({
         supportId: Joi.string().guid().required(),
-        year: Joi.number().integer().min(1900).max(2100).required(),
-        month: Joi.number().integer().min(1).max(12).required(),
-        day: Joi.number().integer().min(1).max(31).required(),
+        date: Joi.date().required(),
         status: Joi.string()
           .valid(...Object.values(InnovationSupportStatusEnum))
           .required()
@@ -52,23 +50,17 @@ export class ValidationService extends BaseService {
     _innovationId: string,
     data: {
       supportId: string;
-      year: number;
-      month: number;
-      day: number;
+      date: Date;
       status: InnovationSupportStatusEnum;
     },
     entityManager?: EntityManager
   ): Promise<ValidationResult> {
     const em = entityManager ?? this.sqlConnection.manager;
-    const dateString = `${data.year}-${data.month}-${data.day}`;
-    const date = new Date(data.year, data.month - 1, data.day);
+    const date = data.date;
+    const dateString = date.toISOString().split('T')[0];
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    date?.setHours(0, 0, 0, 0);
-    // Ensuring that the date is the same, invalid date will return NaN and semi valid date (ie: 2023-11-31) will return a different date (ie: 2023-12-01)
-    if (date?.getDate() !== data.day) {
-      throw new BadRequestError(GenericErrorsEnum.INVALID_PAYLOAD, { message: 'Invalid date' });
-    }
+    date.setHours(0, 0, 0, 0);
 
     if (date > today) {
       throw new BadRequestError(GenericErrorsEnum.INVALID_PAYLOAD, { message: 'Date cannot be in the future' });

--- a/apps/innovations/v1-innovation-support-summary-progress-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-summary-progress-create/index.spec.ts
@@ -1,12 +1,12 @@
 import azureFunction from '.';
 
+import { GenericErrorsEnum } from '@innovations/shared/errors';
 import { AzureHttpTriggerBuilder, TestsHelper } from '@innovations/shared/tests';
 import type { TestUserType } from '@innovations/shared/tests/builders/user.builder';
 import type { ErrorResponseType } from '@innovations/shared/types';
 import { randText } from '@ngneat/falso';
 import { InnovationSupportsService } from '../_services/innovation-supports.service';
 import type { BodyType, ParamsType } from './validation.schemas';
-import { GenericErrorsEnum } from '@innovations/shared/errors';
 
 jest.mock('@innovations/shared/decorators', () => ({
   JwtDecoder: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {

--- a/apps/innovations/v1-innovation-support-summary-progress-create/validation.schemas.ts
+++ b/apps/innovations/v1-innovation-support-summary-progress-create/validation.schemas.ts
@@ -15,6 +15,7 @@ export type BodyType = {
   description: string;
   document?: InnovationFileType;
   params: SupportLogProgressUpdate['params'];
+  createdAt?: Date;
 };
 export const BodySchema = Joi.object<BodyType>({
   description: Joi.string().max(TEXTAREA_LENGTH_LIMIT.xl).required(),
@@ -26,5 +27,6 @@ export const BodySchema = Joi.object<BodyType>({
       category: Joi.string().max(100).required(),
       subCategories: JoiHelper.AppCustomJoi().stringArray().items(Joi.string().max(100)).required()
     })
-  ])
+  ]),
+  createdAt: Joi.date()
 }).required();

--- a/apps/innovations/v1-innovation-support-summary-progress-create/validation.schemas.ts
+++ b/apps/innovations/v1-innovation-support-summary-progress-create/validation.schemas.ts
@@ -28,5 +28,5 @@ export const BodySchema = Joi.object<BodyType>({
       subCategories: JoiHelper.AppCustomJoi().stringArray().items(Joi.string().max(100)).required()
     })
   ]),
-  createdAt: Joi.date()
+  createdAt: Joi.date().max('now')
 }).required();


### PR DESCRIPTION
Allows creation of past progress updates by support orgs as long as they were engaging at the time

Closes: [AB#163601](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/163601)
Related: [AB#162991](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/162991)