### PR TITLE
feat: change the save and submit of section

### DIFF
--- a/apps/innovations/_services/innovations.service.ts
+++ b/apps/innovations/_services/innovations.service.ts
@@ -17,7 +17,8 @@ import {
   NotificationUserEntity,
   OrganisationEntity,
   UserEntity,
-  UserRoleEntity
+  UserRoleEntity,
+  InnovationDocumentDraftEntity
 } from '@innovations/shared/entities';
 import {
   ActivityEnum,
@@ -61,7 +62,7 @@ import { createDocumentFromInnovation } from '@innovations/shared/entities/innov
 import { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
 import { ActionEnum } from '@innovations/shared/services/integrations/audit.service';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
-import { groupBy, isString, mapValues, pick, snakeCase } from 'lodash';
+import { groupBy, isString, mapValues, omit, pick, snakeCase } from 'lodash';
 import { BaseService } from './base.service';
 
 // TODO move types
@@ -1794,6 +1795,7 @@ export class InnovationsService extends BaseService {
 
     // Only fetch the document version and category data (maybe create a helper for this in the future)
     const documentData = await connection
+      // TODO: DRAFT Change this
       .createQueryBuilder(InnovationDocumentEntity, 'innovationDocument')
       .select("JSON_QUERY(document, '$.INNOVATION_DESCRIPTION.categories')", 'categories')
       .addSelect(
@@ -1994,10 +1996,9 @@ export class InnovationsService extends BaseService {
         })
       );
 
-      await transaction.save(
-        InnovationDocumentEntity,
-        createDocumentFromInnovation(savedInnovation, { website: data.website })
-      );
+      const document = createDocumentFromInnovation(savedInnovation, { website: data.website });
+      await transaction.save(InnovationDocumentEntity, document);
+      await transaction.save(InnovationDocumentDraftEntity, omit(document, ['isSnapshot', 'description']));
 
       // Mark some section to status DRAFT.
       const sectionsToBeInDraft: CurrentCatalogTypes.InnovationSections[] = ['INNOVATION_DESCRIPTION'];

--- a/libs/data-access/migrations/1709822169049-create-innovation-document-draft.ts
+++ b/libs/data-access/migrations/1709822169049-create-innovation-document-draft.ts
@@ -1,0 +1,26 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class createInnovationDocumentDraftTable1709822169049 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE innovation_document_draft (
+        id uniqueidentifier NOT NULL,
+        version AS JSON_VALUE(document,'$.version'),
+        document nvarchar(max) NOT NULL CONSTRAINT "df_innovation_document_draft_document" DEFAULT '{}',
+        "created_at" datetime2 NOT NULL CONSTRAINT "df_innovation_document_draft_created_at" DEFAULT getdate(),
+        "created_by" uniqueidentifier,
+        "updated_at" datetime2 NOT NULL CONSTRAINT "df_innovation_document_draft_updated_at" DEFAULT getdate(),
+        "updated_by" uniqueidentifier,
+        "deleted_at" datetime2,
+        CONSTRAINT "pk_innovation_document_draft_id" PRIMARY KEY ("id"),
+        CONSTRAINT "CK_innovation_document_draft_document_is_json" CHECK (ISJSON(document)=1)
+      );
+    `);
+
+    // TODO: still needs to add the migration
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "innovation_document_draft";`);
+  }
+}

--- a/libs/shared/entities/index.ts
+++ b/libs/shared/entities/index.ts
@@ -12,6 +12,7 @@ import { InnovationTaskEntity } from './innovation/innovation-task.entity';
 import { InnovationAssessmentEntity } from './innovation/innovation-assessment.entity';
 import { InnovationCollaboratorEntity } from './innovation/innovation-collaborator.entity';
 import { InnovationDocumentEntity } from './innovation/innovation-document.entity';
+import { InnovationDocumentDraftEntity } from './innovation/innovation-document-draft.entity';
 import { InnovationEvidenceEntity } from './innovation/innovation-evidence.entity';
 import { InnovationExportRequestEntity } from './innovation/innovation-export-request.entity';
 import { InnovationFileLegacyEntity } from './innovation/innovation-file-legacy.entity';
@@ -30,6 +31,7 @@ export { InnovationTaskEntity } from './innovation/innovation-task.entity';
 export { InnovationAssessmentEntity } from './innovation/innovation-assessment.entity';
 export { InnovationCollaboratorEntity } from './innovation/innovation-collaborator.entity';
 export { InnovationDocumentEntity } from './innovation/innovation-document.entity';
+export { InnovationDocumentDraftEntity } from './innovation/innovation-document-draft.entity';
 export { InnovationEvidenceEntity } from './innovation/innovation-evidence.entity';
 export { InnovationExportRequestEntity } from './innovation/innovation-export-request.entity';
 export { InnovationFileLegacyEntity } from './innovation/innovation-file-legacy.entity';
@@ -93,6 +95,7 @@ export const INNOVATION_ENTITIES = [
   InnovationAssessmentEntity,
   InnovationCollaboratorEntity,
   InnovationDocumentEntity,
+  InnovationDocumentDraftEntity,
   InnovationEvidenceEntity,
   InnovationExportRequestEntity,
   InnovationFileLegacyEntity,

--- a/libs/shared/entities/innovation/innovation-document-draft.entity.ts
+++ b/libs/shared/entities/innovation/innovation-document-draft.entity.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm';
+
+import { BaseEntity } from '../base.entity';
+
+import type { DocumentType } from '../../schemas/innovation-record/index';
+import { InnovationEntity } from './innovation.entity';
+
+@Entity('innovation_document_draft')
+export class InnovationDocumentDraftEntity extends BaseEntity {
+  @PrimaryColumn({ type: 'uniqueidentifier' })
+  id: string;
+
+  @Column({ type: 'simple-json' })
+  document: DocumentType;
+
+  @Column({ type: 'nvarchar', update: false, insert: false })
+  version: DocumentType['version'];
+
+  @OneToOne(() => InnovationEntity)
+  @JoinColumn({ name: 'id' })
+  innovation: InnovationEntity;
+}

--- a/libs/shared/entities/innovation/innovation-document.entity.ts
+++ b/libs/shared/entities/innovation/innovation-document.entity.ts
@@ -61,7 +61,7 @@ export const createDocumentFromInnovation = (
     id: innovation.id,
     version: CurrentDocumentConfig.version,
     document: document,
-    isSnapshot: false,
+    isSnapshot: true,
     description: 'Initial document',
     innovation: innovation,
     createdAt: innovation.createdAt,

--- a/libs/shared/entities/innovation/innovation-support-log.entity.ts
+++ b/libs/shared/entities/innovation/innovation-support-log.entity.ts
@@ -7,7 +7,7 @@ import { UserRoleEntity } from '../user/user-role.entity';
 import { InnovationEntity } from './innovation.entity';
 
 import { InnovationSupportLogTypeEnum, InnovationSupportStatusEnum } from '../../enums/innovation.enums';
-import type { SupportLogProgressUpdate } from 'libs/shared/types';
+import type { SupportLogProgressUpdate } from '@innovations/shared/types';
 
 @Entity('innovation_support_log')
 export class InnovationSupportLogEntity extends BaseEntity {

--- a/libs/shared/entities/innovation/innovation-support-log.entity.ts
+++ b/libs/shared/entities/innovation/innovation-support-log.entity.ts
@@ -7,7 +7,7 @@ import { UserRoleEntity } from '../user/user-role.entity';
 import { InnovationEntity } from './innovation.entity';
 
 import { InnovationSupportLogTypeEnum, InnovationSupportStatusEnum } from '../../enums/innovation.enums';
-import type { SupportLogProgressUpdate } from '@innovations/shared/types';
+import type { SupportLogProgressUpdate } from '../../types/domain.types';
 
 @Entity('innovation_support_log')
 export class InnovationSupportLogEntity extends BaseEntity {

--- a/libs/shared/entities/views/innovation-list-view.entity.ts
+++ b/libs/shared/entities/views/innovation-list-view.entity.ts
@@ -10,6 +10,7 @@ import { InnovationAssessmentEntity } from '../innovation/innovation-assessment.
 import { InnovationSupportEntity } from '../innovation/innovation-support.entity';
 import { OrganisationEntity } from '../organisation/organisation.entity';
 
+// NOTE: The document information is from the submitted one
 @ViewEntity('innovation_list_view')
 export class InnovationListView {
   @PrimaryColumn() // Primary column is required for ViewEntity to work properly with pagination

--- a/libs/shared/tests/builders/innovation.builder.ts
+++ b/libs/shared/tests/builders/innovation.builder.ts
@@ -2,6 +2,7 @@ import { randBoolean, randCountry, randProduct, randText } from '@ngneat/falso';
 import type { DeepPartial, EntityManager } from 'typeorm';
 
 import { InnovationDocumentEntity } from '../../entities/innovation/innovation-document.entity';
+import { InnovationDocumentDraftEntity } from '../../entities/innovation/innovation-document-draft.entity';
 import { InnovationEntity } from '../../entities/innovation/innovation.entity';
 import { InnovationSectionStatusEnum, InnovationStatusEnum } from '../../enums/innovation.enums';
 import { NotFoundError } from '../../errors/errors.config';
@@ -172,6 +173,13 @@ export class InnovationBuilder extends BaseBuilder {
 
     await this.getEntityManager()
       .getRepository(InnovationDocumentEntity)
+      .save({
+        innovation: { id: savedInnovation.id },
+        version: this.document.version,
+        document: this.document
+      });
+    await this.getEntityManager()
+      .getRepository(InnovationDocumentDraftEntity)
       .save({
         innovation: { id: savedInnovation.id },
         version: this.document.version,


### PR DESCRIPTION
**Description:**
This PR introduces the first change for the feature to see the latest submitted IR version. This basically involves in adding a new structure to save the drafts called `InnovationDocumentDraft`. By adding this structure we are able to have two different tables:
 - `innovation_document`: that contains the latest version submitted by the innovators.
 - `innovation_document_draft`: that contains the version that contains the drafts made by the innovators.

The following diagram represents how the sync works between the different tables (think of the `cherry-pick` as syncing that current section). All the updates are saved to the `innovation_document_draft` table, and when the innovators submit the section the sync is made and the `innovation_document` gets updated with the submitted version.

```mermaid
%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'rotateCommitLabel': true, 'mainBranchName': 'document'}} }%%

gitGraph
commit id: "create"
branch document_draft
commit id: "section 1 #1"
commit id: "section 2 #2"
checkout document
cherry-pick id: "section 2 #2"
cherry-pick id: "section 1 #1"
checkout document_draft
commit id: "section 2 #3"
commit id: "section 2 #4"
checkout document
merge document_draft
```
**Related tickets:**
Closes: [AB#164783](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/164783).
Related US: [AB#159217](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/159217).