### PR TITLE
Task/change all get document info to helper

### DIFF
--- a/apps/innovations/_config/inversify.ts
+++ b/apps/innovations/_config/inversify.ts
@@ -3,6 +3,7 @@ import { container } from '@innovations/shared/config/inversify.config';
 import { ExportFileService } from '../_services/export-file-service';
 import { InnovationAssessmentsService } from '../_services/innovation-assessments.service';
 import { InnovationCollaboratorsService } from '../_services/innovation-collaborators.service';
+import { InnovationDocumentService } from '../_services/innovation-document.service';
 import { InnovationExportRequestService } from '../_services/innovation-export-request.service';
 import { InnovationFileService } from '../_services/innovation-file.service';
 import { InnovationSectionsService } from '../_services/innovation-sections.service';
@@ -45,6 +46,10 @@ container
 container
   .bind<InnovationExportRequestService>(SYMBOLS.InnovationExportRequestService)
   .to(InnovationExportRequestService)
+  .inSingletonScope();
+container
+  .bind<InnovationDocumentService>(SYMBOLS.InnovationDocumentService)
+  .to(InnovationDocumentService)
   .inSingletonScope();
 container.bind<InnovationsService>(SYMBOLS.InnovationsService).to(InnovationsService).inSingletonScope();
 container.bind<ExportFileService>(SYMBOLS.ExportFileService).to(ExportFileService).inSingletonScope();

--- a/apps/innovations/_services/innovation-document.service.spec.ts
+++ b/apps/innovations/_services/innovation-document.service.spec.ts
@@ -1,0 +1,75 @@
+import { container } from '../_config';
+
+import { CurrentDocumentConfig } from '@innovations/shared/schemas/innovation-record';
+import { TestsHelper } from '@innovations/shared/tests';
+import { randProductDescription } from '@ngneat/falso';
+import type { EntityManager } from 'typeorm';
+import SYMBOLS from './symbols';
+import type { InnovationDocumentService } from './innovation-document.service';
+import { ServiceRoleEnum } from '@innovations/shared/enums';
+
+describe('Innovation Document suite', () => {
+  let sut: InnovationDocumentService;
+
+  const testsHelper = new TestsHelper();
+  const scenario = testsHelper.getCompleteScenario();
+
+  let em: EntityManager;
+
+  beforeAll(async () => {
+    sut = container.get<InnovationDocumentService>(SYMBOLS.InnovationDocumentService);
+    await testsHelper.init();
+  });
+
+  beforeEach(async () => {
+    em = await testsHelper.getQueryRunnerEntityManager();
+  });
+
+  afterEach(async () => {
+    await testsHelper.releaseQueryRunnerEntityManager();
+  });
+
+  const johnInnovator = scenario.users.johnInnovator;
+  const innovation = johnInnovator.innovations.johnInnovation;
+
+  describe('getInnovationDocument', () => {
+    const draftDescription = randProductDescription();
+
+    beforeEach(async () => {
+      await em.query(
+        `UPDATE innovation_document_draft
+      SET document = JSON_MODIFY(document, @0, JSON_QUERY(@1)), updated_by=@2, updated_at=@3 WHERE id = @4`,
+        [
+          `$.INNOVATION_DESCRIPTION`,
+          JSON.stringify({ description: draftDescription }),
+          johnInnovator.id,
+          new Date(),
+          innovation.id
+        ]
+      );
+    });
+
+    it('should return the version in draft', async () => {
+      const document = await sut.getInnovationDocument(innovation.id, CurrentDocumentConfig.version, 'DRAFT', em);
+      expect(document.INNOVATION_DESCRIPTION.description).toBe(draftDescription);
+    });
+
+    it('should return the version that was latest submitted', async () => {
+      const document = await sut.getInnovationDocument(innovation.id, CurrentDocumentConfig.version, 'SUBMITTED', em);
+      expect(document.INNOVATION_DESCRIPTION.description).not.toBe(draftDescription);
+    });
+  });
+
+  describe('getDocumentTypeAccordingWithRole', () => {
+    it.each([
+      [ServiceRoleEnum.INNOVATOR, 'DRAFT'],
+      [ServiceRoleEnum.ADMIN, 'DRAFT'],
+      [ServiceRoleEnum.QUALIFYING_ACCESSOR, 'SUBMITTED'],
+      [ServiceRoleEnum.ACCESSOR, 'SUBMITTED'],
+      [ServiceRoleEnum.ASSESSMENT, 'SUBMITTED']
+    ])('document type for %s should be %s', (role: ServiceRoleEnum, type: string) => {
+      const outputType = sut.getDocumentTypeAccordingWithRole(role);
+      expect(type).toBe(outputType);
+    });
+  });
+});

--- a/apps/innovations/_services/innovation-document.service.ts
+++ b/apps/innovations/_services/innovation-document.service.ts
@@ -1,0 +1,87 @@
+import { injectable } from 'inversify';
+
+import type { EntityManager } from 'typeorm';
+
+import { ServiceRoleEnum } from '@innovations/shared/enums';
+import { ConflictError, InnovationErrorsEnum, NotFoundError } from '@innovations/shared/errors';
+import {
+  CurrentDocumentConfig,
+  DocumentType,
+  DocumentTypeFromVersion
+} from '@innovations/shared/schemas/innovation-record';
+
+import { BaseService } from './base.service';
+import { InnovationDocumentDraftEntity, InnovationDocumentEntity } from '@innovations/shared/entities';
+
+@injectable()
+export class InnovationDocumentService extends BaseService {
+  constructor() {
+    super();
+  }
+
+  /**
+   * retrieves the latest version of a document from the database and validates the version
+   * @param innovationId the innovation id
+   * @param version version of the document to retrieve
+   * @param type submitted or draft type
+   * @param entityManager optional entity manager for running inside transaction
+   * @returns the document
+   */
+  async getInnovationDocument<V extends DocumentType['version'], T extends DocumentTypeFromVersion<V>>(
+    innovationId: string,
+    version: V,
+    type: 'SUBMITTED' | 'DRAFT',
+    entityManager?: EntityManager
+  ): Promise<T> {
+    const connection = entityManager ?? this.sqlConnection.manager;
+    let document: DocumentType | undefined;
+
+    if (version === CurrentDocumentConfig.version) {
+      document = (
+        await connection
+          .createQueryBuilder(
+            type === 'SUBMITTED' ? InnovationDocumentEntity : InnovationDocumentDraftEntity,
+            'document'
+          )
+          .where('document.id = :innovationId', { innovationId })
+          .andWhere('document.version = :version', { version })
+          .getOne()
+      )?.document;
+    } else {
+      const raw = await connection.query(
+        `
+        SELECT TOP 1 document
+        FROM ${type === 'SUBMITTED' ? 'innovation_document' : 'innovation_document_draft'}
+        FOR SYSTEM_TIME ALL
+        WHERE id = @0
+        AND version = @1
+        ORDER BY valid_to DESC
+      `,
+        [innovationId, version]
+      );
+
+      document = raw.length ? JSON.parse(raw[0].document) : undefined;
+    }
+
+    if (!document) {
+      throw new NotFoundError(InnovationErrorsEnum.INNOVATION_NOT_FOUND);
+    }
+
+    if (document.version !== version) {
+      throw new ConflictError(InnovationErrorsEnum.INNOVATION_DOCUMENT_VERSION_MISMATCH);
+    }
+
+    return document as T;
+  }
+
+  /**
+   * This function returns the type of IR that the role can see.
+   * This is "the most consensual" but there are some exceptions, namely for the ADMIN which are not handled here.
+   * Admin: on lists see the SUBMITTED version but on the info he sees the DRAFT.
+   * QA/A/NA: always sees the SUBMITTED version.
+   * Innovators: always sees the DRAFT version.
+   */
+  getDocumentTypeAccordingWithRole(role: ServiceRoleEnum): 'SUBMITTED' | 'DRAFT' {
+    return [ServiceRoleEnum.INNOVATOR, ServiceRoleEnum.ADMIN].includes(role) ? 'DRAFT' : 'SUBMITTED';
+  }
+}

--- a/apps/innovations/_services/innovation-file.service.spec.ts
+++ b/apps/innovations/_services/innovation-file.service.spec.ts
@@ -1366,7 +1366,12 @@ describe('Services / Innovation File service suite', () => {
 
       const keys = sut['contextTypeId2Key'];
 
-      const res = await sut['files2ResolvedContexts'](filesParameter, innovation.id, em);
+      const res = await sut['files2ResolvedContexts'](
+        DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
+        filesParameter,
+        innovation.id,
+        em
+      );
       const expected = new Map();
       files.forEach(f => {
         const { type, id } = f.context;

--- a/apps/innovations/_services/innovation-sections.service.spec.ts
+++ b/apps/innovations/_services/innovation-sections.service.spec.ts
@@ -63,7 +63,7 @@ describe('Innovation Sections Suite', () => {
   });
 
   describe('getInnovationSectionInfo', () => {
-    it('should get submitted section info as assessment user', async () => {
+    it('should get submitted section info', async () => {
       const sectionsList = await sut.getInnovationSectionInfo(
         DTOsHelper.getUserRequestContext(scenario.users.paulNeedsAssessor),
         innovation.id,
@@ -73,42 +73,6 @@ describe('Innovation Sections Suite', () => {
       );
 
       expect(sectionsList.id).toBeDefined();
-    });
-
-    it('should not get draft section info as accessor', async () => {
-      await em.update(
-        InnovationSectionEntity,
-        { id: innovation.sections.INNOVATION_DESCRIPTION.id },
-        { status: InnovationSectionStatusEnum.DRAFT }
-      );
-
-      const section = await sut.getInnovationSectionInfo(
-        DTOsHelper.getUserRequestContext(scenario.users.aliceQualifyingAccessor),
-        innovation.id,
-        'INNOVATION_DESCRIPTION',
-        {},
-        em
-      );
-
-      expect(section.data).toStrictEqual({});
-    });
-
-    it('should not get draft section info as NA', async () => {
-      await em.update(
-        InnovationSectionEntity,
-        { id: innovation.sections.INNOVATION_DESCRIPTION.id },
-        { status: InnovationSectionStatusEnum.DRAFT }
-      );
-
-      const section = await sut.getInnovationSectionInfo(
-        DTOsHelper.getUserRequestContext(scenario.users.paulNeedsAssessor),
-        innovation.id,
-        'INNOVATION_DESCRIPTION',
-        {},
-        em
-      );
-
-      expect(section.data).toStrictEqual({});
     });
   });
 

--- a/apps/innovations/_services/innovation-sections.service.spec.ts
+++ b/apps/innovations/_services/innovation-sections.service.spec.ts
@@ -3,7 +3,7 @@ import { container } from '../_config';
 
 import { InnovationEntity, InnovationSectionEntity } from '@innovations/shared/entities';
 import { InnovationSectionStatusEnum } from '@innovations/shared/enums';
-import { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import { CurrentCatalogTypes, CurrentDocumentConfig } from '@innovations/shared/schemas/innovation-record';
 import { TestsHelper } from '@innovations/shared/tests';
 import { DTOsHelper } from '@innovations/shared/tests/helpers/dtos.helper';
 import { rand, randText } from '@ngneat/falso';
@@ -124,13 +124,14 @@ describe('Innovation Sections Suite', () => {
         em
       );
 
-      const dbInnovation = await em.createQueryBuilder(InnovationEntity, 'innovation')
+      const dbInnovation = await em
+        .createQueryBuilder(InnovationEntity, 'innovation')
         .addSelect("JSON_VALUE(document.document, '$.INNOVATION_DESCRIPTION.summary')", 'documentSummary')
         .addSelect("JSON_VALUE(documentDraft.document, '$.INNOVATION_DESCRIPTION.summary')", 'documentDraftSummary')
         .innerJoin('innovation.document', 'document')
         .innerJoin('innovation_document_draft', 'documentDraft', 'documentDraft.id = innovation.id')
         .where('innovation.id = :innovationId', { innovationId: innovation.id })
-        .getRawOne()
+        .getRawOne();
 
       expect(dbInnovation.documentSummary).not.toBe(newSummary);
       expect(dbInnovation.documentDraftSummary).toBe(newSummary);
@@ -147,14 +148,15 @@ describe('Innovation Sections Suite', () => {
         em
       );
 
-      const dbInnovation = await em.createQueryBuilder(InnovationEntity, 'innovation')
+      const dbInnovation = await em
+        .createQueryBuilder(InnovationEntity, 'innovation')
         .select('innovation.name', 'innovationName')
         .addSelect("JSON_VALUE(document.document, '$.INNOVATION_DESCRIPTION.name')", 'documentName')
         .addSelect("JSON_VALUE(documentDraft.document, '$.INNOVATION_DESCRIPTION.name')", 'documentDraftName')
         .innerJoin('innovation.document', 'document')
         .innerJoin('innovation_document_draft', 'documentDraft', 'documentDraft.id = innovation.id')
         .where('innovation.id = :innovationId', { innovationId: innovation.id })
-        .getRawOne()
+        .getRawOne();
 
       expect(dbInnovation.innovationName).toBe(newValue);
       expect(dbInnovation.documentName).toBe(newValue);
@@ -283,7 +285,9 @@ describe('Innovation Sections Suite', () => {
     it('should return empty section data if the user is an accessor and the section is not submitted', async () => {
       const allSectionsInfo = await sut.findAllSections(
         DTOsHelper.getUserRequestContext(scenario.users.aliceQualifyingAccessor),
-        innovation.id
+        innovation.id,
+        CurrentDocumentConfig.version,
+        em
       );
 
       expect(allSectionsInfo).toStrictEqual([
@@ -313,7 +317,7 @@ describe('Innovation Sections Suite', () => {
             submittedBy: { displayTag: 'Innovator', name: '[unknown user]' },
             openTasksCount: 0
           },
-          data: {}
+          data: expect.any(Object)
         },
         ...[
           'MARKET_RESEARCH',

--- a/apps/innovations/_services/innovation-sections.service.ts
+++ b/apps/innovations/_services/innovation-sections.service.ts
@@ -460,7 +460,7 @@ export class InnovationSectionsService extends BaseService {
     const document = await this.innovationDocumentService.getInnovationDocument(
       innovationId,
       version ?? CurrentDocumentConfig.version,
-      'DRAFT',
+      this.innovationDocumentService.getDocumentTypeAccordingWithRole(domainContext.currentRole.role),
       em
     );
     const innovationSections = this.getDocumentSections(document).map(section => ({

--- a/apps/innovations/_services/innovations.service.ts
+++ b/apps/innovations/_services/innovations.service.ts
@@ -1188,9 +1188,13 @@ export class InnovationsService extends BaseService {
     }
 
     // Only fetch the document version and category data (maybe create a helper for this in the future)
-    const documentData = await connection
-      // TODO: DRAFT Change this
-      .createQueryBuilder(InnovationDocumentEntity, 'innovationDocument')
+    let documentDataQuery: SelectQueryBuilder<InnovationDocumentEntity | InnovationDocumentDraftEntity> =
+      connection.createQueryBuilder(InnovationDocumentEntity, 'innovationDocument');
+    if ([ServiceRoleEnum.INNOVATOR, ServiceRoleEnum.ADMIN].includes(domainContext.currentRole.role)) {
+      documentDataQuery = connection.createQueryBuilder(InnovationDocumentDraftEntity, 'innovationDocument');
+    }
+
+    const documentData = await documentDataQuery
       .select("JSON_QUERY(document, '$.INNOVATION_DESCRIPTION.categories')", 'categories')
       .addSelect(
         "JSON_VALUE(document, '$.INNOVATION_DESCRIPTION.otherCategoryDescription')",

--- a/apps/innovations/_services/symbols.ts
+++ b/apps/innovations/_services/symbols.ts
@@ -9,6 +9,7 @@ export const SYMBOLS = {
   InnovationTasksService: Symbol.for('InnovationTasksService'),
   InnovationThreadsService: Symbol.for('InnovationThreadsService'),
   InnovationTransferService: Symbol.for('InnovationTransferService'),
+  InnovationDocumentService: Symbol.for('InnovationDocumentService'),
   ExportFileService: Symbol.for('ExportFileService'),
   StatisticsService: Symbol.for('StatisticsService'),
   ValidationService: Symbol.for('ValidationService')

--- a/apps/innovations/v1-innovation-evidence-info/index.ts
+++ b/apps/innovations/v1-innovation-evidence-info/index.ts
@@ -24,7 +24,7 @@ class GetInnovationEvidenceInfo {
     try {
       const params = JoiHelper.Validate<ParamsType>(ParamsSchema, request.params);
 
-      await authorizationService
+      const auth = await authorizationService
         .validate(context)
         .setInnovation(params.innovationId)
         .checkAssessmentType()
@@ -34,7 +34,11 @@ class GetInnovationEvidenceInfo {
         .checkInnovation()
         .verify();
 
-      const result = await innovationSectionsService.getInnovationEvidenceInfo(params.innovationId, params.evidenceId);
+      const result = await innovationSectionsService.getInnovationEvidenceInfo(
+        auth.getContext(),
+        params.innovationId,
+        params.evidenceId
+      );
 
       context.res = ResponseHelper.Ok<ResponseDTO>({
         id: result.id,


### PR DESCRIPTION
**Description:**
By having two different versions of the IR, we have to return the right version for our different roles and occasions. The rules are:

- **Innovators** always access the DRAFT version (updates/getters).
- **Admin** sees the DRAFT version when looking at the innovation, but it uses the SUBMITTED version for the list and filters.
- **QA/A/NA** always access the SUBMITTED version.

**Related tickets:**
- Closes [AB#164802](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/164802).
- US [AB#159217](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/159217).