### PR TITLE
feat: sync only on innovation submit on create and archive

### DIFF
--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -2310,16 +2310,29 @@ paths:
       summary: Submit an innovation section.
       operationId: v1-innovation-section-submit
       parameters:
-        - in: path
-          name: innovationId
+        - name: innovationId
+          in: path
           required: true
           schema:
             type: string
-        - in: path
-          name: sectionKey
+            format: uuid
+        - name: sectionKey
+          in: path
           required: true
           schema:
             type: string
+            enum:
+              - INNOVATION_DESCRIPTION
+              - UNDERSTANDING_OF_NEEDS
+              - EVIDENCE_OF_EFFECTIVENESS
+              - MARKET_RESEARCH
+              - CURRENT_CARE_PATHWAY
+              - TESTING_WITH_USERS
+              - REGULATIONS_AND_STANDARDS
+              - INTELLECTUAL_PROPERTY
+              - REVENUE_MODEL
+              - COST_OF_INNOVATION
+              - DEPLOYMENT
       requestBody:
         description: Innovation section submit request body.
         content:
@@ -2558,10 +2571,10 @@ paths:
       parameters:
         - name: innovationId
           in: path
-          description: Innovation ID
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: Innovation submitted successfully.

--- a/apps/innovations/_services/innovation-document.service.spec.ts
+++ b/apps/innovations/_services/innovation-document.service.spec.ts
@@ -7,12 +7,18 @@ import type { EntityManager } from 'typeorm';
 import SYMBOLS from './symbols';
 import type { InnovationDocumentService } from './innovation-document.service';
 import { ServiceRoleEnum } from '@innovations/shared/enums';
+import { DTOsHelper } from '@innovations/shared/tests/helpers/dtos.helper';
+import { InnovationDocumentEntity } from '@innovations/shared/entities';
 
 describe('Innovation Document suite', () => {
   let sut: InnovationDocumentService;
 
   const testsHelper = new TestsHelper();
   const scenario = testsHelper.getCompleteScenario();
+
+  const johnInnovator = scenario.users.johnInnovator;
+  const innovation = johnInnovator.innovations.johnInnovation;
+  const draftDescription = randProductDescription();
 
   let em: EntityManager;
 
@@ -23,32 +29,24 @@ describe('Innovation Document suite', () => {
 
   beforeEach(async () => {
     em = await testsHelper.getQueryRunnerEntityManager();
+    await em.query(
+      `UPDATE innovation_document_draft
+      SET document = JSON_MODIFY(document, @0, JSON_QUERY(@1)), updated_by=@2, updated_at=@3 WHERE id = @4`,
+      [
+        `$.INNOVATION_DESCRIPTION`,
+        JSON.stringify({ description: draftDescription }),
+        johnInnovator.id,
+        new Date(),
+        innovation.id
+      ]
+    );
   });
 
   afterEach(async () => {
     await testsHelper.releaseQueryRunnerEntityManager();
   });
 
-  const johnInnovator = scenario.users.johnInnovator;
-  const innovation = johnInnovator.innovations.johnInnovation;
-
   describe('getInnovationDocument', () => {
-    const draftDescription = randProductDescription();
-
-    beforeEach(async () => {
-      await em.query(
-        `UPDATE innovation_document_draft
-      SET document = JSON_MODIFY(document, @0, JSON_QUERY(@1)), updated_by=@2, updated_at=@3 WHERE id = @4`,
-        [
-          `$.INNOVATION_DESCRIPTION`,
-          JSON.stringify({ description: draftDescription }),
-          johnInnovator.id,
-          new Date(),
-          innovation.id
-        ]
-      );
-    });
-
     it('should return the version in draft', async () => {
       const document = await sut.getInnovationDocument(innovation.id, CurrentDocumentConfig.version, 'DRAFT', em);
       expect(document.INNOVATION_DESCRIPTION.description).toBe(draftDescription);
@@ -57,6 +55,25 @@ describe('Innovation Document suite', () => {
     it('should return the version that was latest submitted', async () => {
       const document = await sut.getInnovationDocument(innovation.id, CurrentDocumentConfig.version, 'SUBMITTED', em);
       expect(document.INNOVATION_DESCRIPTION.description).not.toBe(draftDescription);
+    });
+  });
+
+  describe('syncDocumentVersions', () => {
+    it('should sync the SUBMITTED version with the DRAFT version', async () => {
+      const now = new Date();
+      await sut.syncDocumentVersions(DTOsHelper.getUserRequestContext(johnInnovator), innovation.id, em, {
+        updatedAt: now
+      });
+
+      const dbDocument = await em
+        .createQueryBuilder(InnovationDocumentEntity, 'document')
+        .select(['document.document', 'document.updatedAt', 'document.updatedBy'])
+        .where('document.id = :innovationId', { innovationId: innovation.id })
+        .getOneOrFail();
+
+      expect(dbDocument.document.INNOVATION_DESCRIPTION.description).toBe(draftDescription);
+      expect(dbDocument.updatedAt).toStrictEqual(now);
+      expect(dbDocument.updatedBy).toBe(johnInnovator.id);
     });
   });
 

--- a/apps/innovations/_services/innovation-sections.service.ts
+++ b/apps/innovations/_services/innovation-sections.service.ts
@@ -423,17 +423,16 @@ export class InnovationSectionsService extends BaseService {
 
       const savedSection = await transaction.save(InnovationSectionEntity, dbSection);
 
-      // Submit document section info
-      await this.submitDocumentSectionInfo(
-        innovationId,
-        sectionKey,
-        { updatedBy: domainContext.id, updatedAt: now },
-        transaction
-      );
+      // Only add to activity log and submit section when is not created/archived
+      if (![InnovationStatusEnum.CREATED, InnovationStatusEnum.ARCHIVED].includes(dbInnovation.status)) {
+        // Submit document section info
+        await this.submitDocumentSectionInfo(
+          innovationId,
+          sectionKey,
+          { updatedBy: domainContext.id, updatedAt: now },
+          transaction
+        );
 
-      // Add activity logs.
-      if (dbInnovation.status != InnovationStatusEnum.CREATED) {
-        // BUSINESS RULE: Don't log section updates before innovation submission, only after.
         await this.domainService.innovations.addActivityLog(
           transaction,
           {

--- a/apps/innovations/_services/innovations.service.ts
+++ b/apps/innovations/_services/innovations.service.ts
@@ -63,6 +63,8 @@ import { ActionEnum } from '@innovations/shared/services/integrations/audit.serv
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import { groupBy, isString, mapValues, omit, pick, snakeCase } from 'lodash';
 import { BaseService } from './base.service';
+import SYMBOLS from './symbols';
+import type { InnovationDocumentService } from './innovation-document.service';
 
 // TODO move types
 export const InnovationListSelectType = [
@@ -191,7 +193,8 @@ type UserWithRoleDTO = { id: string; name: string | null }; // role: ServiceRole
 export class InnovationsService extends BaseService {
   constructor(
     @inject(SHARED_SYMBOLS.DomainService) private domainService: DomainService,
-    @inject(SHARED_SYMBOLS.NotifierService) private notifierService: NotifierService
+    @inject(SHARED_SYMBOLS.NotifierService) private notifierService: NotifierService,
+    @inject(SYMBOLS.InnovationDocumentService) private innovationDocumentService: InnovationDocumentService
   ) {
     super();
   }
@@ -1687,6 +1690,11 @@ export class InnovationsService extends BaseService {
           archiveReason: null
         }
       );
+
+      // Sync the Submitted document with the Draft document
+      await this.innovationDocumentService.syncDocumentVersions(domainContext, innovationId, transaction, {
+        updatedAt: now
+      });
 
       await this.domainService.innovations.addActivityLog(
         transaction,

--- a/apps/innovations/v1-innovation-section-submit/index.ts
+++ b/apps/innovations/v1-innovation-section-submit/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -23,16 +23,15 @@ class V1InnovationSectionSubmit {
     try {
       const params = JoiHelper.Validate<ParamsType>(ParamsSchema, request.params);
 
-      const authInstance = await authorizationService
+      const auth = await authorizationService
         .validate(context)
         .setInnovation(params.innovationId)
         .checkInnovatorType()
         .checkInnovation()
         .verify();
-      const domainContext = authInstance.getContext();
 
       const result = await innovationSectionsService.submitInnovationSection(
-        domainContext,
+        auth.getContext(),
         params.innovationId,
         params.sectionKey
       );
@@ -54,10 +53,7 @@ export default openApi(
       tags: ['Innovation'],
       summary: 'Submit an innovation section.',
       operationId: 'v1-innovation-section-submit',
-      parameters: [
-        { in: 'path', name: 'innovationId', required: true, schema: { type: 'string' } },
-        { in: 'path', name: 'sectionKey', required: true, schema: { type: 'string' } }
-      ],
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       requestBody: {
         description: 'Innovation section submit request body.',
         content: {

--- a/apps/innovations/v1-innovation-submit/index.ts
+++ b/apps/innovations/v1-innovation-submit/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { Audit, JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import { ActionEnum, TargetEnum } from '@innovations/shared/services/integrations/audit.service';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -36,13 +36,8 @@ class V1InnovationSubmit {
         .checkInnovation()
         .verify();
 
-      const domainContext = auth.getContext();
-
-      const result = await innovationsService.submitInnovation(domainContext, params.innovationId);
-      context.res = ResponseHelper.Ok<ResponseDTO>({
-        id: result.id,
-        status: result.status
-      });
+      const result = await innovationsService.submitInnovation(auth.getContext(), params.innovationId);
+      context.res = ResponseHelper.Ok<ResponseDTO>({ id: result.id, status: result.status });
       return;
     } catch (error) {
       context.res = ResponseHelper.Error(context, error);
@@ -57,17 +52,7 @@ export default openApi(V1InnovationSubmit.httpTrigger as AzureFunction, '/v1/{in
     description: 'Submit an innovation for assessment.',
     operationId: 'v1-innovation-submit',
     tags: ['Innovation'],
-    parameters: [
-      {
-        name: 'innovationId',
-        in: 'path',
-        description: 'Innovation ID',
-        required: true,
-        schema: {
-          type: 'string'
-        }
-      }
-    ],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
       200: {
         description: 'Innovation submitted successfully.',


### PR DESCRIPTION
**Description:**
To be able to see the latest submit version on create and archive it's necessary to don't sync the draft and submitted document versions on submit while in CREATED and ARCHIVED status.

This sync is made when the innovation is submitted or sent to NA reassessment.

**Related Tickets:**
- Closes: [AB#165186](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/165186).
- US: [AB#159217](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/159217).