### PR TITLE
Encodes email to escape special characters such as '#'

### DIFF
--- a/apps/admin/_services/users.service.ts
+++ b/apps/admin/_services/users.service.ts
@@ -224,7 +224,7 @@ export class UsersService extends BaseService {
     })[];
   }> {
     const em = entityManager ?? this.sqlConnection.manager;
-    const identifier = this.isUuid(encodeURIComponent(idOrEmail)) ? { userId: idOrEmail } : { email: idOrEmail };
+    const identifier = this.isUuid(idOrEmail) ? { userId: idOrEmail } : { email: idOrEmail };
     const user = await this.domainService.users.getUserInfo(identifier, {}, em);
 
     return {

--- a/apps/admin/_services/users.service.ts
+++ b/apps/admin/_services/users.service.ts
@@ -224,8 +224,7 @@ export class UsersService extends BaseService {
     })[];
   }> {
     const em = entityManager ?? this.sqlConnection.manager;
-
-    const identifier = this.isUuid(idOrEmail) ? { userId: idOrEmail } : { email: idOrEmail };
+    const identifier = this.isUuid(encodeURIComponent(idOrEmail)) ? { userId: idOrEmail } : { email: idOrEmail };
     const user = await this.domainService.users.getUserInfo(identifier, {}, em);
 
     return {

--- a/apps/admin/v1-admin-user-info/index.ts
+++ b/apps/admin/v1-admin-user-info/index.ts
@@ -26,7 +26,7 @@ class V1AdminUserInfo {
 
       await authorizationService.validate(context).checkAdminType().verify();
 
-      const result = await usersService.getUserInfo(params.userIdOrEmail);
+      const result = await usersService.getUserInfo(encodeURIComponent(params.userIdOrEmail));
 
       context.res = ResponseHelper.Ok<ResponseDTO>(result);
       return;

--- a/apps/admin/v1-admin-user-info/index.ts
+++ b/apps/admin/v1-admin-user-info/index.ts
@@ -26,7 +26,7 @@ class V1AdminUserInfo {
 
       await authorizationService.validate(context).checkAdminType().verify();
 
-      const result = await usersService.getUserInfo(encodeURIComponent(params.userIdOrEmail));
+      const result = await usersService.getUserInfo(params.userIdOrEmail);
 
       context.res = ResponseHelper.Ok<ResponseDTO>(result);
       return;

--- a/libs/shared/services/integrations/identity-provider.service.ts
+++ b/libs/shared/services/integrations/identity-provider.service.ts
@@ -162,8 +162,8 @@ export class IdentityProviderService {
     phone: null | string;
   }> {
     await this.verifyAccessToken();
-
-    const odataFilter = `$filter=identities/any(c:c/issuerAssignedId eq '${encodeURIComponent(email)}' and c/issuer eq '${this.tenantName}.onmicrosoft.com')`;
+    const encodedEmail = encodeURIComponent(email);
+    const odataFilter = `$filter=identities/any(c:c/issuerAssignedId eq '${encodedEmail}' and c/issuer eq '${this.tenantName}.onmicrosoft.com')`;
 
     const response = await axios
       .get<b2cGetUserInfoByEmailDTO>(`https://graph.microsoft.com/v1.0/users?${odataFilter}`, {

--- a/libs/shared/services/integrations/identity-provider.service.ts
+++ b/libs/shared/services/integrations/identity-provider.service.ts
@@ -163,7 +163,7 @@ export class IdentityProviderService {
   }> {
     await this.verifyAccessToken();
 
-    const odataFilter = `$filter=identities/any(c:c/issuerAssignedId eq '${email}' and c/issuer eq '${this.tenantName}.onmicrosoft.com')`;
+    const odataFilter = `$filter=identities/any(c:c/issuerAssignedId eq '${encodeURIComponent(email)}' and c/issuer eq '${this.tenantName}.onmicrosoft.com')`;
 
     const response = await axios
       .get<b2cGetUserInfoByEmailDTO>(`https://graph.microsoft.com/v1.0/users?${odataFilter}`, {


### PR DESCRIPTION
Fixes a bug occurring when getting user info, while an Admin attempts to add a user using an email with special characters (such as '#').

Screenshots:
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/4017664/13d9d33c-cc37-4272-81a2-de140ad3533c)
![image](https://github.com/nhsengland/innovation-service-transactional-frontend/assets/4017664/ba21e5fd-17a9-43a6-b8cf-6cbee9ee47f5)
