### PR TITLE
Task/get search innovations list

### DIFF
--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -4632,6 +4632,257 @@ paths:
                     description: Unique identifier for innovation object
         "400":
           description: Invalid innovation payload
+  /v1/search:
+    get:
+      operationId: v1-innovations-search
+      description: Get search innovations list
+      parameters:
+        - name: skip
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: take
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            default: 20
+        - name: order
+          in: query
+          required: false
+          schema:
+            type: object
+            properties: {}
+            additionalProperties:
+              type: string
+              enum:
+                - ASC
+                - DESC
+            default: {}
+        - name: careSettings
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - ACADEMIA
+                - ACUTE_TRUSTS_INPATIENT
+                - ACUTE_TRUSTS_OUTPATIENT
+                - AMBULANCE
+                - CARE_HOMES_CARE_SETTING
+                - END_LIFE_CARE
+                - ICS
+                - INDUSTRY
+                - LOCAL_AUTHORITY_EDUCATION
+                - MENTAL_HEALTH
+                - PHARMACY
+                - PRIMARY_CARE
+                - SOCIAL_CARE
+                - THIRD_SECTOR_ORGANISATIONS
+                - URGENT_AND_EMERGENCY
+                - OTHER
+        - name: categories
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - MEDICAL_DEVICE
+                - IN_VITRO_DIAGNOSTIC
+                - PHARMACEUTICAL
+                - DIGITAL
+                - AI
+                - EDUCATION
+                - PPE
+                - MODELS_CARE
+                - ESTATES_FACILITIES
+                - TRAVEL_TRANSPORT
+                - FOOD_NUTRITION
+                - DATA_MONITORING
+                - OTHER
+        - name: dateFilters
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                field:
+                  type: string
+                  enum:
+                    - lastAssessmentRequestAt
+                    - submittedAt
+                    - updatedAt
+                    - support.updatedAt
+                startDate:
+                  type: string
+                  format: date-time
+                endDate:
+                  type: string
+                  format: date-time
+              required:
+                - field
+              additionalProperties: false
+        - name: diseasesAndConditions
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              maxLength: 100
+        - name: engagingOrganisations
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: engagingUnits
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
+        - name: fields
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - id
+                - name
+                - status
+                - statusUpdatedAt
+                - groupedStatus
+                - submittedAt
+                - updatedAt
+                - lastAssessmentRequestAt
+                - careSettings
+                - categories
+                - countryName
+                - diseasesAndConditions
+                - involvedAACProgrammes
+                - keyHealthInequalities
+                - mainCategory
+                - otherCareSetting
+                - otherCategoryDescription
+                - postcode
+                - assessment.id
+                - assessment.isExempt
+                - assessment.assignedTo
+                - assessment.updatedAt
+                - engagingOrganisations
+                - engagingUnits
+                - suggestion.suggestedBy
+                - suggestion.suggestedOn
+                - support.id
+                - support.status
+                - support.updatedAt
+                - support.updatedBy
+                - support.closedReason
+                - owner.id
+                - owner.name
+                - owner.companyName
+                - statistics.notifications
+                - statistics.tasks
+                - statistics.messages
+            minItems: 1
+        - name: groupedStatuses
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - RECORD_NOT_SHARED
+                - AWAITING_NEEDS_ASSESSMENT
+                - NEEDS_ASSESSMENT
+                - AWAITING_SUPPORT
+                - RECEIVING_SUPPORT
+                - NO_ACTIVE_SUPPORT
+                - AWAITING_NEEDS_REASSESSMENT
+                - ARCHIVED
+        - name: involvedAACProgrammes
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - No
+                - Health Innovation Network
+                - Artificial Intelligence in Health and Care Award
+                - Clinical Entrepreneur Programme
+                - Early Access to Medicines Scheme
+                - Innovation for Healthcare Inequalities Programme
+                - Innovation and Technology Payment Programme
+                - NHS Innovation Accelerator
+                - NHS Insights Prioritisation Programme
+                - Pathway Transformation Fund
+                - Rapid Uptake Products Programme
+                - Small Business Research Initiative for Healthcare
+                - Test beds
+        - name: keyHealthInequalities
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - MATERNITY
+                - SEVER_MENTAL_ILLNESS
+                - CHRONIC_RESPIRATORY_DISEASE
+                - EARLY_CANCER_DIAGNOSIS
+                - HYPERTENSION_CASE_FINDING
+                - NONE
+        - name: locations
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - England
+                - Scotland
+                - Wales
+                - Northern Ireland
+                - Based outside UK
+        - name: search
+          in: query
+          required: false
+          schema:
+            type: string
+            maxLength: 200
+            nullable: true
+      responses:
+        "204":
+          description: Success
+        "400":
+          description: Bad Request
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
   /v1/{innovationId}/validate:
     get:
       description: Get validation information.

--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -4660,7 +4660,8 @@ paths:
               enum:
                 - ASC
                 - DESC
-            default: {}
+            default:
+              default: DESC
         - name: careSettings
           in: query
           required: false

--- a/apps/innovations/_helpers/es-query-builder.helper.ts
+++ b/apps/innovations/_helpers/es-query-builder.helper.ts
@@ -53,15 +53,40 @@ export class ElasticSearchQueryBuilder {
 }
 
 // Helpers to reduce query boilerplate
-export function createNestedQuery(path: string, query: QueryDslQueryContainer): { nested: QueryDslNestedQuery } {
+
+/**
+ * Creates a nested query for ElasticSearch.
+ *
+ * This function helps to construct a nested query, which allows you to search within an array of objects
+ * in your ElasticSearch documents (e.g., supports).
+ *
+ * @see {@link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html Documentation}
+ */
+export function nestedQuery(path: string, query: QueryDslQueryContainer): { nested: QueryDslNestedQuery } {
   return { nested: { path, query } };
 }
 
-export function createOrQuery(queries: QueryDslQueryContainer[]): { bool: QueryDslBoolQuery } {
+/**
+ * Creates an OR query using ElasticSearch.
+ *
+ * This is done by using a bool should query with minimum_should_match of 1 to replicate
+ * the OR condition. This is useful for when we want to create a OR clause:
+ *
+ * @example
+ * isShared || hasSupport === orQuery([isShared, hasSupport])
+ */
+export function orQuery(queries: QueryDslQueryContainer[]): { bool: QueryDslBoolQuery } {
   return { bool: { should: queries, minimum_should_match: 1 } };
 }
 
-export function createBoolQuery(params: {
+/**
+ * Creates a bool query using ElasticSearch.
+ *
+ * This function helps to construct a bool query, which combines multiple query clauses using the `must`, `must_not`, `should`, and `filter` parameters.
+ *
+ * @see {@link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html Documentation}
+ */
+export function boolQuery(params: {
   must?: QueryDslQueryContainer | QueryDslQueryContainer[];
   mustNot?: QueryDslQueryContainer | QueryDslQueryContainer[];
   should?: QueryDslQueryContainer | QueryDslQueryContainer[];

--- a/apps/innovations/_helpers/es-query-builder.helper.ts
+++ b/apps/innovations/_helpers/es-query-builder.helper.ts
@@ -1,0 +1,73 @@
+import type {
+  QueryDslBoolQuery,
+  QueryDslNestedQuery,
+  QueryDslQueryContainer,
+  SearchHighlight,
+  SearchRequest,
+  Sort
+} from '@elastic/elasticsearch/lib/api/types';
+import { isArray } from 'lodash';
+
+type SearchQueryBody = SearchRequest & { query: SearchBoolQuery };
+type SearchBoolQuery = {
+  bool: { must: QueryDslQueryContainer[]; must_not: QueryDslQueryContainer[]; filter: QueryDslQueryContainer[] };
+};
+
+export class ElasticSearchQueryBuilder {
+  private search: SearchQueryBody = {
+    sort: [],
+    query: { bool: { must: [], must_not: [], filter: [] } }
+  };
+
+  constructor(index: string) {
+    this.search.index = index;
+  }
+
+  addMust(must: QueryDslQueryContainer | QueryDslQueryContainer[]): this {
+    const musts = isArray(must) ? must : [must];
+    this.search.query.bool.must.push(...musts);
+    return this;
+  }
+
+  addFilter(filter: QueryDslQueryContainer | QueryDslQueryContainer[]): this {
+    const filters = isArray(filter) ? filter : [filter];
+    this.search.query.bool.filter.push(...filters);
+    return this;
+  }
+
+  addHighlight(highlight: SearchHighlight): this {
+    this.search.highlight = highlight;
+    return this;
+  }
+
+  addPagination(params: { from: number; size: number; sort?: Sort }): this {
+    this.search.from = params.from;
+    this.search.size = params.size;
+    this.search.sort = params.sort;
+    return this;
+  }
+
+  build(): SearchQueryBody {
+    return this.search;
+  }
+}
+
+// Helpers to reduce query boilerplate
+export function createNestedQuery(path: string, query: QueryDslQueryContainer): { nested: QueryDslNestedQuery } {
+  return { nested: { path, query } };
+}
+
+export function createOrQuery(queries: QueryDslQueryContainer[]): { bool: QueryDslBoolQuery } {
+  return { bool: { should: queries, minimum_should_match: 1 } };
+}
+
+export function createBoolQuery(params: {
+  must?: QueryDslQueryContainer | QueryDslQueryContainer[];
+  mustNot?: QueryDslQueryContainer | QueryDslQueryContainer[];
+  should?: QueryDslQueryContainer | QueryDslQueryContainer[];
+  filter?: QueryDslQueryContainer | QueryDslQueryContainer[];
+}): { bool: QueryDslBoolQuery } {
+  return {
+    bool: { must: params.must, must_not: params.mustNot, should: params.should, filter: params.filter }
+  };
+}

--- a/apps/innovations/_services/search.service.ts
+++ b/apps/innovations/_services/search.service.ts
@@ -19,13 +19,13 @@ import {
   isAssessmentDomainContextType
 } from '@innovations/shared/types';
 import { inject, injectable } from 'inversify';
-import { isArray, isString, mapValues, groupBy, pick } from 'lodash';
+import { groupBy, isArray, isString, mapValues, pick } from 'lodash';
 import { InnovationLocationEnum } from '../_enums/innovation.enums';
 import {
+  ElasticSearchQueryBuilder,
   createBoolQuery,
   createNestedQuery,
-  createOrQuery,
-  ElasticSearchQueryBuilder
+  createOrQuery
 } from '../_helpers/es-query-builder.helper';
 import { BaseService } from './base.service';
 import type {
@@ -128,7 +128,7 @@ export class SearchService extends BaseService {
    * Can be used when an innovation changes and an update on the properties is needed.
    */
   async upsertDocument(innovationId: string): Promise<void> {
-    const [data] = await this.domainService.innovations.getESDocumentsInformation([innovationId]);
+    const data = await this.domainService.innovations.getESDocumentsInformation(innovationId);
     if (data) {
       await this.esService.upsertDocument(this.index, data);
     }

--- a/apps/innovations/_services/search.service.ts
+++ b/apps/innovations/_services/search.service.ts
@@ -1,9 +1,89 @@
+import type {
+  QueryDslQueryContainer,
+  QueryDslRangeQuery,
+  SearchHit,
+  SearchRequest,
+  SearchTotalHits,
+  Sort
+} from '@elastic/elasticsearch/lib/api/types';
 import { ES_ENV } from '@innovations/shared/config';
+import type { InnovationListView } from '@innovations/shared/entities';
+import { InnovationStatusEnum, InnovationSupportStatusEnum, ServiceRoleEnum } from '@innovations/shared/enums';
+import { GenericErrorsEnum, NotImplementedError } from '@innovations/shared/errors';
+import type { PaginationQueryParamsType } from '@innovations/shared/helpers';
 import type { CurrentElasticSearchDocumentType } from '@innovations/shared/schemas/innovation-record';
-import type { DomainService, ElasticSearchService } from '@innovations/shared/services';
+import type { DomainService, DomainUsersService, ElasticSearchService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
+import {
+  DomainContextType,
+  isAccessorDomainContextType,
+  isAssessmentDomainContextType
+} from '@innovations/shared/types';
 import { inject, injectable } from 'inversify';
+import { isArray, isString, mapValues, groupBy, pick } from 'lodash';
+import { InnovationLocationEnum } from '../_enums/innovation.enums';
 import { BaseService } from './base.service';
+import type {
+  DateFilterFieldsType,
+  InnovationListFilters,
+  InnovationListFullResponseType
+} from './innovations.service';
+
+type SearchInnovationListSelectType =
+  // | keyof Omit<CurrentElasticSearchDocumentType, 'assessment' | 'supports'>
+  | keyof Omit<InnovationListView, 'assessment' | 'supports' | 'ownerId'> // TODO: should be changed in the future, keeping the same for simplification proccess
+  | 'careSettings'
+  | 'otherCareSetting'
+  | 'categories'
+  | 'countryName'
+  | 'diseasesAndConditions'
+  | 'mainCategory'
+  | 'otherCategoryDescription'
+  | 'postcode'
+  | 'assessment.id'
+  | 'assessment.updatedAt'
+  | 'assessment.assignedTo'
+  | 'assessment.isExempt'
+  | 'support.id'
+  | 'support.status'
+  | 'support.updatedAt'
+  | 'support.updatedBy'
+  | 'support.closedReason'
+  | 'owner.id'
+  | 'owner.name'
+  | 'owner.companyName';
+
+const translations = new Map([
+  ['careSettings', ['document', 'INNOVATION_DESCRIPTION', 'careSettings']],
+  ['otherCareSetting', ['document', 'INNOVATION_DESCRIPTION', 'otherCareSetting']],
+  ['categories', ['document', 'INNOVATION_DESCRIPTION', 'categories']],
+  ['countryName', ['document', 'INNOVATION_DESCRIPTION', 'countryName']],
+  ['diseasesAndConditions', ['document', 'UNDERSTANDING_OF_NEEDS', 'diseasesConditionsImpact']],
+  ['mainCategory', ['document', 'INNOVATION_DESCRIPTION', 'mainCategory']],
+  ['otherCategoryDescription', ['document', 'INNOVATION_DESCRIPTION', 'otherCategoryDescription']],
+  ['postcode', ['document', 'INNOVATION_DESCRIPTION', 'postcode']]
+]);
+
+type PickHandlerReturnType<T extends { [k: string]: any }, K extends keyof T> = {
+  [k in K]: Awaited<ReturnType<T[k]>>;
+};
+
+type InnovationListJoinTypes = SearchInnovationListSelectType extends infer X
+  ? X extends `${infer U}.${infer _D}`
+    ? U
+    : never
+  : never;
+
+type InnovationListChildrenType<T extends InnovationListJoinTypes> = SearchInnovationListSelectType extends infer X
+  ? X extends `${T}.${infer D}`
+    ? D
+    : never
+  : never;
+
+type SearchQueryBody = SearchRequest & { query: SearchBoolQuery };
+type SearchBoolQuery = {
+  bool: { must: QueryDslQueryContainer[]; must_not: QueryDslQueryContainer[]; filter: QueryDslQueryContainer[] };
+};
 
 @injectable()
 export class SearchService extends BaseService {
@@ -34,5 +114,575 @@ export class SearchService extends BaseService {
     if (data) {
       await this.esService.upsertDocument(this.index, data);
     }
+  }
+
+  async getDocuments<S extends SearchInnovationListSelectType>(
+    domainContext: DomainContextType,
+    params: {
+      fields: S[];
+      pagination: PaginationQueryParamsType<any>;
+      filters?: InnovationListFilters;
+    }
+  ): Promise<{ count: number; data: unknown[] }> {
+    if (!params.fields.length) {
+      return { count: 0, data: [] };
+    }
+
+    const searchQuery: SearchQueryBody = {
+      index: this.index,
+      sort: [],
+      query: { bool: { must: [], must_not: [], filter: [] } }
+    };
+
+    // Add Permission Guards according with role
+    this.addPermissionGuards(domainContext, searchQuery);
+
+    // filters
+    for (const [key, value] of Object.entries(params?.filters ?? {})) {
+      // add to do a as any for the filters as the value was evaluated as never but this should be safe to use
+      if ((this.filtersHandlers[key as keyof typeof this.filtersHandlers] as any) !== undefined) {
+        await (this.filtersHandlers[key as keyof typeof this.filtersHandlers] as any)(
+          domainContext,
+          searchQuery,
+          value
+        );
+      }
+    }
+
+    // pagination and sorting
+    const sort: Sort = [];
+    Object.entries(params.pagination.order).forEach(([key, value]) => {
+      if (value === 'ASC' || value === 'DESC') {
+        const order = value === 'ASC' ? 'asc' : 'desc';
+
+        // TODO: find a cleaner way to approach this sort. Like this for now.
+        switch (key) {
+          case 'owner.name':
+          case 'support.updatedBy':
+            throw new NotImplementedError(GenericErrorsEnum.NOT_IMPLEMENTED_ERROR, {
+              message: 'Sort by name is not allowed'
+            });
+
+          case 'support.closedReason':
+            throw new NotImplementedError(GenericErrorsEnum.NOT_IMPLEMENTED_ERROR, {
+              message: 'Filter not needed yet'
+            });
+
+          case 'countryName':
+            sort.push({ [`document.INNOVATION_DESCRIPTION.${key}.keyword`]: { order } });
+            break;
+
+          case 'name':
+            sort.push({ [`${key}.keyword`]: { order } });
+            break;
+
+          case 'support.updatedAt':
+            if (isAccessorDomainContextType(domainContext)) {
+              sort.push({
+                'supports.updatedAt': {
+                  order,
+                  nested: {
+                    path: 'supports',
+                    filter: {
+                      term: { 'supports.unitId': domainContext.organisation.organisationUnit.id }
+                    }
+                  }
+                }
+              });
+            }
+            break;
+
+          case 'relevance':
+            // Default is by "relevance"
+            break;
+
+          default:
+            // TODO: Verify if is nested!
+            sort.push({ [key]: { order } });
+        }
+      }
+    });
+    searchQuery.from = params.pagination.skip;
+    searchQuery.size = params.pagination.take;
+    searchQuery.sort = sort;
+
+    const response = await this.esService.client.search<CurrentElasticSearchDocumentType>(searchQuery);
+
+    // console.log(response);
+    // for (const i in response.hits.hits) {
+    //   const hit: any = response.hits.hits[i];
+    //   console.log(`${i}: ${hit?._source.name}`);
+    // }
+
+    const handlerMaps: {
+      [k in keyof typeof this.postHandlers]: Awaited<ReturnType<(typeof this.postHandlers)[k]>>;
+    } = {} as any; // initialization
+    for (const key of Object.keys(this.postHandlers) as (keyof typeof this.postHandlers)[]) {
+      handlerMaps[key] = (await this.postHandlers[key as keyof typeof handlerMaps](response.hits.hits)) as any;
+    }
+
+    const fieldGroups = mapValues(
+      groupBy(params.fields, item => item.split('.')[0]),
+      v => v.filter(i => i.split('.')[1]).map(item => item.split('.')[1]!)
+    );
+    return {
+      count: (response.hits.total as SearchTotalHits).value ?? 0,
+      data: response.hits.hits.map(hit => {
+        const doc = hit._source!;
+
+        const res = { highlights: hit.highlight } as any;
+        Object.entries(fieldGroups).forEach(([key, value]) => {
+          if (key in this.displayHandlers) {
+            const handler = this.displayHandlers[key as keyof typeof this.displayHandlers];
+            if (handler) {
+              res[key] = handler(domainContext, doc, value as any[], handlerMaps); // this any should be safe since it comes from the groupBy
+            }
+          } else {
+            // Handle plain object directly from the view
+            if (translations.has(key)) {
+              res[key] = translations.get(key)!.reduce((o, k) => (o ? o[k] : null), doc as any);
+            } else {
+              if (key === 'id') {
+                res[key] = hit._id;
+              } else {
+                res[key] = doc[key as keyof CurrentElasticSearchDocumentType];
+              }
+            }
+          }
+        });
+
+        // Extra postProcessing the items if required (this might become handlers in the future, keeping a function for now)
+        return isAccessorDomainContextType(domainContext) && !doc.shares.includes(domainContext.organisation.id)
+          ? this.cleanupAccessorsNotSharedInnovation(res)
+          : res;
+      })
+    };
+  }
+
+  private displayHandlers: {
+    [k in 'assessment' | 'support' | 'owner' | 'engagingUnits']: (
+      domainContext: DomainContextType,
+      item: CurrentElasticSearchDocumentType,
+      fields: k extends InnovationListJoinTypes ? InnovationListChildrenType<k>[] : string[],
+      postHandlers: { [k in keyof typeof this.postHandlers]: Awaited<ReturnType<(typeof this.postHandlers)[k]>> }
+    ) => Partial<InnovationListFullResponseType[k]>;
+  } = {
+    assessment: this.displayAssessment.bind(this),
+    engagingUnits: this.displayEngagingUnits.bind(this),
+    support: this.displaySupport.bind(this),
+    owner: this.displayOwner.bind(this)
+  };
+
+  private displayAssessment(
+    _domainContext: DomainContextType,
+    item: CurrentElasticSearchDocumentType,
+    fields: InnovationListChildrenType<'assessment'>[],
+    extra: PickHandlerReturnType<typeof this.postHandlers, 'users'>
+  ): Partial<InnovationListFullResponseType['assessment']> {
+    const res = {} as any;
+    fields.forEach(field => {
+      switch (field) {
+        case 'assignedTo':
+          res[field] = extra.users.get(item.assessment?.assignedToId ?? '')?.displayName ?? null;
+          break;
+        case 'isExempt':
+          res[field] = item.assessment?.isExempt;
+          break;
+        default:
+          res[field] = item.assessment?.[field] ?? null;
+      }
+    });
+    return res;
+  }
+
+  private displayEngagingUnits(
+    _domainContext: DomainContextType,
+    item: CurrentElasticSearchDocumentType,
+    _fields: string[],
+    extra: PickHandlerReturnType<typeof this.postHandlers, 'users'>
+  ): Partial<InnovationListFullResponseType['engagingUnits']> {
+    // currently not doing any field selection, just replacing user names
+    return (
+      item.engagingUnits?.map(unit => ({
+        acronym: unit.acronym,
+        assignedAccessors:
+          unit.assignedAccessors?.map(({ id }) => ({
+            id,
+            name: extra.users.get(id)?.displayName ?? null
+          })) ?? null,
+        name: unit.name,
+        unitId: unit.unitId
+      })) || null
+    );
+  }
+
+  private displaySupport(
+    domainContext: DomainContextType,
+    item: CurrentElasticSearchDocumentType,
+    fields: InnovationListChildrenType<'support'>[],
+    extra: PickHandlerReturnType<typeof this.postHandlers, 'users'>
+  ): Partial<InnovationListFullResponseType['support']> {
+    if (isAccessorDomainContextType(domainContext)) {
+      const support = item.supports.filter(s => s.unitId === domainContext.organisation.organisationUnit.id)[0];
+      const updatedBy = extra.users?.get(support?.updatedBy ?? '') ?? null;
+      const displayName =
+        // Ensuring that updatedBy is always innovator if the innovation is archived or not shared
+        item.status === InnovationStatusEnum.ARCHIVED ||
+        !item.shares?.length ||
+        // if the user has the innovator role (currently exclusive) as the updatedBy is not a role but user id and we can't
+        // distinguish if there's multiple roles for the same user
+        updatedBy?.roles.some(r => r.role === ServiceRoleEnum.INNOVATOR)
+          ? 'Innovator'
+          : updatedBy?.displayName ?? null;
+
+      // support is handled differently to remove the nested array since it's only 1 element in this case
+      return {
+        ...(fields.includes('id') && { id: support?.id ?? null }),
+        ...(fields.includes('status') && { status: support?.status ?? InnovationSupportStatusEnum.UNASSIGNED }),
+        ...(fields.includes('updatedAt') && { updatedAt: support?.updatedAt }),
+        ...(fields.includes('updatedBy') && { updatedBy: displayName }),
+        ...(fields.includes('closedReason') && {
+          closedReason:
+            support?.status === InnovationSupportStatusEnum.CLOSED
+              ? !item.shares.some(s => s === domainContext.organisation.id)
+                ? 'STOPPED_SHARED'
+                : item.status === 'ARCHIVED'
+                  ? 'ARCHIVED'
+                  : 'CLOSED'
+              : null
+        })
+      };
+    }
+
+    return null;
+  }
+
+  private displayOwner(
+    _domainContext: DomainContextType,
+    item: CurrentElasticSearchDocumentType,
+    fields: InnovationListChildrenType<'owner'>[],
+    extra: PickHandlerReturnType<typeof this.postHandlers, 'users'>
+  ): Partial<InnovationListFullResponseType['owner']> {
+    if (!item.owner) {
+      return null;
+    }
+    return {
+      ...(fields.includes('id') && { id: item.owner.id }),
+      ...(fields.includes('name') && { name: extra.users.get(item.owner.id ?? '')?.displayName ?? null }),
+      ...(fields.includes('companyName') && { companyName: item.owner.companyName ?? null })
+    };
+  }
+
+  private readonly filtersHandlers: {
+    [k in keyof Partial<InnovationListFilters>]: (
+      domainContext: DomainContextType,
+      query: SearchQueryBody,
+      value: Required<InnovationListFilters>[k]
+    ) => void | Promise<void>;
+  } = {
+    assignedToMe: this.addAssignedToMeFilter.bind(this),
+    careSettings: this.addJsonFilter('document.INNOVATION_DESCRIPTION.careSettings').bind(this),
+    categories: this.addJsonFilter('document.INNOVATION_DESCRIPTION.categories').bind(this),
+    dateFilters: this.addDateFilters.bind(this),
+    diseasesAndConditions: this.addJsonFilter('document.UNDERSTANDING_OF_NEEDS.diseasesConditionsImpact').bind(this),
+    engagingOrganisations: this.addJsonFilter('engagingOrganisations', { fieldSelector: 'organisationId' }).bind(this),
+    engagingUnits: this.addJsonFilter('engagingUnits', { fieldSelector: 'unitId' }).bind(this),
+    groupedStatuses: this.addJsonFilter('groupedStatus').bind(this),
+    involvedAACProgrammes: this.addJsonFilter('document.INNOVATION_DESCRIPTION.involvedAACProgrammes').bind(this),
+    keyHealthInequalities: this.addJsonFilter('document.UNDERSTANDING_OF_NEEDS.keyHealthInequalities').bind(this),
+    locations: this.addLocationFilter.bind(this),
+    search: this.addSearchFilter.bind(this),
+    // suggestedOnly: this.addSuggestedOnlyFilter.bind(this),
+    supportStatuses: this.addSupportFilter.bind(this)
+  };
+
+  // NOTE: Do we keep the search by email on admin?
+  private addSearchFilter(_domainContext: DomainContextType, query: SearchQueryBody, search: string): void {
+    const priorities = [
+      ['document.INNOVATION_DESCRIPTION.name', 'owner.companyName'],
+      ['document.INNOVATION_DESCRIPTION.description'],
+      ['document.UNDERSTANDING_OF_NEEDS.problemsTackled'],
+      ['document.UNDERSTANDING_OF_NEEDS.impactDiseaseCondition'],
+      ['document.INNOVATION_DESCRIPTION.mainPurpose'],
+      ['document.UNDERSTANDING_OF_NEEDS.benefitsOrImpact'],
+      ['document.INNOVATION_DESCRIPTION.careSettings', 'document.INNOVATION_DESCRIPTION.otherCareSetting'], // NOTE: not sure if other should enter here.
+      ['document.TESTING_WITH_USERS.*'],
+      [
+        'document.REGULATIONS_AND_STANDARDS.standardsType',
+        'document.REGULATIONS_AND_STANDARDS.otherRegulationDescription'
+      ],
+      ['document.INNOVATION_DESCRIPTION.countryName'],
+      ['document.INNOVATION_DESCRIPTION.postcode']
+    ];
+    const fields = priorities.reverse().flatMap((priority, i) => priority.map(p => `${p}^${i + 1}`));
+
+    if (search) {
+      const searchQuery = {
+        query_string: {
+          query: search,
+          fields: [...fields, '*'], // NOTE: should the highlights return the name and document.name?
+          fuzziness: 'AUTO'
+        }
+      };
+      query.query.bool.must.push(searchQuery);
+      query.highlight = { fields: { '*': { order: 'score', highlight_query: searchQuery } } };
+    }
+  }
+
+  private addAssignedToMeFilter(domainContext: DomainContextType, query: SearchQueryBody, value: boolean): void {
+    if (value) {
+      if (isAccessorDomainContextType(domainContext)) {
+        query.query.bool.must.push({
+          nested: {
+            path: 'supports',
+            query: {
+              term: { 'supports.assignedAccessorsRoleIds': domainContext.currentRole.id }
+            }
+          }
+        });
+      }
+      if (isAssessmentDomainContextType(domainContext)) {
+        query.query.bool.must.push({ term: { 'assessment.assignedToId': domainContext.id } });
+      }
+    }
+  }
+
+  private addJsonFilter(
+    filterKey: string,
+    options?: { fieldSelector: string } // fieldSelector == nested
+  ): (_domainContext: DomainContextType, query: SearchQueryBody, value: string | string[]) => void {
+    return (_domainContext: DomainContextType, query: SearchQueryBody, value: string | string[]) => {
+      const type = isArray(value) ? 'terms' : 'term';
+
+      if (options?.fieldSelector) {
+        query.query.bool.must.push({
+          nested: {
+            path: filterKey,
+            query: { [type]: { [`${filterKey}.${options.fieldSelector}`]: value } }
+          }
+        });
+      } else {
+        query.query.bool.must.push({ [type]: { [filterKey]: value } });
+      }
+    };
+  }
+
+  private addLocationFilter(
+    _domainContext: DomainContextType,
+    query: SearchQueryBody,
+    locations: InnovationLocationEnum[]
+  ): void {
+    const should: QueryDslQueryContainer[] = [];
+
+    if (locations.length) {
+      if (locations.includes(InnovationLocationEnum['Based outside UK'])) {
+        const predefinedLocations = [
+          InnovationLocationEnum.England,
+          InnovationLocationEnum['Northern Ireland'],
+          InnovationLocationEnum.Scotland,
+          InnovationLocationEnum.Wales
+        ];
+
+        should.push({
+          bool: {
+            must_not: [{ terms: { 'document.INNOVATION_DESCRIPTION.countryName.keyword': predefinedLocations } }]
+          }
+        });
+      }
+      should.push({
+        terms: {
+          'document.INNOVATION_DESCRIPTION.countryName.keyword': locations.filter(
+            l => l !== InnovationLocationEnum['Based outside UK']
+          )
+        }
+      });
+    }
+
+    query.query.bool.must.push({ bool: { should, minimum_should_match: 1 } });
+  }
+
+  private addSupportFilter(
+    domainContext: DomainContextType,
+    query: SearchQueryBody,
+    supportStatuses: InnovationSupportStatusEnum[]
+  ): void {
+    if (supportStatuses.length && isAccessorDomainContextType(domainContext)) {
+      query.query.bool.must.push({
+        bool: {
+          should: [
+            {
+              nested: {
+                path: 'supports',
+                query: {
+                  bool: {
+                    must: [
+                      { term: { 'supports.unitId': domainContext.organisation.organisationUnit.id } },
+                      { terms: { 'supports.status': supportStatuses } }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              bool: {
+                must_not: [
+                  {
+                    nested: {
+                      path: 'supports',
+                      query: {
+                        term: { 'supports.unitId': domainContext.organisation.organisationUnit.id }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          minimum_should_match: 1
+        }
+      });
+    }
+  }
+
+  private readonly postHandlers = {
+    users: this.withUsers.bind(this)
+  };
+
+  private async withUsers(
+    results: SearchHit<CurrentElasticSearchDocumentType>[]
+  ): ReturnType<DomainUsersService['getUsersMap']> {
+    const usersSet = new Set<string>();
+    for (const hit of results) {
+      const doc = hit._source;
+      if (doc) {
+        [
+          doc.owner.id,
+          doc.supports[0]?.updatedBy,
+          doc.assessment?.assignedToId,
+          ...(doc.engagingUnits?.flatMap(u => u.assignedAccessors.map(a => a.id)) || [])
+        ]
+          .filter(isString)
+          .forEach(u => usersSet.add(u));
+      }
+    }
+    return this.domainService.users.getUsersMap({ userIds: [...usersSet] });
+  }
+
+  private addDateFilters(
+    _domainContext: DomainContextType,
+    query: SearchQueryBody,
+    dateFilters: { field: DateFilterFieldsType; startDate?: Date; endDate?: Date }[]
+  ): void {
+    if (dateFilters && dateFilters.length > 0) {
+      for (const filter of dateFilters) {
+        let filterKey = !filter.field.includes('.') ? filter.field : filter.field;
+
+        // TODO: handle this date filter differently because of nested
+        if (filterKey.includes('support')) {
+        }
+
+        const range: QueryDslRangeQuery = {};
+        if (filter.startDate) {
+          range.gte = filter.startDate.toISOString();
+        }
+
+        if (filter.endDate) {
+          // This is needed because default TimeStamp for a DD/MM/YYYY date is 00:00:00
+          const beforeDateWithTimestamp = new Date(filter.endDate);
+          beforeDateWithTimestamp.setDate(beforeDateWithTimestamp.getDate() + 1);
+
+          range.lt = beforeDateWithTimestamp.toISOString();
+        }
+
+        query.query.bool.must.push({ range: { [filterKey]: range } });
+      }
+    }
+  }
+
+  private addPermissionGuards(domainContext: DomainContextType, query: SearchQueryBody): void {
+    if (domainContext.currentRole.role === ServiceRoleEnum.ASSESSMENT) {
+      query.query.bool.filter.push({ bool: { must_not: { term: { rawStatus: InnovationStatusEnum.CREATED } } } });
+    }
+
+    if (isAccessorDomainContextType(domainContext)) {
+      query.query.bool.filter.push({ term: { rawStatus: InnovationStatusEnum.IN_PROGRESS } });
+      query.query.bool.filter.push({
+        bool: {
+          should: [
+            { term: { shares: domainContext.organisation.id } },
+            {
+              nested: {
+                path: 'supports',
+                query: {
+                  term: { 'supports.unitId': domainContext.organisation.organisationUnit.id }
+                }
+              }
+            }
+          ],
+          minimum_should_match: 1
+        }
+      });
+      query.query.bool.filter.push({
+        bool: {
+          should: [
+            { bool: { must_not: { term: { status: InnovationStatusEnum.ARCHIVED } } } },
+            {
+              nested: {
+                path: 'supports',
+                query: {
+                  term: { 'supports.unitId': domainContext.organisation.organisationUnit.id }
+                }
+              }
+            }
+          ],
+          minimum_should_match: 1
+        }
+      });
+
+      if (domainContext.currentRole.role === ServiceRoleEnum.ACCESSOR) {
+        query.query.bool.filter.push({
+          nested: {
+            path: 'supports',
+            query: {
+              bool: {
+                must: [
+                  { term: { 'supports.unitId': domainContext.organisation.organisationUnit.id } },
+                  {
+                    terms: {
+                      'supports.status': [InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.CLOSED]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        });
+      }
+    }
+
+    if (domainContext.currentRole.role !== ServiceRoleEnum.ADMIN) {
+      query.query.bool.filter.push({ bool: { must_not: { term: { rawStatus: InnovationStatusEnum.WITHDRAWN } } } });
+    }
+  }
+
+  /**
+   * Cleanup innovation output to keep only the fields an accessor as access when not shared
+   * @param input the input to be cleaned
+   * @returns cleanup the response to remove fields that are not shared
+   */
+  private cleanupAccessorsNotSharedInnovation<T extends object>(input: T): Partial<T> {
+    return pick(input, [
+      'id',
+      'name',
+      'statusUpdatedAt',
+      'submittedAt',
+      'groupedStatus',
+      'updatedAt',
+      'mainCategory',
+      'otherCategoryDescription',
+      'countryName',
+      'postCode',
+      'support'
+    ]);
   }
 }

--- a/apps/innovations/_services/search.service.ts
+++ b/apps/innovations/_services/search.service.ts
@@ -530,30 +530,6 @@ export class SearchService extends BaseService {
     }
   }
 
-  private readonly postHandlers = {
-    users: this.withUsers.bind(this)
-  };
-
-  private async withUsers(
-    results: SearchHit<CurrentElasticSearchDocumentType>[]
-  ): ReturnType<DomainUsersService['getUsersMap']> {
-    const usersSet = new Set<string>();
-    for (const hit of results) {
-      const doc = hit._source;
-      if (doc) {
-        [
-          doc.owner.id,
-          doc.supports[0]?.updatedBy,
-          doc.assessment?.assignedToId,
-          ...(doc.engagingUnits?.flatMap(u => u.assignedAccessors.map(a => a.id)) || [])
-        ]
-          .filter(isString)
-          .forEach(u => usersSet.add(u));
-      }
-    }
-    return this.domainService.users.getUsersMap({ userIds: [...usersSet] });
-  }
-
   private addDateFilters(
     _domainContext: DomainContextType,
     builder: ElasticSearchQueryBuilder,
@@ -581,6 +557,30 @@ export class SearchService extends BaseService {
         }
       }
     }
+  }
+
+  private readonly postHandlers = {
+    users: this.withUsers.bind(this)
+  };
+
+  private async withUsers(
+    results: SearchHit<CurrentElasticSearchDocumentType>[]
+  ): ReturnType<DomainUsersService['getUsersMap']> {
+    const usersSet = new Set<string>();
+    for (const hit of results) {
+      const doc = hit._source;
+      if (doc) {
+        [
+          doc.owner.id,
+          doc.supports[0]?.updatedBy,
+          doc.assessment?.assignedToId,
+          ...(doc.engagingUnits?.flatMap(u => u.assignedAccessors.map(a => a.id)) ?? [])
+        ]
+          .filter(isString)
+          .forEach(u => usersSet.add(u));
+      }
+    }
+    return this.domainService.users.getUsersMap({ userIds: [...usersSet] });
   }
 
   private addPermissionGuards(domainContext: DomainContextType, builder: ElasticSearchQueryBuilder): void {

--- a/apps/innovations/v1-innovations-search/function.json
+++ b/apps/innovations/v1-innovations-search/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get"],
+      "route": "v1/search"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/apps/innovations/v1-innovations-search/index.ts
+++ b/apps/innovations/v1-innovations-search/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { SearchService } from '../_services/search.service';
 import SYMBOLS from '../_services/symbols';
-import type { NewResponseDTO } from './transformation.dtos';
+import type { ResponseDTO } from './transformation.dtos';
 import { QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1InnovationsSearch {
@@ -35,9 +35,13 @@ class V1InnovationsSearch {
       const { skip, take, order, fields, ...filters } = queryParams;
 
       // TODO: fix this as any
-      const response = await searchService.getDocuments(domainContext, { fields: fields as any, filters, pagination: { skip, take, order } });
+      const response = await searchService.getDocuments(domainContext, {
+        fields: fields as any,
+        filters,
+        pagination: { skip, take, order }
+      });
 
-      context.res = ResponseHelper.Ok<NewResponseDTO>(response as any); // todo fix this any
+      context.res = ResponseHelper.Ok<ResponseDTO>(response as any); // todo fix this any
 
       return;
     } catch (error) {

--- a/apps/innovations/v1-innovations-search/index.ts
+++ b/apps/innovations/v1-innovations-search/index.ts
@@ -1,0 +1,64 @@
+import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
+import type { AzureFunction, HttpRequest } from '@azure/functions';
+
+import { JwtDecoder } from '@innovations/shared/decorators';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
+import type { AuthorizationService } from '@innovations/shared/services';
+import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
+import type { CustomContextType } from '@innovations/shared/types';
+
+import { container } from '../_config';
+
+import type { SearchService } from '../_services/search.service';
+import SYMBOLS from '../_services/symbols';
+import type { NewResponseDTO } from './transformation.dtos';
+import { QueryParamsSchema, QueryParamsType } from './validation.schemas';
+
+class V1InnovationsSearch {
+  @JwtDecoder()
+  static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
+    const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
+    const searchService = container.get<SearchService>(SYMBOLS.SearchService);
+
+    try {
+      const authInstance = await authorizationService
+        .validate(context)
+        .checkAssessmentType()
+        .checkAccessorType()
+        .checkAdminType()
+        .verify();
+      const domainContext = authInstance.getContext();
+
+      const queryParams = JoiHelper.Validate<QueryParamsType>(QueryParamsSchema, request.query, {
+        userType: domainContext.currentRole.role
+      });
+      const { skip, take, order, fields, ...filters } = queryParams;
+
+      // TODO: fix this as any
+      const response = await searchService.getDocuments(domainContext, { fields: fields as any, filters, pagination: { skip, take, order } });
+
+      context.res = ResponseHelper.Ok<NewResponseDTO>(response as any); // todo fix this any
+
+      return;
+    } catch (error) {
+      context.res = ResponseHelper.Error(context, error);
+      return;
+    }
+  }
+}
+
+export default openApi(V1InnovationsSearch.httpTrigger as AzureFunction, '/v1/search', {
+  get: {
+    operationId: 'v1-innovations-search',
+    description: 'Get search innovations list',
+    parameters: SwaggerHelper.paramJ2S({ query: QueryParamsSchema }),
+    responses: {
+      204: { description: 'Success' },
+      400: { description: 'Bad Request' },
+      401: { description: 'Unauthorized' },
+      403: { description: 'Forbidden' },
+      404: { description: 'Not Found' },
+      500: { description: 'Internal Server Error' }
+    }
+  }
+});

--- a/apps/innovations/v1-innovations-search/transformation.dtos.ts
+++ b/apps/innovations/v1-innovations-search/transformation.dtos.ts
@@ -1,65 +1,6 @@
-import type {
-  InnovationGroupedStatusEnum,
-  InnovationStatusEnum,
-  InnovationSupportStatusEnum,
-  ServiceRoleEnum
-} from '@innovations/shared/enums';
-import type { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
 import type { InnovationListFullResponseType } from '../_services/innovations.service';
 
 export type ResponseDTO = {
   count: number;
-  data: {
-    id: string;
-    name: string;
-    description: null | string;
-    status: InnovationStatusEnum;
-    groupedStatus?: InnovationGroupedStatusEnum;
-    statusUpdatedAt: Date;
-    submittedAt: null | Date;
-    updatedAt: null | Date;
-    countryName: null | string;
-    postCode: null | string;
-    mainCategory: null | CurrentCatalogTypes.catalogCategory;
-    otherMainCategoryDescription: null | string;
-    assessment?: null | {
-      id: string;
-      createdAt: Date;
-      finishedAt: null | Date;
-      assignedTo?: { name: string };
-      reassessmentCount: number;
-      isExempted?: boolean;
-    };
-    supports?: {
-      id: string;
-      status: InnovationSupportStatusEnum;
-      updatedAt: Date;
-      organisation: {
-        id: string;
-        name: string;
-        acronym: null | string;
-        unit: {
-          id: string;
-          name: string;
-          acronym: string;
-          // Users only exists while a support is ENGAGING.
-          users?: {
-            name: string;
-            role: ServiceRoleEnum;
-          }[];
-        };
-      };
-    }[];
-    notifications?: number;
-    statistics?: {
-      tasks: number;
-      messages: number;
-    };
-    highlights?: Record<string, string[]>;
-  }[];
-};
-
-export type NewResponseDTO = {
-  count: number;
-  data: Partial<InnovationListFullResponseType>;
+  data: Partial<Omit<InnovationListFullResponseType, 'statistics'>>;
 };

--- a/apps/innovations/v1-innovations-search/transformation.dtos.ts
+++ b/apps/innovations/v1-innovations-search/transformation.dtos.ts
@@ -55,6 +55,7 @@ export type ResponseDTO = {
       tasks: number;
       messages: number;
     };
+    highlights?: Record<string, string[]>;
   }[];
 };
 

--- a/apps/innovations/v1-innovations-search/transformation.dtos.ts
+++ b/apps/innovations/v1-innovations-search/transformation.dtos.ts
@@ -1,0 +1,64 @@
+import type {
+  InnovationGroupedStatusEnum,
+  InnovationStatusEnum,
+  InnovationSupportStatusEnum,
+  ServiceRoleEnum
+} from '@innovations/shared/enums';
+import type { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import type { InnovationListFullResponseType } from '../_services/innovations.service';
+
+export type ResponseDTO = {
+  count: number;
+  data: {
+    id: string;
+    name: string;
+    description: null | string;
+    status: InnovationStatusEnum;
+    groupedStatus?: InnovationGroupedStatusEnum;
+    statusUpdatedAt: Date;
+    submittedAt: null | Date;
+    updatedAt: null | Date;
+    countryName: null | string;
+    postCode: null | string;
+    mainCategory: null | CurrentCatalogTypes.catalogCategory;
+    otherMainCategoryDescription: null | string;
+    assessment?: null | {
+      id: string;
+      createdAt: Date;
+      finishedAt: null | Date;
+      assignedTo?: { name: string };
+      reassessmentCount: number;
+      isExempted?: boolean;
+    };
+    supports?: {
+      id: string;
+      status: InnovationSupportStatusEnum;
+      updatedAt: Date;
+      organisation: {
+        id: string;
+        name: string;
+        acronym: null | string;
+        unit: {
+          id: string;
+          name: string;
+          acronym: string;
+          // Users only exists while a support is ENGAGING.
+          users?: {
+            name: string;
+            role: ServiceRoleEnum;
+          }[];
+        };
+      };
+    }[];
+    notifications?: number;
+    statistics?: {
+      tasks: number;
+      messages: number;
+    };
+  }[];
+};
+
+export type NewResponseDTO = {
+  count: number;
+  data: Partial<InnovationListFullResponseType>;
+};

--- a/apps/innovations/v1-innovations-search/validation.schemas.ts
+++ b/apps/innovations/v1-innovations-search/validation.schemas.ts
@@ -1,0 +1,138 @@
+import Joi from 'joi';
+
+import { InnovationGroupedStatusEnum, InnovationSupportStatusEnum, ServiceRoleEnum } from '@innovations/shared/enums';
+import { JoiHelper, PaginationQueryParamsType } from '@innovations/shared/helpers';
+
+import { TEXTAREA_LENGTH_LIMIT } from '@innovations/shared/constants';
+import { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import { InnovationLocationEnum } from '../_enums/innovation.enums';
+import {
+  DateFilterFieldsType,
+  HasAccessThroughKeys,
+  InnovationListFilters,
+  InnovationListSelectType
+} from '../_services/innovations.service';
+
+export type QueryParamsType = PaginationQueryParamsType<InnovationListSelectType> &
+  InnovationListFilters & {
+    fields: InnovationListSelectType[];
+  };
+
+export const QueryParamsSchema = JoiHelper.PaginationJoiSchema({
+  orderKeys: Object.values(InnovationListSelectType),
+  defaultOrder: {} // The new innovation list doesn't have a default order and enforces the user to order by a selected field
+})
+  .append<QueryParamsType>({
+    careSettings: JoiHelper.AppCustomJoi()
+      .stringArray()
+      .items(Joi.string().valid(...CurrentCatalogTypes.catalogCareSettings))
+      .optional(),
+    categories: JoiHelper.AppCustomJoi()
+      .stringArray()
+      .items(Joi.string().valid(...CurrentCatalogTypes.catalogCategory))
+      .optional(),
+    dateFilters: JoiHelper.AppCustomJoi()
+      .stringArrayOfObjects()
+      .items(
+        Joi.object({
+          field: Joi.string()
+            .valid(...DateFilterFieldsType)
+            .required(),
+          startDate: Joi.date().optional(),
+          endDate: Joi.date().optional()
+        })
+      )
+      .optional(),
+    diseasesAndConditions: JoiHelper.AppCustomJoi().stringArray().items(Joi.string().max(100)).optional(),
+    engagingOrganisations: JoiHelper.AppCustomJoi().stringArray().items(Joi.string()).optional(),
+    engagingUnits: JoiHelper.AppCustomJoi().stringArray().items(Joi.string().uuid()).optional(),
+    fields: JoiHelper.AppCustomJoi()
+      .stringArray()
+      .items(Joi.string().valid(...Object.values(InnovationListSelectType)))
+      .min(1)
+      .required(),
+    groupedStatuses: JoiHelper.AppCustomJoi()
+      .stringArray()
+      .items(
+        Joi.string().valid(
+          ...Object.values(InnovationGroupedStatusEnum).filter(v => v !== InnovationGroupedStatusEnum.WITHDRAWN)
+        )
+      ) // withdrawn is not allowed filter except for admin
+      .optional(),
+    involvedAACProgrammes: JoiHelper.AppCustomJoi()
+      .stringArray()
+      .items(Joi.string().valid(...CurrentCatalogTypes.catalogInvolvedAACProgrammes))
+      .optional(),
+    keyHealthInequalities: JoiHelper.AppCustomJoi()
+      .stringArray()
+      .items(Joi.string().valid(...CurrentCatalogTypes.catalogKeyHealthInequalities))
+      .optional(),
+    locations: JoiHelper.AppCustomJoi()
+      .stringArray()
+      .items(Joi.string().valid(...Object.values(InnovationLocationEnum)))
+      .optional(),
+    search: JoiHelper.AppCustomJoi().decodeURIString().trim().max(TEXTAREA_LENGTH_LIMIT.xs).allow(null, '').optional()
+  })
+  .when('$userType', {
+    switch: [
+      {
+        is: ServiceRoleEnum.INNOVATOR,
+        then: Joi.object({
+          hasAccessThrough: JoiHelper.AppCustomJoi()
+            .stringArray()
+            .items(Joi.string().valid(...HasAccessThroughKeys))
+            .default(['owner', 'collaborator'])
+            .min(1)
+        })
+      },
+      {
+        is: ServiceRoleEnum.ASSESSMENT,
+        then: Joi.object({
+          assignedToMe: Joi.boolean().optional(),
+          latestWorkedByMe: Joi.boolean().optional()
+        })
+      },
+      {
+        is: ServiceRoleEnum.ACCESSOR,
+        then: Joi.object({
+          assignedToMe: Joi.boolean().optional(),
+          closedByMyOrganisation: Joi.boolean().optional(),
+          suggestedOnly: Joi.boolean().optional(),
+          supportStatuses: JoiHelper.AppCustomJoi()
+            .stringArray()
+            .items(Joi.string().valid(InnovationSupportStatusEnum.ENGAGING, InnovationSupportStatusEnum.CLOSED))
+            .optional()
+        })
+      },
+      {
+        is: ServiceRoleEnum.QUALIFYING_ACCESSOR,
+        then: Joi.object({
+          assignedToMe: Joi.boolean().optional(),
+          closedByMyOrganisation: Joi.boolean().optional(),
+          suggestedOnly: Joi.boolean().optional(),
+          supportStatuses: JoiHelper.AppCustomJoi()
+            .stringArray()
+            .items(Joi.string().valid(...Object.values(InnovationSupportStatusEnum)))
+            .optional()
+        })
+      },
+      {
+        is: ServiceRoleEnum.ADMIN,
+        then: Joi.object({
+          groupedStatuses: JoiHelper.AppCustomJoi()
+            .stringArray()
+            .items(Joi.string().valid(...Object.values(InnovationGroupedStatusEnum)))
+            .optional(),
+          supportStatuses: JoiHelper.AppCustomJoi()
+            .stringArray()
+            .items(Joi.string().valid(...Object.values(InnovationSupportStatusEnum)))
+            .optional(),
+          supportUnit: Joi.when('supportStatuses', {
+            is: Joi.exist(),
+            then: Joi.string().uuid().required()
+          })
+        })
+      }
+    ]
+  })
+  .required();

--- a/apps/innovations/v1-innovations-search/validation.schemas.ts
+++ b/apps/innovations/v1-innovations-search/validation.schemas.ts
@@ -8,7 +8,6 @@ import { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-reco
 import { InnovationLocationEnum } from '../_enums/innovation.enums';
 import {
   DateFilterFieldsType,
-  HasAccessThroughKeys,
   InnovationListFilters,
   InnovationListSelectType
 } from '../_services/innovations.service';
@@ -19,7 +18,7 @@ export type QueryParamsType = PaginationQueryParamsType<InnovationListSelectType
   };
 
 export const QueryParamsSchema = JoiHelper.PaginationJoiSchema({
-  orderKeys: Object.values(InnovationListSelectType),
+  orderKeys: ['relevance', ...Object.values(InnovationListSelectType)]
 })
   .append<QueryParamsType>({
     careSettings: JoiHelper.AppCustomJoi()
@@ -74,28 +73,28 @@ export const QueryParamsSchema = JoiHelper.PaginationJoiSchema({
   })
   .when('$userType', {
     switch: [
-      {
-        is: ServiceRoleEnum.INNOVATOR,
-        then: Joi.object({
-          hasAccessThrough: JoiHelper.AppCustomJoi()
-            .stringArray()
-            .items(Joi.string().valid(...HasAccessThroughKeys))
-            .default(['owner', 'collaborator'])
-            .min(1)
-        })
-      },
+      // {
+      //   is: ServiceRoleEnum.INNOVATOR,
+      //   then: Joi.object({
+      //     hasAccessThrough: JoiHelper.AppCustomJoi()
+      //       .stringArray()
+      //       .items(Joi.string().valid(...HasAccessThroughKeys))
+      //       .default(['owner', 'collaborator'])
+      //       .min(1)
+      //   })
+      // },
       {
         is: ServiceRoleEnum.ASSESSMENT,
         then: Joi.object({
           assignedToMe: Joi.boolean().optional(),
-          latestWorkedByMe: Joi.boolean().optional()
+          latestWorkedByMe: Joi.boolean().optional().forbidden()
         })
       },
       {
         is: ServiceRoleEnum.ACCESSOR,
         then: Joi.object({
           assignedToMe: Joi.boolean().optional(),
-          closedByMyOrganisation: Joi.boolean().optional(),
+          closedByMyOrganisation: Joi.boolean().optional().forbidden(),
           suggestedOnly: Joi.boolean().optional(),
           supportStatuses: JoiHelper.AppCustomJoi()
             .stringArray()
@@ -107,7 +106,7 @@ export const QueryParamsSchema = JoiHelper.PaginationJoiSchema({
         is: ServiceRoleEnum.QUALIFYING_ACCESSOR,
         then: Joi.object({
           assignedToMe: Joi.boolean().optional(),
-          closedByMyOrganisation: Joi.boolean().optional(),
+          closedByMyOrganisation: Joi.boolean().optional().forbidden(),
           suggestedOnly: Joi.boolean().optional(),
           supportStatuses: JoiHelper.AppCustomJoi()
             .stringArray()

--- a/apps/innovations/v1-innovations-search/validation.schemas.ts
+++ b/apps/innovations/v1-innovations-search/validation.schemas.ts
@@ -13,14 +13,13 @@ import {
   InnovationListSelectType
 } from '../_services/innovations.service';
 
-export type QueryParamsType = PaginationQueryParamsType<InnovationListSelectType> &
+export type QueryParamsType = PaginationQueryParamsType<InnovationListSelectType & 'relevance'> &
   InnovationListFilters & {
     fields: InnovationListSelectType[];
   };
 
 export const QueryParamsSchema = JoiHelper.PaginationJoiSchema({
   orderKeys: Object.values(InnovationListSelectType),
-  defaultOrder: {} // The new innovation list doesn't have a default order and enforces the user to order by a selected field
 })
   .append<QueryParamsType>({
     careSettings: JoiHelper.AppCustomJoi()

--- a/libs/shared/schemas/innovation-record/202304/elastic-search.schema.ts
+++ b/libs/shared/schemas/innovation-record/202304/elastic-search.schema.ts
@@ -5,7 +5,6 @@ import type { MappingProperty } from '@elastic/elasticsearch/lib/api/types';
 
 export type ElasticSearchDocumentType202304 = {
   id: string;
-  name: string;
   status: InnovationStatusEnum;
   archivedStatus: InnovationStatusEnum | null;
   statusUpdatedAt: Date;
@@ -70,7 +69,6 @@ export const ElasticSearchSchema202304: CreateIndexParams = {
         }
       },
 
-      name: TextWithNestedKeywordType,
       status: { type: 'keyword' },
       archivedStatus: { type: 'keyword' },
       rawStatus: { type: 'keyword' },
@@ -142,7 +140,7 @@ export const ElasticSearchSchema202304: CreateIndexParams = {
           version: { type: 'constant_keyword' },
           INNOVATION_DESCRIPTION: {
             properties: {
-              name: { type: 'text' },
+              name: TextWithNestedKeywordType,
               description: { type: 'text' },
               postcode: { type: 'text' },
               countryName: TextWithNestedKeywordType,

--- a/libs/shared/schemas/innovation-record/202304/elastic-search.schema.ts
+++ b/libs/shared/schemas/innovation-record/202304/elastic-search.schema.ts
@@ -1,7 +1,12 @@
-import type { CreateIndexParams } from '../../../services/integrations/elastic-search.service';
-import type { InnovationStatusEnum, InnovationGroupedStatusEnum, InnovationSupportStatusEnum } from '../../../enums';
-import type { DocumentType } from '../index';
 import type { MappingProperty } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  InnovationGroupedStatusEnum,
+  InnovationStatusEnum,
+  InnovationSupportStatusEnum,
+  UserStatusEnum
+} from '../../../enums';
+import type { CreateIndexParams } from '../../../services/integrations/elastic-search.service';
+import type { DocumentType } from '../index';
 
 export type ElasticSearchDocumentType202304 = {
   id: string;
@@ -13,21 +18,22 @@ export type ElasticSearchDocumentType202304 = {
   updatedAt: Date;
   lastAssessmentRequestAt: Date | null;
   document: DocumentType;
-  owner: { id?: string; identityId?: string; companyName: string | null };
-  engagingOrganisations: { organisationId: string; name: string; acronym: null | string }[];
-  engagingUnits: {
+  owner?: { id: string; identityId: string; companyName: string | null; status: UserStatusEnum };
+  engagingOrganisations?: { organisationId: string; name: string; acronym: string }[];
+  engagingUnits?: {
     unitId: string;
     name: string;
     acronym: string;
-    assignedAccessors: { id: string; identityId: string }[];
+    assignedAccessors?: { roleId: string; id: string; identityId: string }[];
   }[];
-  shares: string[];
-  supports: {
+  shares?: string[];
+  supports?: {
     id: string;
     unitId: string;
     status: InnovationSupportStatusEnum;
     updatedAt: Date;
     updatedBy: string;
+    assignedAccessorsRoleIds?: string[];
   }[];
   assessment?: {
     id: string;
@@ -36,7 +42,6 @@ export type ElasticSearchDocumentType202304 = {
     updatedAt: Date;
     isExempt: boolean;
   };
-  // NOTE: This is not being populated yet
   suggestions?: {
     suggestedUnitId: string;
     suggestedBy: string[];
@@ -65,7 +70,8 @@ export const ElasticSearchSchema202304: CreateIndexParams = {
         properties: {
           id: { type: 'keyword' },
           identityId: { type: 'keyword' },
-          companyName: { type: 'text' }
+          companyName: { type: 'text' },
+          status: { type: 'keyword' }
         }
       },
 

--- a/libs/shared/schemas/innovation-record/202304/elastic-search.schema.ts
+++ b/libs/shared/schemas/innovation-record/202304/elastic-search.schema.ts
@@ -14,7 +14,7 @@ export type ElasticSearchDocumentType202304 = {
   updatedAt: Date;
   lastAssessmentRequestAt: Date | null;
   document: DocumentType;
-  owner: { id?: string; identityId?: string; companyName?: string };
+  owner: { id?: string; identityId?: string; companyName: string | null };
   engagingOrganisations: { organisationId: string; name: string; acronym: null | string }[];
   engagingUnits: {
     unitId: string;

--- a/libs/shared/schemas/innovation-record/202304/elastic-search.schema.ts
+++ b/libs/shared/schemas/innovation-record/202304/elastic-search.schema.ts
@@ -122,7 +122,6 @@ export const ElasticSearchSchema202304: CreateIndexParams = {
       },
       shares: { type: 'keyword' },
 
-      // NOTE: This is not being populated yet
       suggestions: {
         type: 'nested',
         properties: {

--- a/libs/shared/services/domain/domain-innovations.service.ts
+++ b/libs/shared/services/domain/domain-innovations.service.ts
@@ -898,7 +898,6 @@ export class DomainInnovationsService {
       .createQueryBuilder(InnovationEntity, 'innovation')
       .select([
         'innovation.id',
-        'innovation.name',
         'innovation.status',
         'innovation.archivedStatus',
         'innovation.statusUpdatedAt',
@@ -986,7 +985,6 @@ export class DomainInnovationsService {
 
       return {
         id: inno.id,
-        name: inno.name,
         status: inno.status,
         archivedStatus: inno.archivedStatus,
         rawStatus: inno.status === InnovationStatusEnum.ARCHIVED ? inno.archivedStatus : inno.status,

--- a/libs/shared/services/domain/domain-innovations.service.ts
+++ b/libs/shared/services/domain/domain-innovations.service.ts
@@ -945,7 +945,7 @@ export class DomainInnovationsService {
       .leftJoin('owner.serviceRoles', 'ownerRole', 'ownerRole.role = :innovatorRole AND ownerRole.isActive = 1', {
         innovatorRole: ServiceRoleEnum.INNOVATOR
       })
-      .leftJoin('ownerRole.organisation', 'ownerOrganisation')
+      .leftJoin('ownerRole.organisation', 'ownerOrganisation', 'ownerOrganisation.is_shadow = 0')
       .withDeleted();
 
     if (innovationIds?.length) {
@@ -1001,7 +1001,7 @@ export class DomainInnovationsService {
         owner: {
           id: inno.owner?.id,
           identityId: inno.owner?.identityId,
-          companyName: inno.owner?.serviceRoles[0]?.organisation?.name
+          companyName: inno.owner?.serviceRoles[0]?.organisation?.name ?? null
         },
 
         engagingOrganisations: [...orgs.values()],


### PR DESCRIPTION
**Description:**
This PR introduces the first version of the Get Innovations List feature using Elasticsearch. This initial version is intended for integration with the front-end.

Contains:
- Adjustments to the schema and document ingestion process to support all selects and filters.
- A new endpoint that accepts the same format as the current one for seamless integration, with the addition of a new order field called relevance.
- A query builder with helper functions to simplify and reduce boilerplate for creating Elasticsearch queries.
- A new function structured similarly to the current "innovation list" function, including necessary changes for Elasticsearch queries.

What is Missing:
- Unit tests need to be added.
- The suggestions filter is pending and depends on the new optimised query.
- Not all filters from the SQL-based innovation list are implemented. These should be either removed from the types or implemented.
- The main `getDocuments` could be refactored further into more simpler and readable structure.

**Related tickets:**
- Closes [AB#169108](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/169108).
- Closes [AB#169114](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/169114).