### PR TITLE
Task/update innovations on ES index

### DIFF
--- a/apps/admin/v1-admin-search-reindex-cron/function.json
+++ b/apps/admin/v1-admin-search-reindex-cron/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "schedule": "0 0 3 * * *",
+      "name": "myTimerReindexElastic",
+      "type": "timerTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/apps/admin/v1-admin-search-reindex-cron/index.spec.ts
+++ b/apps/admin/v1-admin-search-reindex-cron/index.spec.ts
@@ -1,0 +1,23 @@
+import azureFunction from '.';
+
+import { TestsHelper } from '@admin/shared/tests';
+import { SearchService } from '../_services/search.service';
+
+const testsHelper = new TestsHelper();
+
+beforeAll(async () => {
+  await testsHelper.init();
+});
+
+const mock = jest.spyOn(SearchService.prototype, 'createAndPopulateIndex').mockResolvedValue();
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('v1-admin-search-reindex-cron', () => {
+  it('should recreate index and populete it', async () => {
+    await azureFunction();
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/admin/v1-admin-search-reindex-cron/index.ts
+++ b/apps/admin/v1-admin-search-reindex-cron/index.ts
@@ -15,8 +15,9 @@ class V1AdminSearchReindexCron {
       logger.log('Running cron job: V1AdminSearchReindexCron');
       await searchService.createAndPopulateIndex();
       logger.log('Finished cron job: V1AdminSearchReindexCron');
-    } catch (err) {
-      logger.error('Error while running cron job: V1AdminSearchReindexCron', err);
+    } catch (error) {
+      logger.error('Error while running cron job: V1AdminSearchReindexCron', error);
+      throw error;
     }
   }
 }

--- a/apps/admin/v1-admin-search-reindex-cron/index.ts
+++ b/apps/admin/v1-admin-search-reindex-cron/index.ts
@@ -1,0 +1,24 @@
+import { container } from '../_config';
+
+import type { LoggerService } from '@admin/shared/services';
+import SHARED_SYMBOLS from '@admin/shared/services/symbols';
+import type { SearchService } from '../_services/search.service';
+import SYMBOLS from '../_services/symbols';
+
+// Run every day at 02:00 (Summer Time) or 03:00 (Winter time)
+class V1AdminSearchReindexCron {
+  static async cronTrigger(): Promise<void> {
+    const searchService = container.get<SearchService>(SYMBOLS.SearchService);
+    const logger = container.get<LoggerService>(SHARED_SYMBOLS.LoggerService);
+
+    try {
+      logger.log('Running cron job: V1AdminSearchReindexCron');
+      await searchService.createAndPopulateIndex();
+      logger.log('Finished cron job: V1AdminSearchReindexCron');
+    } catch (err) {
+      logger.error('Error while running cron job: V1AdminSearchReindexCron', err);
+    }
+  }
+}
+
+export default V1AdminSearchReindexCron.cronTrigger;

--- a/apps/innovations/v1-innovation-archive/index.spec.ts
+++ b/apps/innovations/v1-innovation-archive/index.spec.ts
@@ -13,7 +13,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-archive/index.ts
+++ b/apps/innovations/v1-innovation-archive/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { Audit, JwtDecoder } from '@innovations/shared/decorators';
+import { Audit, ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationStatusEnum } from '@innovations/shared/enums';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
@@ -18,6 +18,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 class V1InnovationPause {
   @JwtDecoder()
   @Audit({ action: ActionEnum.UPDATE, target: TargetEnum.INNOVATION, identifierParam: 'innovationId' })
+  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationsService = container.get<InnovationsService>(SYMBOLS.InnovationsService);

--- a/apps/innovations/v1-innovation-assessment-assessor-update/index.spec.ts
+++ b/apps/innovations/v1-innovation-assessment-assessor-update/index.spec.ts
@@ -8,7 +8,8 @@ import type { BodyType, ParamsType } from './validation.schemas';
 jest.mock('@innovations/shared/decorators', () => ({
   JwtDecoder: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-assessment-assessor-update/index.ts
+++ b/apps/innovations/v1-innovation-assessment-assessor-update/index.ts
@@ -3,7 +3,7 @@ import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import type { AuthorizationService } from '@innovations/shared/services';
 
-import { JwtDecoder } from '@innovations/shared/decorators';
+import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationStatusEnum } from '@innovations/shared/enums';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -18,6 +18,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 
 class V1InnovationAssessmentAssessorUpdate {
   @JwtDecoder()
+  @ElasticSearchDocumentUpdate('ASSESSMENT_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationAssessmentsService = container.get<InnovationAssessmentsService>(

--- a/apps/innovations/v1-innovation-assessment-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-assessment-create/index.spec.ts
@@ -13,7 +13,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-assessment-create/index.ts
+++ b/apps/innovations/v1-innovation-assessment-create/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { Audit, JwtDecoder } from '@innovations/shared/decorators';
+import { Audit, ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationStatusEnum } from '@innovations/shared/enums';
 import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
@@ -23,6 +23,7 @@ class CreateInnovationAssessment {
     target: TargetEnum.ASSESSMENT,
     identifierResponseField: 'id'
   })
+  @ElasticSearchDocumentUpdate('ASSESSMENT_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationAssessmentsService = container.get<InnovationAssessmentsService>(

--- a/apps/innovations/v1-innovation-assessment-update/index.spec.ts
+++ b/apps/innovations/v1-innovation-assessment-update/index.spec.ts
@@ -13,7 +13,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-assessment-update/index.ts
+++ b/apps/innovations/v1-innovation-assessment-update/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { Audit, JwtDecoder } from '@innovations/shared/decorators';
+import { Audit, ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationStatusEnum } from '@innovations/shared/enums';
 import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
@@ -23,6 +23,7 @@ class V1InnovationAssessmentUpdate {
     target: TargetEnum.ASSESSMENT,
     identifierParam: 'assessmentId'
   })
+  @ElasticSearchDocumentUpdate('ASSESSMENT_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationAssessmentsService = container.get<InnovationAssessmentsService>(

--- a/apps/innovations/v1-innovation-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-create/index.spec.ts
@@ -14,7 +14,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-create/index.ts
+++ b/apps/innovations/v1-innovation-create/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { Audit, JwtDecoder } from '@innovations/shared/decorators';
+import { Audit, ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import { ActionEnum, TargetEnum } from '@innovations/shared/services/integrations/audit.service';
@@ -22,6 +22,7 @@ class V1InnovationCreate {
     identifierResponseField: 'id',
     target: TargetEnum.INNOVATION
   })
+  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationService = container.get<InnovationsService>(SYMBOLS.InnovationsService);

--- a/apps/innovations/v1-innovation-reassessment-request-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/index.spec.ts
@@ -14,7 +14,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-reassessment-request-create/index.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { JwtDecoder } from '@innovations/shared/decorators';
+import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationStatusEnum } from '@innovations/shared/enums';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
@@ -17,6 +17,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 
 class V1InnovationReassessmentRequestCreate {
   @JwtDecoder()
+  @ElasticSearchDocumentUpdate('ASSESSMENT_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationAssessmentsService = container.get<InnovationAssessmentsService>(

--- a/apps/innovations/v1-innovation-section-submit/index.spec.ts
+++ b/apps/innovations/v1-innovation-section-submit/index.spec.ts
@@ -14,7 +14,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-section-submit/index.ts
+++ b/apps/innovations/v1-innovation-section-submit/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { JwtDecoder } from '@innovations/shared/decorators';
+import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -16,6 +16,7 @@ import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationSectionSubmit {
   @JwtDecoder()
+  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationSectionsService = container.get<InnovationSectionsService>(SYMBOLS.InnovationSectionsService);

--- a/apps/innovations/v1-innovation-section-update/index.spec.ts
+++ b/apps/innovations/v1-innovation-section-update/index.spec.ts
@@ -14,7 +14,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-section-update/index.ts
+++ b/apps/innovations/v1-innovation-section-update/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { JwtDecoder } from '@innovations/shared/decorators';
+import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
 import { CurrentDocumentSchemaMap } from '@innovations/shared/schemas/innovation-record';
 import type { AuthorizationService } from '@innovations/shared/services';
@@ -17,6 +17,7 @@ import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationSectionUpdate {
   @JwtDecoder()
+  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationSectionsService = container.get<InnovationSectionsService>(SYMBOLS.InnovationSectionsService);

--- a/apps/innovations/v1-innovation-shares-update/index.spec.ts
+++ b/apps/innovations/v1-innovation-shares-update/index.spec.ts
@@ -14,7 +14,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-shares-update/index.ts
+++ b/apps/innovations/v1-innovation-shares-update/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { JwtDecoder } from '@innovations/shared/decorators';
+import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -16,6 +16,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 
 class V1InnovationSharesUpdate {
   @JwtDecoder()
+  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationsService = container.get<InnovationsService>(SYMBOLS.InnovationsService);

--- a/apps/innovations/v1-innovation-submit/index.spec.ts
+++ b/apps/innovations/v1-innovation-submit/index.spec.ts
@@ -15,7 +15,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-submit/index.ts
+++ b/apps/innovations/v1-innovation-submit/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { Audit, JwtDecoder } from '@innovations/shared/decorators';
+import { Audit, ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import { ActionEnum, TargetEnum } from '@innovations/shared/services/integrations/audit.service';
@@ -22,6 +22,7 @@ class V1InnovationSubmit {
     target: TargetEnum.INNOVATION,
     identifierParam: 'innovationId'
   })
+  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationsService = container.get<InnovationsService>(SYMBOLS.InnovationsService);

--- a/apps/innovations/v1-innovation-support-change-accessors/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-change-accessors/index.spec.ts
@@ -13,7 +13,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-support-change-accessors/index.ts
+++ b/apps/innovations/v1-innovation-support-change-accessors/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { JwtDecoder } from '@innovations/shared/decorators';
+import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { ServiceRoleEnum } from '@innovations/shared/enums';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
@@ -16,6 +16,7 @@ import { BodySchema, ParamsSchema, type BodyType, type ParamsType } from './vali
 
 class V1InnovationSupportUpdate {
   @JwtDecoder()
+  @ElasticSearchDocumentUpdate('SUPPORT_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationSupportsService = container.get<InnovationSupportsService>(SYMBOLS.InnovationSupportsService);

--- a/apps/innovations/v1-innovation-support-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-create/index.spec.ts
@@ -15,7 +15,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-support-create/index.ts
+++ b/apps/innovations/v1-innovation-support-create/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { JwtDecoder } from '@innovations/shared/decorators';
+import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { ServiceRoleEnum } from '@innovations/shared/enums';
 import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
@@ -17,6 +17,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 
 class V1InnovationSupportCreate {
   @JwtDecoder()
+  @ElasticSearchDocumentUpdate('SUPPORT_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationSupportsService = container.get<InnovationSupportsService>(SYMBOLS.InnovationSupportsService);

--- a/apps/innovations/v1-innovation-support-logs-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-logs-create/index.spec.ts
@@ -14,7 +14,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-support-logs-create/index.ts
+++ b/apps/innovations/v1-innovation-support-logs-create/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { JwtDecoder } from '@innovations/shared/decorators';
+import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { ServiceRoleEnum } from '@innovations/shared/enums';
 import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
@@ -19,6 +19,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 // OPTIMIZE CREATE INNOVATION ORGANISATIONS SUGGESTIONS
 class V1InnovationsSupportLogCreate {
   @JwtDecoder()
+  @ElasticSearchDocumentUpdate('SUPPORT_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationSupportsService = container.get<InnovationSupportsService>(SYMBOLS.InnovationSupportsService);

--- a/apps/innovations/v1-innovation-support-update/index.spec.ts
+++ b/apps/innovations/v1-innovation-support-update/index.spec.ts
@@ -14,7 +14,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-support-update/index.ts
+++ b/apps/innovations/v1-innovation-support-update/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { JwtDecoder } from '@innovations/shared/decorators';
+import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationSupportStatusEnum, ServiceRoleEnum } from '@innovations/shared/enums';
 import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
@@ -17,6 +17,7 @@ import { BodySchema, ParamsSchema, type BodyType, type ParamsType } from './vali
 
 class V1InnovationSupportUpdate {
   @JwtDecoder()
+  @ElasticSearchDocumentUpdate('SUPPORT_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationSupportsService = container.get<InnovationSupportsService>(SYMBOLS.InnovationSupportsService);

--- a/apps/innovations/v1-innovation-transfer-update/index.spec.ts
+++ b/apps/innovations/v1-innovation-transfer-update/index.spec.ts
@@ -15,7 +15,8 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  })
+  }),
+  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-transfer-update/index.ts
+++ b/apps/innovations/v1-innovation-transfer-update/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { JwtDecoder } from '@innovations/shared/decorators';
+import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -16,6 +16,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 
 class V1InnovationTransferUpdate {
   @JwtDecoder()
+  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const transferService = container.get<InnovationTransferService>(SYMBOLS.InnovationTransferService);

--- a/apps/innovations/v1-innovation-update-index-listener/function.json
+++ b/apps/innovations/v1-innovation-update-index-listener/function.json
@@ -1,0 +1,16 @@
+{
+  "bindings": [
+    {
+      "type": "queueTrigger",
+      "direction": "in",
+      "name": "queueItem",
+      "queueName": "elasticsearch-queue",
+      "connection": "AZURE_STORAGE_CONNECTIONSTRING"
+    }
+  ],
+  "retry": {
+    "strategy": "fixedDelay",
+    "delayInterval": "00:00:01",
+    "maxRetryCount": 1
+  }
+}

--- a/apps/innovations/v1-innovation-update-index-listener/index.spec.ts
+++ b/apps/innovations/v1-innovation-update-index-listener/index.spec.ts
@@ -34,13 +34,12 @@ describe('v1-innovation-updated-index-listener suite', () => {
     expect(result.done).toBe(true);
   });
 
-
   it('Should run function and fail when payload is invalid', async () => {
     const innovation = scenario.users.johnInnovator.innovations.johnInnovation;
 
     try {
       await new AzureQueueTriggerBuilder()
-        .setRequestData({ innovationId: innovation.id, type: 'BATATA' })
+        .setRequestData({ innovationId: innovation.id, type: 'BAD_TYPE' })
         .call<{ done: boolean }>(azureFunction);
 
       fail();

--- a/apps/innovations/v1-innovation-update-index-listener/index.spec.ts
+++ b/apps/innovations/v1-innovation-update-index-listener/index.spec.ts
@@ -1,0 +1,51 @@
+import azureFunction from '.';
+
+import { AzureQueueTriggerBuilder, CompleteScenarioType, TestsHelper } from '@innovations/shared/tests';
+
+import { SearchService } from '../_services/search.service';
+import type { ElasticSearchEventUpdateTypes } from '@innovations/shared/decorators';
+import { BadRequestError, GenericErrorsEnum } from '@innovations/shared/errors';
+
+describe('v1-innovation-updated-index-listener suite', () => {
+  let testsHelper: TestsHelper;
+  let scenario: CompleteScenarioType;
+
+  beforeAll(async () => {
+    testsHelper = await new TestsHelper().init();
+    scenario = testsHelper.getCompleteScenario();
+  });
+  afterEach(async () => {
+    jest.restoreAllMocks();
+  });
+
+  it('Should run function and succeed', async () => {
+    const serviceSpy = jest.spyOn(SearchService.prototype, 'upsertDocument').mockResolvedValue();
+    const innovation = scenario.users.johnInnovator.innovations.johnInnovation;
+
+    const result = await new AzureQueueTriggerBuilder()
+      .setRequestData({
+        innovationId: innovation.id,
+        type: 'INNOVATION_UPDATE' as ElasticSearchEventUpdateTypes
+      })
+      .call<{ done: boolean }>(azureFunction);
+
+    expect(result).toBeDefined();
+    expect(serviceSpy).toHaveBeenCalledWith(innovation.id);
+    expect(result.done).toBe(true);
+  });
+
+
+  it('Should run function and fail when payload is invalid', async () => {
+    const innovation = scenario.users.johnInnovator.innovations.johnInnovation;
+
+    try {
+      await new AzureQueueTriggerBuilder()
+        .setRequestData({ innovationId: innovation.id, type: 'BATATA' })
+        .call<{ done: boolean }>(azureFunction);
+
+      fail();
+    } catch (error) {
+      expect(error).toEqual(new BadRequestError(GenericErrorsEnum.INVALID_PAYLOAD));
+    }
+  });
+});

--- a/apps/innovations/v1-innovation-update-index-listener/index.ts
+++ b/apps/innovations/v1-innovation-update-index-listener/index.ts
@@ -1,0 +1,29 @@
+import type { Context } from '@azure/functions';
+
+import { JoiHelper } from '@innovations/shared/helpers';
+import { container } from '../_config';
+import type { SearchService } from '../_services/search.service';
+import SYMBOLS from '../_services/symbols';
+import { EventMessageSchema, EventMessageType } from './validation.schemas';
+
+class V1InnovationUpdateIndexListener {
+  static async queueTrigger(context: Context, requestMessage: EventMessageType): Promise<void> {
+    const searchService = container.get<SearchService>(SYMBOLS.SearchService);
+
+    context.log.info('InnovationUpdateIndex LISTENER: ', JSON.stringify(requestMessage));
+
+    try {
+      const { data } = JoiHelper.Validate<EventMessageType>(EventMessageSchema, requestMessage);
+
+      await searchService.upsertDocument(data.innovationId);
+
+      context.res = { done: true };
+      return;
+    } catch (error) {
+      context.log.error('ERROR: Unexpected error parsing message: ', JSON.stringify(error));
+      throw error;
+    }
+  }
+}
+
+export default V1InnovationUpdateIndexListener.queueTrigger;

--- a/apps/innovations/v1-innovation-update-index-listener/validation.schemas.ts
+++ b/apps/innovations/v1-innovation-update-index-listener/validation.schemas.ts
@@ -1,0 +1,11 @@
+import { ElasticSearchEventUpdateMessageType, ElasticSearchEventUpdateTypes } from '@innovations/shared/decorators';
+import Joi from 'joi';
+
+export type EventMessageType = ElasticSearchEventUpdateMessageType;
+
+export const EventMessageSchema = Joi.object<EventMessageType>({
+  data: {
+    innovationId: Joi.string().guid().required(),
+    type: Joi.string().valid(...ElasticSearchEventUpdateTypes)
+  }
+});

--- a/libs/shared/decorators/es-document-update.decorator.ts
+++ b/libs/shared/decorators/es-document-update.decorator.ts
@@ -5,12 +5,7 @@ import { QueuesEnum } from '../services/integrations/storage-queue.service';
 import SHARED_SYMBOLS from '../services/symbols';
 import type { CustomContextType } from '../types';
 
-export const ElasticSearchEventUpdateTypes = [
-  'INNOVATION_UPDATE',
-  'ASSESSMENT_UPDATE',
-  'SUPPORT_UPDATE',
-  'SUGGESTION_UPDATE'
-] as const;
+export const ElasticSearchEventUpdateTypes = ['INNOVATION_UPDATE', 'ASSESSMENT_UPDATE', 'SUPPORT_UPDATE'] as const;
 export type ElasticSearchEventUpdateTypes = (typeof ElasticSearchEventUpdateTypes)[number];
 
 export type ElasticSearchEventUpdateMessageType = {

--- a/libs/shared/decorators/es-document-update.decorator.ts
+++ b/libs/shared/decorators/es-document-update.decorator.ts
@@ -1,0 +1,44 @@
+import type { HttpRequest } from '@azure/functions';
+import { container } from '../config/inversify.config';
+import type { StorageQueueService } from '../services';
+import { QueuesEnum } from '../services/integrations/storage-queue.service';
+import SHARED_SYMBOLS from '../services/symbols';
+import type { CustomContextType } from '../types';
+
+export const ElasticSearchEventUpdateTypes = [
+  'INNOVATION_UPDATE',
+  'ASSESSMENT_UPDATE',
+  'SUPPORT_UPDATE',
+  'SUGGESTION_UPDATE'
+] as const;
+export type ElasticSearchEventUpdateTypes = (typeof ElasticSearchEventUpdateTypes)[number];
+
+export type ElasticSearchEventUpdateMessageType = {
+  data: {
+    innovationId: string;
+    type: ElasticSearchEventUpdateTypes;
+  };
+};
+
+export function ElasticSearchDocumentUpdate(type: ElasticSearchEventUpdateTypes) {
+  return function (_target: any, _propertyKey: string, descriptor: PropertyDescriptor) {
+    const original = descriptor.value;
+
+    const storageService = container.get<StorageQueueService>(SHARED_SYMBOLS.StorageQueueService);
+
+    descriptor.value = async function (context: CustomContextType, request: HttpRequest) {
+      await original.apply(this, [context, request]);
+
+      if (context.res?.['status'] >= 400) {
+        return;
+      }
+
+      const innovationId =
+        request.params['innovationId'] ?? request.query['innovationId'] ?? request.body['innovationId'];
+
+      await storageService.sendMessage<ElasticSearchEventUpdateMessageType>(QueuesEnum.ELASTIC_SEARCH, {
+        data: { innovationId, type }
+      });
+    };
+  };
+}

--- a/libs/shared/decorators/index.ts
+++ b/libs/shared/decorators/index.ts
@@ -1,2 +1,3 @@
 export { Audit } from './audit.decorator';
 export { JwtDecoder } from './jwt-decoder.decorator';
+export * from './es-document-update.decorator';

--- a/libs/shared/services/integrations/elastic-search.service.ts
+++ b/libs/shared/services/integrations/elastic-search.service.ts
@@ -1,7 +1,7 @@
 import { Client } from '@elastic/elasticsearch';
 import type { IndicesCreateRequest } from '@elastic/elasticsearch/lib/api/types';
 import { inject, injectable } from 'inversify';
-import { ES_CONNECTION_CONFIG } from 'libs/shared/config/elastic-search.config';
+import { ES_CONNECTION_CONFIG} from '../../config/elastic-search.config';
 import SHARED_SYMBOLS from '../symbols';
 import type { LoggerService } from './logger.service';
 

--- a/libs/shared/services/integrations/storage-queue.service.ts
+++ b/libs/shared/services/integrations/storage-queue.service.ts
@@ -13,7 +13,8 @@ export enum QueuesEnum {
   EMAIL = 'email-send-queue',
   IDENTITY = 'identity-ops-queue',
   IN_APP = 'in-app-send-queue',
-  NOTIFICATION = 'notification-queue'
+  NOTIFICATION = 'notification-queue',
+  ELASTIC_SEARCH = 'elasticsearch-queue'
 }
 
 @injectable()


### PR DESCRIPTION
**Description**
This PR introduces several updates to ensure the ElasticSearch index for innovations remains up-to-date. This includes a scheduled reindexing task, decorators for endpoints affecting the index, and a listener for queue-based updates.

Contains:
- Cron job that runs daily at 3AM to recreate the ES index and ingest all documents, ensuring data is up-to-date.
- Created a reusable decorator for endpoints to trigger updates to the innovation index on ElasticSearch.
- Added decorators to endpoints that impact the ES index, streamlining the update process.
- Implemented a function that listens for queue messages to update innovations in real-time on the ES index.

The endpoints/actions that use the decorator are:
- Innovation Archive
- Assessment Assessor update
- Assessment Create
- Assessment Update
- Innovation Create
- Reassessment Request create
- Section Submit
- Section Update
- Shares Update
- Innovation Submit
- Support Change Accessors
- Support Create
- Support Organisation Suggestions
- Support Update
- Transfer Update

**Related tickets:**
- Closes [AB#169109](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/169109).
