### PR TITLE
Task/add email and suggestion filter

### DIFF
--- a/apps/innovations/_services/search.service.ts
+++ b/apps/innovations/_services/search.service.ts
@@ -392,7 +392,7 @@ export class SearchService extends BaseService {
     keyHealthInequalities: this.addGenericFilter('document.UNDERSTANDING_OF_NEEDS.keyHealthInequalities').bind(this),
     locations: this.addLocationFilter.bind(this),
     search: this.addSearchFilter.bind(this),
-    // suggestedOnly: this.addSuggestedOnlyFilter.bind(this),
+    suggestedOnly: this.addSuggestedOnlyFilter.bind(this),
     supportStatuses: this.addSupportFilter.bind(this)
   };
 
@@ -490,6 +490,20 @@ export class SearchService extends BaseService {
       });
     }
     builder.addFilter(orQuery(should));
+  }
+
+  private addSuggestedOnlyFilter(
+    domainContext: DomainContextType,
+    builder: ElasticSearchQueryBuilder,
+    value: boolean
+  ): void {
+    if (value && isAccessorDomainContextType(domainContext)) {
+      builder.addFilter(
+        nestedQuery('suggestions', {
+          term: { 'suggestions.suggestedUnitId': domainContext.organisation.organisationUnit.id }
+        })
+      );
+    }
   }
 
   private addSupportFilter(

--- a/apps/innovations/_services/search.service.ts
+++ b/apps/innovations/_services/search.service.ts
@@ -304,7 +304,7 @@ export class SearchService extends BaseService {
       item.engagingUnits?.map(unit => ({
         acronym: unit.acronym,
         assignedAccessors:
-          unit.assignedAccessors?.map(({ id }) => ({
+          unit.assignedAccessors?.map(({ userId: id }) => ({
             id,
             name: extra.users.get(id)?.displayName ?? null
           })) ?? null,
@@ -396,11 +396,24 @@ export class SearchService extends BaseService {
     supportStatuses: this.addSupportFilter.bind(this)
   };
 
-  // NOTE: Do we keep the search by email on admin?
-  private addSearchFilter(_domainContext: DomainContextType, builder: ElasticSearchQueryBuilder, search: string): void {
-    const fields = priorities.reverse().flatMap((priority, i) => priority.map(p => `${p}^${i + 1}`));
-
+  private async addSearchFilter(
+    domainContext: DomainContextType,
+    builder: ElasticSearchQueryBuilder,
+    search: string
+  ): Promise<void> {
     if (search) {
+      // Admins can search by email (full match search)
+      const targetUser =
+        domainContext.currentRole.role === ServiceRoleEnum.ADMIN && search.match(/^\S+@\S+$/)
+          ? await this.domainService.users.getUserByEmail(search)
+          : null;
+      if (targetUser?.length && targetUser[0]) {
+        builder.addMust({ term: { 'owner.id': targetUser[0].id } });
+        return;
+      }
+
+      // If is not an email we do the normal search
+      const fields = priorities.reverse().flatMap((priority, i) => priority.map(p => `${p}^${i + 1}`));
       const searchQuery = {
         query_string: {
           query: this.escapeElasticSpecialChars(search),
@@ -557,7 +570,7 @@ export class SearchService extends BaseService {
           doc.owner?.id,
           doc.supports?.[0]?.updatedBy,
           doc.assessment?.assignedToId,
-          ...(doc.engagingUnits?.flatMap(u => (u.assignedAccessors ?? []).map(a => a.id)) ?? [])
+          ...(doc.engagingUnits?.flatMap(u => (u.assignedAccessors ?? []).map(a => a.userId)) ?? [])
         ]
           .filter(isString)
           .forEach(u => usersSet.add(u));

--- a/libs/shared/schemas/innovation-record/202304/elastic-search.schema.ts
+++ b/libs/shared/schemas/innovation-record/202304/elastic-search.schema.ts
@@ -11,6 +11,7 @@ import type { DocumentType } from '../index';
 export type ElasticSearchDocumentType202304 = {
   id: string;
   status: InnovationStatusEnum;
+  rawStatus: InnovationStatusEnum;
   archivedStatus: InnovationStatusEnum | null;
   statusUpdatedAt: Date;
   groupedStatus: InnovationGroupedStatusEnum;
@@ -24,7 +25,7 @@ export type ElasticSearchDocumentType202304 = {
     unitId: string;
     name: string;
     acronym: string;
-    assignedAccessors?: { roleId: string; id: string; identityId: string }[];
+    assignedAccessors?: { roleId: string; userId: string; identityId: string }[];
   }[];
   shares?: string[];
   supports?: {
@@ -114,7 +115,7 @@ export const ElasticSearchSchema202304: CreateIndexParams = {
             type: 'nested',
             properties: {
               roleId: { type: 'keyword' },
-              id: { type: 'keyword' },
+              userId: { type: 'keyword' },
               identityId: { type: 'keyword' }
             }
           }


### PR DESCRIPTION
**Description:**
This PR adds two features:
- Admin can search by email on the new elastic search endpoint.
- QA/As can filter by suggestedOnly.

**Related tickets:**
- Closes [AB#169392](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/169392).
- Closes [AB#169393](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/169393).