### PR TITLE
fix: innovation creation didnt trigger reindex

### DIFF
--- a/apps/innovations/v1-innovation-archive/index.ts
+++ b/apps/innovations/v1-innovation-archive/index.ts
@@ -18,7 +18,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 class V1InnovationPause {
   @JwtDecoder()
   @Audit({ action: ActionEnum.UPDATE, target: TargetEnum.INNOVATION, identifierParam: 'innovationId' })
-  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'INNOVATION_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationsService = container.get<InnovationsService>(SYMBOLS.InnovationsService);

--- a/apps/innovations/v1-innovation-assessment-assessor-update/index.ts
+++ b/apps/innovations/v1-innovation-assessment-assessor-update/index.ts
@@ -18,7 +18,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 
 class V1InnovationAssessmentAssessorUpdate {
   @JwtDecoder()
-  @ElasticSearchDocumentUpdate('ASSESSMENT_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'ASSESSMENT_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationAssessmentsService = container.get<InnovationAssessmentsService>(

--- a/apps/innovations/v1-innovation-assessment-create/index.ts
+++ b/apps/innovations/v1-innovation-assessment-create/index.ts
@@ -23,7 +23,7 @@ class CreateInnovationAssessment {
     target: TargetEnum.ASSESSMENT,
     identifierResponseField: 'id'
   })
-  @ElasticSearchDocumentUpdate('ASSESSMENT_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'ASSESSMENT_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationAssessmentsService = container.get<InnovationAssessmentsService>(

--- a/apps/innovations/v1-innovation-assessment-update/index.ts
+++ b/apps/innovations/v1-innovation-assessment-update/index.ts
@@ -23,7 +23,7 @@ class V1InnovationAssessmentUpdate {
     target: TargetEnum.ASSESSMENT,
     identifierParam: 'assessmentId'
   })
-  @ElasticSearchDocumentUpdate('ASSESSMENT_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'ASSESSMENT_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationAssessmentsService = container.get<InnovationAssessmentsService>(

--- a/apps/innovations/v1-innovation-create/index.ts
+++ b/apps/innovations/v1-innovation-create/index.ts
@@ -22,7 +22,7 @@ class V1InnovationCreate {
     identifierResponseField: 'id',
     target: TargetEnum.INNOVATION
   })
-  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'INNOVATION_UPDATE', identifierResponseField: 'id' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationService = container.get<InnovationsService>(SYMBOLS.InnovationsService);

--- a/apps/innovations/v1-innovation-reassessment-request-create/index.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/index.ts
@@ -17,7 +17,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 
 class V1InnovationReassessmentRequestCreate {
   @JwtDecoder()
-  @ElasticSearchDocumentUpdate('ASSESSMENT_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'ASSESSMENT_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationAssessmentsService = container.get<InnovationAssessmentsService>(

--- a/apps/innovations/v1-innovation-section-submit/index.ts
+++ b/apps/innovations/v1-innovation-section-submit/index.ts
@@ -16,7 +16,7 @@ import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationSectionSubmit {
   @JwtDecoder()
-  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'INNOVATION_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationSectionsService = container.get<InnovationSectionsService>(SYMBOLS.InnovationSectionsService);

--- a/apps/innovations/v1-innovation-section-update/index.spec.ts
+++ b/apps/innovations/v1-innovation-section-update/index.spec.ts
@@ -14,8 +14,7 @@ jest.mock('@innovations/shared/decorators', () => ({
   }),
   Audit: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
     return descriptor;
-  }),
-  ElasticSearchDocumentUpdate: jest.fn(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor)
+  })
 }));
 
 const testsHelper = new TestsHelper();

--- a/apps/innovations/v1-innovation-section-update/index.ts
+++ b/apps/innovations/v1-innovation-section-update/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
-import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
+import { JwtDecoder } from '@innovations/shared/decorators';
 import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
 import { CurrentDocumentSchemaMap } from '@innovations/shared/schemas/innovation-record';
 import type { AuthorizationService } from '@innovations/shared/services';
@@ -17,7 +17,6 @@ import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationSectionUpdate {
   @JwtDecoder()
-  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationSectionsService = container.get<InnovationSectionsService>(SYMBOLS.InnovationSectionsService);

--- a/apps/innovations/v1-innovation-shares-update/index.ts
+++ b/apps/innovations/v1-innovation-shares-update/index.ts
@@ -16,7 +16,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 
 class V1InnovationSharesUpdate {
   @JwtDecoder()
-  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'INNOVATION_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationsService = container.get<InnovationsService>(SYMBOLS.InnovationsService);

--- a/apps/innovations/v1-innovation-submit/index.ts
+++ b/apps/innovations/v1-innovation-submit/index.ts
@@ -22,7 +22,7 @@ class V1InnovationSubmit {
     target: TargetEnum.INNOVATION,
     identifierParam: 'innovationId'
   })
-  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'INNOVATION_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationsService = container.get<InnovationsService>(SYMBOLS.InnovationsService);

--- a/apps/innovations/v1-innovation-support-change-accessors/index.ts
+++ b/apps/innovations/v1-innovation-support-change-accessors/index.ts
@@ -16,7 +16,7 @@ import { BodySchema, ParamsSchema, type BodyType, type ParamsType } from './vali
 
 class V1InnovationSupportUpdate {
   @JwtDecoder()
-  @ElasticSearchDocumentUpdate('SUPPORT_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'SUPPORT_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationSupportsService = container.get<InnovationSupportsService>(SYMBOLS.InnovationSupportsService);

--- a/apps/innovations/v1-innovation-support-create/index.ts
+++ b/apps/innovations/v1-innovation-support-create/index.ts
@@ -17,7 +17,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 
 class V1InnovationSupportCreate {
   @JwtDecoder()
-  @ElasticSearchDocumentUpdate('SUPPORT_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'SUPPORT_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationSupportsService = container.get<InnovationSupportsService>(SYMBOLS.InnovationSupportsService);

--- a/apps/innovations/v1-innovation-support-logs-create/index.ts
+++ b/apps/innovations/v1-innovation-support-logs-create/index.ts
@@ -19,7 +19,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 // OPTIMIZE CREATE INNOVATION ORGANISATIONS SUGGESTIONS
 class V1InnovationsSupportLogCreate {
   @JwtDecoder()
-  @ElasticSearchDocumentUpdate('SUPPORT_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'SUPPORT_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationSupportsService = container.get<InnovationSupportsService>(SYMBOLS.InnovationSupportsService);

--- a/apps/innovations/v1-innovation-support-update/index.ts
+++ b/apps/innovations/v1-innovation-support-update/index.ts
@@ -17,7 +17,7 @@ import { BodySchema, ParamsSchema, type BodyType, type ParamsType } from './vali
 
 class V1InnovationSupportUpdate {
   @JwtDecoder()
-  @ElasticSearchDocumentUpdate('SUPPORT_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'SUPPORT_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const innovationSupportsService = container.get<InnovationSupportsService>(SYMBOLS.InnovationSupportsService);

--- a/apps/innovations/v1-innovation-transfer-update/index.ts
+++ b/apps/innovations/v1-innovation-transfer-update/index.ts
@@ -16,7 +16,7 @@ import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.sch
 
 class V1InnovationTransferUpdate {
   @JwtDecoder()
-  @ElasticSearchDocumentUpdate('INNOVATION_UPDATE')
+  @ElasticSearchDocumentUpdate({ type: 'INNOVATION_UPDATE' })
   static async httpTrigger(context: CustomContextType, request: HttpRequest): Promise<void> {
     const authorizationService = container.get<AuthorizationService>(SHARED_SYMBOLS.AuthorizationService);
     const transferService = container.get<InnovationTransferService>(SYMBOLS.InnovationTransferService);

--- a/libs/shared/decorators/es-document-update.decorator.ts
+++ b/libs/shared/decorators/es-document-update.decorator.ts
@@ -15,7 +15,9 @@ export type ElasticSearchEventUpdateMessageType = {
   };
 };
 
-export function ElasticSearchDocumentUpdate(type: ElasticSearchEventUpdateTypes) {
+type DocumentUpdateParams = { type: ElasticSearchEventUpdateTypes, identifierResponseField?: string };
+
+export function ElasticSearchDocumentUpdate(options: DocumentUpdateParams) {
   return function (_target: any, _propertyKey: string, descriptor: PropertyDescriptor) {
     const original = descriptor.value;
 
@@ -28,11 +30,15 @@ export function ElasticSearchDocumentUpdate(type: ElasticSearchEventUpdateTypes)
         return;
       }
 
-      const innovationId =
+      let innovationId =
         request.params['innovationId'] ?? request.query['innovationId'] ?? request.body['innovationId'];
 
+      if ('identifierResponseField' in options && options.identifierResponseField) {
+        innovationId = context.res?.['body'][options.identifierResponseField];
+      }
+
       await storageService.sendMessage<ElasticSearchEventUpdateMessageType>(QueuesEnum.ELASTIC_SEARCH, {
-        data: { innovationId, type }
+        data: { innovationId, type: options.type }
       });
     };
   };


### PR DESCRIPTION
**Description:**
- Decorator now accepts a param to get the info from the body.
- Removed the section-update decorator since was not needed.