### PR TITLE
Task/extract filter keywords to outside document

### DIFF
--- a/apps/innovations/_services/search.service.ts
+++ b/apps/innovations/_services/search.service.ts
@@ -11,7 +11,6 @@ import { InnovationStatusEnum, InnovationSupportStatusEnum, ServiceRoleEnum } fr
 import { GenericErrorsEnum, NotImplementedError } from '@innovations/shared/errors';
 import type { PaginationQueryParamsType } from '@innovations/shared/helpers';
 import type { CurrentElasticSearchDocumentType } from '@innovations/shared/schemas/innovation-record';
-import { translateValue } from '@innovations/shared/schemas/innovation-record/202304/translation.helper';
 import type { DomainService, DomainUsersService, ElasticSearchService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import {
@@ -183,11 +182,10 @@ export class SearchService extends BaseService {
               message: 'Sort by name is not allowed'
             });
 
-          // add here the ones that have nested keyword (since sort only allows sort by keyword)
+          // add here the ones that are from the document and are in the "filters" object
           case 'countryName':
           case 'name': {
-            const translation = translations.get(key)?.join('.');
-            sort.push({ [`${translation ?? key}.keyword`]: { order } });
+            sort.push({ [`filters.${key}`]: { order } });
             break;
           }
 
@@ -220,6 +218,7 @@ export class SearchService extends BaseService {
     });
     searchQuery.addPagination({ from: params.pagination.skip, size: params.pagination.take, sort });
 
+    console.log(JSON.stringify(searchQuery.build()));
     const response = await this.esService.client.search<CurrentElasticSearchDocumentType>(searchQuery.build());
 
     const handlerMaps: {
@@ -238,13 +237,7 @@ export class SearchService extends BaseService {
       data: response.hits.hits.map(hit => {
         const doc = hit._source!;
 
-        // Filter out keys that end with .keyword from hit.highlight
-        const filteredEntries = Object.entries(hit.highlight || {}).filter(([key]) => !key.endsWith('.keyword'));
-
-        // If filteredEntries is empty, assign null to highlights; otherwise, create an object from filteredEntries
-        const highlights = filteredEntries.length > 0 ? Object.fromEntries(filteredEntries) : undefined;
-
-        const res = { highlights } as any;
+        const res = { highlights: hit.highlight } as any;
         for (const [key, value] of Object.entries(fieldGroups)) {
           if (key in this.displayHandlers) {
             const handler = this.displayHandlers[key as keyof typeof this.displayHandlers];
@@ -385,17 +378,17 @@ export class SearchService extends BaseService {
     ) => void | Promise<void>;
   } = {
     assignedToMe: this.addAssignedToMeFilter.bind(this),
-    careSettings: this.addGenericFilter('document.INNOVATION_DESCRIPTION.careSettings').bind(this),
-    categories: this.addGenericFilter('document.INNOVATION_DESCRIPTION.categories').bind(this),
+    careSettings: this.addGenericFilter('filters.careSettings').bind(this),
+    categories: this.addGenericFilter('filters.categories').bind(this),
     dateFilters: this.addDateFilters.bind(this),
-    diseasesAndConditions: this.addGenericFilter('document.UNDERSTANDING_OF_NEEDS.diseasesConditionsImpact').bind(this),
+    diseasesAndConditions: this.addGenericFilter('filters.diseasesAndConditions').bind(this),
     engagingOrganisations: this.addGenericFilter('engagingOrganisations', { fieldSelector: 'organisationId' }).bind(
       this
     ),
     engagingUnits: this.addGenericFilter('engagingUnits', { fieldSelector: 'unitId' }).bind(this),
     groupedStatuses: this.addGenericFilter('groupedStatus').bind(this),
-    involvedAACProgrammes: this.addGenericFilter('document.INNOVATION_DESCRIPTION.involvedAACProgrammes').bind(this),
-    keyHealthInequalities: this.addGenericFilter('document.UNDERSTANDING_OF_NEEDS.keyHealthInequalities').bind(this),
+    involvedAACProgrammes: this.addGenericFilter('filters.involvedAACProgrammes').bind(this),
+    keyHealthInequalities: this.addGenericFilter('filters.keyHealthInequalities').bind(this),
     locations: this.addLocationFilter.bind(this),
     search: this.addSearchFilter.bind(this),
     suggestedOnly: this.addSuggestedOnlyFilter.bind(this),
@@ -474,27 +467,18 @@ export class SearchService extends BaseService {
     }
   }
 
-  // Generic filter assumes that the field (from document) is a keyword in elasticsearch as filters won't work otherwise
+  // All filters need to be of type keyword.
   private addGenericFilter(
     filterKey: string,
     options?: { fieldSelector: string } // fieldSelector == nested
   ): (_domainContext: DomainContextType, builder: ElasticSearchQueryBuilder, value: string | string[]) => void {
     return (_domainContext: DomainContextType, builder: ElasticSearchQueryBuilder, value: string | string[]) => {
       const type = isArray(value) ? 'terms' : 'term';
-      let translatedValues = typeof value === 'string' ? [value] : value;
 
-      const [head, ...tail] = (options?.fieldSelector ? `${filterKey}.${options.fieldSelector}` : filterKey).split('.');
-      if (head === 'document' && tail) {
-        translatedValues = translatedValues.map(v => translateValue(tail, v));
-      }
-
-      const suffix = head === 'document' ? '.keyword' : '';
       if (options?.fieldSelector) {
-        builder.addFilter(
-          nestedQuery(filterKey, { [type]: { [`${filterKey}.${options.fieldSelector}${suffix}`]: translatedValues } })
-        );
+        builder.addFilter(nestedQuery(filterKey, { [type]: { [`${filterKey}.${options.fieldSelector}`]: value } }));
       } else {
-        builder.addFilter({ [type]: { [`${filterKey}${suffix}`]: translatedValues } });
+        builder.addFilter({ [type]: { [`${filterKey}`]: value } });
       }
     };
   }
@@ -517,16 +501,14 @@ export class SearchService extends BaseService {
 
         should.push(
           boolQuery({
-            mustNot: { terms: { 'document.INNOVATION_DESCRIPTION.countryName.keyword': predefinedLocations } }
+            mustNot: { terms: { 'filters.countryName': predefinedLocations } }
           })
         );
       }
 
       should.push({
         terms: {
-          'document.INNOVATION_DESCRIPTION.countryName.keyword': locations.filter(
-            l => l !== InnovationLocationEnum['Based outside UK']
-          )
+          'filters.countryName': locations.filter(l => l !== InnovationLocationEnum['Based outside UK'])
         }
       });
     }

--- a/libs/shared/schemas/innovation-record/202304/elastic-search.schema.ts
+++ b/libs/shared/schemas/innovation-record/202304/elastic-search.schema.ts
@@ -6,7 +6,7 @@ import type {
   UserStatusEnum
 } from '../../../enums';
 import type { CreateIndexParams } from '../../../services/integrations/elastic-search.service';
-import type { DocumentType } from '../index';
+import type { CurrentDocumentType, DocumentType } from '../index';
 
 export type ElasticSearchDocumentType202304 = {
   id: string;
@@ -46,11 +46,18 @@ export type ElasticSearchDocumentType202304 = {
     suggestedUnitId: string;
     suggestedBy: string[];
   }[];
+  filters: {
+    name: CurrentDocumentType['INNOVATION_DESCRIPTION']['name'];
+    countryName: CurrentDocumentType['INNOVATION_DESCRIPTION']['countryName'];
+    categories: CurrentDocumentType['INNOVATION_DESCRIPTION']['categories'];
+    careSettings: CurrentDocumentType['INNOVATION_DESCRIPTION']['careSettings'];
+    involvedAACProgrammes: CurrentDocumentType['INNOVATION_DESCRIPTION']['careSettings'];
+    diseasesAndConditions: CurrentDocumentType['UNDERSTANDING_OF_NEEDS']['diseasesConditionsImpact'];
+    keyHealthInequalities: CurrentDocumentType['UNDERSTANDING_OF_NEEDS']['keyHealthInequalities'];
+  };
 };
-const TextWithNestedKeywordType: MappingProperty = {
-  type: 'text',
-  fields: { keyword: { type: 'keyword', normalizer: 'lowercase' } }
-};
+
+const KeywordType: MappingProperty = { type: 'keyword', normalizer: 'lowercase' };
 
 export const ElasticSearchSchema202304: CreateIndexParams = {
   settings: {
@@ -140,70 +147,82 @@ export const ElasticSearchSchema202304: CreateIndexParams = {
         }
       },
 
+      filters: {
+        properties: {
+          name: KeywordType,
+          countryName: KeywordType,
+          categories: KeywordType,
+          careSettings: KeywordType,
+          involvedAACProgrammes: KeywordType,
+          diseasesAndConditions: KeywordType,
+          keyHealthInequalities: KeywordType
+        }
+      },
+
       document: {
         properties: {
           version: { type: 'constant_keyword' },
           INNOVATION_DESCRIPTION: {
             properties: {
-              name: TextWithNestedKeywordType,
+              name: { type: 'text' },
               description: { type: 'text' },
               postcode: { type: 'text' },
-              countryName: TextWithNestedKeywordType,
+              countryName: { type: 'text' },
               website: { type: 'text' },
-              categories: TextWithNestedKeywordType,
+              categories: { type: 'text' },
               otherCategoryDescription: { type: 'text' },
-              mainCategory: TextWithNestedKeywordType,
-              areas: TextWithNestedKeywordType,
-              careSettings: TextWithNestedKeywordType,
+              mainCategory: { type: 'text' },
+              areas: { type: 'text' },
+              careSettings: { type: 'text' },
               otherCareSetting: { type: 'text' },
-              mainPurpose: TextWithNestedKeywordType,
+              mainPurpose: { type: 'text' },
               supportDescription: { type: 'text' },
               currentlyReceivingSupport: { type: 'text' },
-              involvedAACProgrammes: TextWithNestedKeywordType
+              involvedAACProgrammes: { type: 'text' }
             }
           },
           UNDERSTANDING_OF_NEEDS: {
             properties: {
               problemsTackled: { type: 'text' },
               howInnovationWork: { type: 'text' },
-              benefitsOrImpact: TextWithNestedKeywordType,
-              impactDiseaseCondition: TextWithNestedKeywordType,
-              diseasesConditionsImpact: TextWithNestedKeywordType,
-              estimatedCarbonReductionSavings: TextWithNestedKeywordType,
+              benefitsOrImpact: { type: 'text' },
+              impactDiseaseCondition: { type: 'text' },
+              diseasesConditionsImpact: { type: 'text' },
+              estimatedCarbonReductionSavings: { type: 'text' },
               estimatedCarbonReductionSavingsDescription: { type: 'text' },
-              carbonReductionPlan: TextWithNestedKeywordType,
-              keyHealthInequalities: TextWithNestedKeywordType,
-              completedHealthInequalitiesImpactAssessment: TextWithNestedKeywordType,
-              hasProductServiceOrPrototype: TextWithNestedKeywordType
+              carbonReductionPlan: { type: 'text' },
+              keyHealthInequalities: { type: 'text' },
+              completedHealthInequalitiesImpactAssessment: { type: 'text' },
+              hasProductServiceOrPrototype: { type: 'text' }
             }
           },
           EVIDENCE_OF_EFFECTIVENESS: {
             properties: {
-              hasEvidence: TextWithNestedKeywordType,
-              currentlyCollectingEvidence: TextWithNestedKeywordType,
+              hasEvidence: { type: 'text' },
+              currentlyCollectingEvidence: { type: 'text' },
               summaryOngoingEvidenceGathering: { type: 'text' },
-              needsSupportAnyArea: TextWithNestedKeywordType
+              needsSupportAnyArea: { type: 'text' }
             }
           },
           MARKET_RESEARCH: {
             properties: {
-              hasMarketResearch: TextWithNestedKeywordType,
+              hasMarketResearch: { type: 'text' },
               marketResearch: { type: 'text' },
-              optionBestDescribesInnovation: TextWithNestedKeywordType,
+              optionBestDescribesInnovation: { type: 'text' },
               whatCompetitorsAlternativesExist: { type: 'text' }
             }
           },
           CURRENT_CARE_PATHWAY: {
             properties: {
-              innovationPathwayKnowledge: TextWithNestedKeywordType,
+              innovationPathwayKnowledge: { type: 'text' },
               potentialPathway: { type: 'text' }
             }
           },
           TESTING_WITH_USERS: {
             properties: {
-              involvedUsersDesignProcess: TextWithNestedKeywordType,
-              testedWithIntendedUsers: TextWithNestedKeywordType,
-              intendedUserGroupsEngaged: TextWithNestedKeywordType,
+              involvedUsersDesignProcess: { type: 'text' },
+              testedWithIntendedUsers: { type: 'text' },
+              intendedUserGroupsEngaged: { type: 'text' },
               otherIntendedUserGroupsEngaged: { type: 'text' },
               userTests: {
                 type: 'nested',
@@ -216,12 +235,12 @@ export const ElasticSearchSchema202304: CreateIndexParams = {
           },
           REGULATIONS_AND_STANDARDS: {
             properties: {
-              hasRegulationKnowledge: TextWithNestedKeywordType,
+              hasRegulationKnowledge: { type: 'text' },
               standards: {
                 type: 'nested',
                 properties: {
-                  type: TextWithNestedKeywordType,
-                  hasMet: TextWithNestedKeywordType
+                  type: { type: 'text' },
+                  hasMet: { type: 'text' }
                 }
               },
               otherRegulationDescription: { type: 'text' }
@@ -229,50 +248,50 @@ export const ElasticSearchSchema202304: CreateIndexParams = {
           },
           INTELLECTUAL_PROPERTY: {
             properties: {
-              hasPatents: TextWithNestedKeywordType,
+              hasPatents: { type: 'text' },
               patentNumbers: { type: 'text' },
-              hasOtherIntellectual: TextWithNestedKeywordType,
+              hasOtherIntellectual: { type: 'text' },
               otherIntellectual: { type: 'text' }
             }
           },
           REVENUE_MODEL: {
             properties: {
-              hasRevenueModel: TextWithNestedKeywordType,
-              revenues: TextWithNestedKeywordType,
+              hasRevenueModel: { type: 'text' },
+              revenues: { type: 'text' },
               otherRevenueDescription: { type: 'text' },
               payingOrganisations: { type: 'text' },
               benefittingOrganisations: { type: 'text' },
-              hasFunding: TextWithNestedKeywordType,
+              hasFunding: { type: 'text' },
               fundingDescription: { type: 'text' }
             }
           },
           COST_OF_INNOVATION: {
             properties: {
-              hasCostKnowledge: TextWithNestedKeywordType,
+              hasCostKnowledge: { type: 'text' },
               costDescription: { type: 'text' },
-              patientsRange: TextWithNestedKeywordType,
+              patientsRange: { type: 'text' },
               eligibilityCriteria: { type: 'text' },
               sellExpectations: { type: 'text' },
               usageExpectations: { type: 'text' },
-              costComparison: TextWithNestedKeywordType
+              costComparison: { type: 'text' }
             }
           },
           DEPLOYMENT: {
             properties: {
-              hasDeployPlan: TextWithNestedKeywordType,
-              isDeployed: TextWithNestedKeywordType,
+              hasDeployPlan: { type: 'text' },
+              isDeployed: { type: 'text' },
               deploymentPlans: { type: 'text' },
               commercialBasis: { type: 'text' },
               organisationDeploymentAffect: { type: 'text' },
-              hasResourcesToScale: TextWithNestedKeywordType
+              hasResourcesToScale: { type: 'text' }
             }
           },
           evidences: {
             type: 'nested',
             properties: {
               id: { type: 'keyword' },
-              evidenceSubmitType: TextWithNestedKeywordType,
-              evidenceType: TextWithNestedKeywordType,
+              evidenceSubmitType: { type: 'text' },
+              evidenceType: { type: 'text' },
               description: { type: 'text' },
               summary: { type: 'text' }
             }

--- a/libs/shared/services/domain/domain-innovations.service.ts
+++ b/libs/shared/services/domain/domain-innovations.service.ts
@@ -991,25 +991,39 @@ export class DomainInnovationsService {
 
     const innovations = await this.sqlConnection.query(sql, innovationId ? [innovationId] : []);
 
-    const parsed: CurrentElasticSearchDocumentType[] = innovations.map((innovation: any) => ({
-      id: innovation.id,
-      status: innovation.status,
-      archivedStatus: innovation.archivedStatus,
-      rawStatus: innovation.rawStatus,
-      statusUpdatedAt: innovation.statusUpdatedAt,
-      groupedStatus: innovation.groupedStatus,
-      submittedAt: innovation.submittedAt,
-      updatedAt: innovation.updatedAt,
-      lastAssessmentRequestAt: innovation.lastAssessmentRequestAt,
-      document: translate(cleanup(JSON.parse(innovation.document ?? {}))),
-      ...(innovation.owner && { owner: JSON.parse(innovation.owner) }),
-      ...(innovation.engagingOrganisations && { engagingOrganisations: JSON.parse(innovation.engagingOrganisations) }),
-      ...(innovation.engagingUnits && { engagingUnits: JSON.parse(innovation.engagingUnits) }),
-      ...(innovation.shares && { shares: JSON.parse(innovation.shares) }),
-      ...(innovation.supports && { supports: JSON.parse(innovation.supports) }),
-      ...(innovation.assessment && { assessment: JSON.parse(innovation.assessment) }),
-      ...(innovation.suggestions && { suggestions: JSON.parse(innovation.suggestions) })
-    }));
+    const parsed: CurrentElasticSearchDocumentType[] = innovations.map((innovation: any) => {
+      const document = cleanup(JSON.parse(innovation.document ?? {}));
+      return {
+        id: innovation.id,
+        status: innovation.status,
+        archivedStatus: innovation.archivedStatus,
+        rawStatus: innovation.rawStatus,
+        statusUpdatedAt: innovation.statusUpdatedAt,
+        groupedStatus: innovation.groupedStatus,
+        submittedAt: innovation.submittedAt,
+        updatedAt: innovation.updatedAt,
+        lastAssessmentRequestAt: innovation.lastAssessmentRequestAt,
+        document: translate(document),
+        ...(innovation.owner && { owner: JSON.parse(innovation.owner) }),
+        ...(innovation.engagingOrganisations && {
+          engagingOrganisations: JSON.parse(innovation.engagingOrganisations)
+        }),
+        ...(innovation.engagingUnits && { engagingUnits: JSON.parse(innovation.engagingUnits) }),
+        ...(innovation.shares && { shares: JSON.parse(innovation.shares) }),
+        ...(innovation.supports && { supports: JSON.parse(innovation.supports) }),
+        ...(innovation.assessment && { assessment: JSON.parse(innovation.assessment) }),
+        ...(innovation.suggestions && { suggestions: JSON.parse(innovation.suggestions) }),
+        filters: {
+          name: document.INNOVATION_DESCRIPTION.name,
+          countryName: document.INNOVATION_DESCRIPTION.countryName,
+          categories: document.INNOVATION_DESCRIPTION.categories,
+          careSettings: document.INNOVATION_DESCRIPTION.careSettings,
+          involvedAACProgrammes: document.INNOVATION_DESCRIPTION.involvedAACProgrammes,
+          diseasesAndConditions: document.UNDERSTANDING_OF_NEEDS.diseasesConditionsImpact,
+          keyHealthInequalities: document.UNDERSTANDING_OF_NEEDS.keyHealthInequalities
+        }
+      };
+    });
 
     return innovationId ? parsed[0] : parsed;
   }

--- a/libs/shared/services/storage/redis.service.ts
+++ b/libs/shared/services/storage/redis.service.ts
@@ -25,12 +25,10 @@ export class RedisService {
 
   async addToSet(key: Sets, members: string | string[]): Promise<void> {
     const values = isArray(members) ? members : [members];
-    for (const value of values) {
-      try {
-        await this.redis.sAdd(key, value);
-      } catch (err) {
-        this.logger.error(`Error adding keys ${value} in set ${key}`, err);
-      }
+    try {
+      await this.redis.sAdd(key, values);
+    } catch (err) {
+      this.logger.error(`Error adding keys ${values} in set ${key}`, err);
     }
   }
 


### PR DESCRIPTION
**Description:**
- Removed the keywords from the document, and moved the ones that are need for filters to another structure called `filters`. This way we will not have repeated matches on the plain text and keyword, and, we will not have unwanted matches on keywords (e.g., Not yet).
- Fixed the problem where the same query was having different orders (this is due to the `reverse` was mutating the array and the boosts were being reversed every call).
- Improve the add to redis set (now adds multiple members on the same call).