### PR TITLE
notify-me: support for suggested organisations status update

### DIFF
--- a/apps/innovations/_services/innovation-supports.service.spec.ts
+++ b/apps/innovations/_services/innovation-supports.service.spec.ts
@@ -281,12 +281,13 @@ describe('Innovations / _services / innovation-supports suite', () => {
     it('should send the notifyMe', async () => {
       const context = DTOsHelper.getUserRequestContext(scenario.users.bartQualifyingAccessor);
       const innovation = scenario.users.adamInnovator.innovations.adamInnovation.id;
+      const message = randText({ charCount: 10 });
       await sut.createInnovationSupport(
         context,
         innovation,
         {
           status: InnovationSupportStatusEnum.ENGAGING,
-          message: randText({ charCount: 10 }),
+          message,
           accessors: [
             {
               id: scenario.users.jamieMadroxAccessor.id,
@@ -299,7 +300,8 @@ describe('Innovations / _services / innovation-supports suite', () => {
 
       expect(notifierSendNotifyMeSpy).toHaveBeenCalledWith(context, innovation, 'SUPPORT_UPDATED', {
         status: InnovationSupportStatusEnum.ENGAGING,
-        units: context.organisation?.organisationUnit?.id
+        units: context.organisation?.organisationUnit?.id,
+        message
       });
     });
 
@@ -886,17 +888,19 @@ describe('Innovations / _services / innovation-supports suite', () => {
 
     it('should send a notifyMe when status is changed', async () => {
       const context = DTOsHelper.getUserRequestContext(scenario.users.aliceQualifyingAccessor);
+      const message = randText({ charCount: 10 });
       await sut.updateInnovationSupport(
         context,
         innovation.id,
         innovation.supports.supportByHealthOrgUnit.id,
-        { status: InnovationSupportStatusEnum.CLOSED, message: randText({ charCount: 10 }) },
+        { status: InnovationSupportStatusEnum.CLOSED, message },
         em
       );
 
       expect(notifierSendNotifyMeSpy).toHaveBeenCalledWith(context, innovation.id, 'SUPPORT_UPDATED', {
         status: InnovationSupportStatusEnum.CLOSED,
-        units: context.organisation?.organisationUnit?.id
+        units: context.organisation?.organisationUnit?.id,
+        message
       });
     });
 

--- a/apps/innovations/_services/innovation-supports.service.ts
+++ b/apps/innovations/_services/innovation-supports.service.ts
@@ -469,7 +469,8 @@ export class InnovationSupportsService extends BaseService {
 
     await this.notifierService.sendNotifyMe(domainContext, innovationId, 'SUPPORT_UPDATED', {
       status: data.status,
-      units: organisationUnitId
+      units: organisationUnitId,
+      message: data.message
     });
 
     return result;
@@ -725,7 +726,8 @@ export class InnovationSupportsService extends BaseService {
 
     await this.notifierService.sendNotifyMe(domainContext, innovationId, 'SUPPORT_UPDATED', {
       status: data.status,
-      units: dbSupport.organisationUnit.id
+      units: dbSupport.organisationUnit.id,
+      message: data.message
     });
 
     return result;

--- a/apps/notifications/_config/emails.config.ts
+++ b/apps/notifications/_config/emails.config.ts
@@ -92,10 +92,11 @@ export const EmailTemplates = {
   CA02_ACCOUNT_CREATION_OF_COLLABORATOR: '7dbfa868-126c-4eee-828c-be6f8831342c',
 
   // NOTIFY ME
-  SUPPORT_UPDATED: 'c24edce0-69cb-463d-bd65-d05304847dec',
-  PROGRESS_UPDATE_CREATED: '27f2a823-b8e4-4861-a208-8a5834c93516',
   INNOVATION_RECORD_UPDATED: '2dce9787-9a38-4d51-9e33-6ddf7683397d',
-  REMINDER: 'e8c593a4-2341-4177-89b5-b92aaaeac595'
+  PROGRESS_UPDATE_CREATED: '27f2a823-b8e4-4861-a208-8a5834c93516',
+  REMINDER: 'e8c593a4-2341-4177-89b5-b92aaaeac595',
+  SUGGESTED_SUPPORT_UPDATED: '6d442fc5-2056-4515-9afc-e32a790ef231',
+  SUPPORT_UPDATED: 'c24edce0-69cb-463d-bd65-d05304847dec'
 } as const;
 export type EmailTemplates = typeof EmailTemplates;
 
@@ -471,5 +472,12 @@ export type EmailTemplatesType = {
     innovation: string;
     reason: string;
     innovation_overview_url: string;
+  };
+  SUGGESTED_SUPPORT_UPDATED: {
+    innovation: string;
+    support_status: string;
+    message: string;
+    organisation: string;
+    support_summary_url: string;
   };
 };

--- a/apps/notifications/_config/inapp.config.ts
+++ b/apps/notifications/_config/inapp.config.ts
@@ -308,4 +308,10 @@ export type InAppTemplatesType = {
     innovation: string;
     reason: string;
   };
+  SUGGESTED_SUPPORT_UPDATED: {
+    event: string;
+    innovation: string;
+    supportStatus: string;
+    organisation: string;
+  };
 };

--- a/apps/notifications/_notify-me/notify-me.handler.spec.ts
+++ b/apps/notifications/_notify-me/notify-me.handler.spec.ts
@@ -284,7 +284,8 @@ describe('NotifyMe Handler Suite', () => {
           preConditions: {
             status: [InnovationSupportStatusEnum.ENGAGING],
             units: [unit]
-          }
+          },
+          notificationType: 'SUPPORT_UPDATED'
         }
       });
 
@@ -312,7 +313,8 @@ describe('NotifyMe Handler Suite', () => {
           preConditions: {
             status: [InnovationSupportStatusEnum.WAITING, InnovationSupportStatusEnum.CLOSED],
             units: [unit]
-          }
+          },
+          notificationType: 'SUPPORT_UPDATED'
         }
       });
 
@@ -341,7 +343,8 @@ describe('NotifyMe Handler Suite', () => {
           preConditions: {
             status: [InnovationSupportStatusEnum.ENGAGING],
             units: [unit]
-          }
+          },
+          notificationType: 'SUPPORT_UPDATED'
         }
       });
 
@@ -368,7 +371,8 @@ describe('NotifyMe Handler Suite', () => {
           preConditions: {
             status: [InnovationSupportStatusEnum.ENGAGING],
             units: [unit]
-          }
+          },
+          notificationType: 'SUPPORT_UPDATED'
         }
       });
 
@@ -400,7 +404,8 @@ describe('NotifyMe Handler Suite', () => {
               preConditions: {
                 status: [InnovationSupportStatusEnum.ENGAGING],
                 units: [unit]
-              }
+              },
+              notificationType: 'SUPPORT_UPDATED'
             }
           },
           { id: randUuid(), name: 'Test Innovation' }
@@ -443,7 +448,8 @@ describe('NotifyMe Handler Suite', () => {
               preConditions: {
                 status: [InnovationSupportStatusEnum.ENGAGING],
                 units: [unit]
-              }
+              },
+              notificationType: 'SUPPORT_UPDATED'
             }
           },
           { id: innovationId, name: 'Test Innovation' }

--- a/apps/notifications/_notify-me/notify-me.handler.ts
+++ b/apps/notifications/_notify-me/notify-me.handler.ts
@@ -180,7 +180,11 @@ export class NotifyMeHandler {
             recipient.role,
             this.event.innovationId,
             this.event.requestUser.organisation?.organisationUnit?.id
-          )
+          ),
+          ...('notificationType' in subscription.config &&
+            subscription.config.notificationType === 'SUGGESTED_SUPPORT_UPDATED' && {
+              message: this.event.params.message
+            })
         };
 
       case 'PROGRESS_UPDATE_CREATED':
@@ -222,11 +226,13 @@ export class NotifyMeHandler {
     subscription: NotifyMeSubscriptionType,
     params: InAppTemplatesType[keyof InAppTemplatesType]
   ): InAppMessageType {
+    const type =
+      'notificationType' in subscription.config ? subscription.config.notificationType : subscription.config.eventType;
     return {
       data: {
         requestUser: { id: this.event.requestUser.id },
         innovationId: this.event.innovationId,
-        context: { type: 'NOTIFY_ME', detail: subscription.config.eventType, id: subscription.id },
+        context: { type: 'NOTIFY_ME', detail: type, id: subscription.id },
         userRoleIds: [subscription.roleId],
         params
       }
@@ -238,8 +244,10 @@ export class NotifyMeHandler {
     subscription: NotifyMeSubscriptionType,
     params: EmailTemplatesType[EventType] & { displayName: string; unsubscribeUrl: string }
   ): EmailMessageType {
+    const type =
+      'notificationType' in subscription.config ? subscription.config.notificationType : subscription.config.eventType;
     return {
-      data: { type: subscription.config.eventType, to: email, params }
+      data: { type: type, to: email, params }
     };
   }
 }

--- a/apps/notifications/v1-notify-me-listener/index.spec.ts
+++ b/apps/notifications/v1-notify-me-listener/index.spec.ts
@@ -1,4 +1,4 @@
-import { randUuid } from '@ngneat/falso';
+import { randText, randUuid } from '@ngneat/falso';
 import { InnovationSupportStatusEnum } from '@notifications/shared/enums';
 import { BadRequestError, GenericErrorsEnum } from '@notifications/shared/errors';
 import { StorageQueueService } from '@notifications/shared/services';
@@ -41,7 +41,8 @@ describe('NotifyMe Listener Suite', () => {
           type: 'SUPPORT_UPDATED',
           params: {
             status: InnovationSupportStatusEnum.ENGAGING,
-            units: randUuid()
+            units: randUuid(),
+            message: randText()
           }
         })
         .call<{ done: boolean }>(v1NotifyMeListener);
@@ -76,7 +77,8 @@ describe('NotifyMe Listener Suite', () => {
         type: 'SUPPORT_UPDATED',
         params: {
           status: InnovationSupportStatusEnum.ENGAGING,
-          units: randUuid()
+          units: randUuid(),
+          message: randText()
         }
       });
 

--- a/apps/notifications/v1-notify-me-listener/validation.schemas.ts
+++ b/apps/notifications/v1-notify-me-listener/validation.schemas.ts
@@ -1,5 +1,6 @@
 import Joi, { ObjectSchema } from 'joi';
 
+import { TEXTAREA_LENGTH_LIMIT } from '@notifications/shared/constants';
 import { InnovationSupportStatusEnum } from '@notifications/shared/enums';
 import { CurrentCatalogTypes } from '@notifications/shared/schemas/innovation-record';
 import { DomainContextSchema, DomainContextType, EventPayloads, EventType } from '@notifications/shared/types';
@@ -34,7 +35,8 @@ export const EventParamsSchema: { [key in EventType]: ObjectSchema<EventPayloads
     status: Joi.string()
       .valid(...Object.values(InnovationSupportStatusEnum))
       .required(),
-    units: RequiredIdSchema
+    units: RequiredIdSchema,
+    message: Joi.string().max(TEXTAREA_LENGTH_LIMIT.xl).required()
   }).required(),
   PROGRESS_UPDATE_CREATED: Joi.object<EventPayloads['PROGRESS_UPDATE_CREATED']>({
     units: RequiredIdSchema

--- a/apps/users/.apim/swagger.yaml
+++ b/apps/users/.apim/swagger.yaml
@@ -1028,6 +1028,7 @@ paths:
                           type: string
                           enum:
                             - INSTANTLY
+                            - ONCE
                           default: INSTANTLY
                         preConditions:
                           type: object
@@ -1052,6 +1053,12 @@ paths:
                             - units
                             - status
                           additionalProperties: false
+                        notificationType:
+                          type: string
+                          enum:
+                            - SUPPORT_UPDATED
+                            - SUGGESTED_SUPPORT_UPDATED
+                          default: SUPPORT_UPDATED
                       required:
                         - eventType
                         - preConditions
@@ -1283,6 +1290,7 @@ paths:
                       type: string
                       enum:
                         - INSTANTLY
+                        - ONCE
                       default: INSTANTLY
                     preConditions:
                       type: object
@@ -1307,6 +1315,12 @@ paths:
                         - units
                         - status
                       additionalProperties: false
+                    notificationType:
+                      type: string
+                      enum:
+                        - SUPPORT_UPDATED
+                        - SUGGESTED_SUPPORT_UPDATED
+                      default: SUPPORT_UPDATED
                   required:
                     - eventType
                     - preConditions

--- a/apps/users/_services/notify-me.service.spec.ts
+++ b/apps/users/_services/notify-me.service.spec.ts
@@ -44,7 +44,20 @@ describe('Users / _services / notify me service suite', () => {
             status: [InnovationSupportStatusEnum.ENGAGING as const],
             units: [randUuid()]
           },
-          subscriptionType: 'INSTANTLY' as const
+          subscriptionType: 'INSTANTLY' as const,
+          notificationType: 'SUPPORT_UPDATED' as const
+        }
+      ],
+      [
+        'SUGGESTED_SUPPORT_UPDATED',
+        {
+          eventType: 'SUPPORT_UPDATED' as const,
+          preConditions: {
+            status: [InnovationSupportStatusEnum.ENGAGING as const],
+            units: [randUuid()]
+          },
+          subscriptionType: 'ONCE' as const,
+          notificationType: 'SUGGESTED_SUPPORT_UPDATED' as const
         }
       ],
       [
@@ -601,7 +614,8 @@ describe('Users / _services / notify me service suite', () => {
             status: [InnovationSupportStatusEnum.UNSUITABLE],
             units: [randUuid()]
           },
-          subscriptionType: 'INSTANTLY'
+          subscriptionType: 'INSTANTLY',
+          notificationType: 'SUPPORT_UPDATED' as const
         },
         em
       );
@@ -683,7 +697,8 @@ describe('Users / _services / notify me service suite', () => {
               status: [InnovationSupportStatusEnum.UNSUITABLE],
               units: [randUuid()]
             },
-            subscriptionType: 'INSTANTLY'
+            subscriptionType: 'INSTANTLY',
+            notificationType: 'SUPPORT_UPDATED' as const
           },
           em
         )

--- a/apps/users/_services/notify-me.service.ts
+++ b/apps/users/_services/notify-me.service.ts
@@ -152,7 +152,8 @@ export class NotifyMeService extends BaseService {
       eventType: s.config.eventType,
       subscriptionType: s.config.subscriptionType,
       organisations: this.groupUnitsByOrganisation(s.config.preConditions.units, retrievedUnits),
-      status: s.config.preConditions.status
+      status: s.config.preConditions.status,
+      notificationType: s.config.notificationType
     }));
   }
 

--- a/apps/users/_types/notify-me.types.ts
+++ b/apps/users/_types/notify-me.types.ts
@@ -28,7 +28,8 @@ const SupportUpdatedSchema = Joi.object<SupportUpdated>({
       )
       .min(1)
       .required()
-  }).required()
+  }).required(),
+  notificationType: Joi.string().valid('SUPPORT_UPDATED', 'SUGGESTED_SUPPORT_UPDATED').default('SUPPORT_UPDATED')
 }).required();
 
 const ProgressUpdateCreatedSchema = Joi.object<ProgressUpdateCreated>({
@@ -116,6 +117,7 @@ export type SupportUpdatedResponseDTO = {
   subscriptionType: 'INSTANTLY' | 'ONCE';
   organisations: OrganisationWithUnits[];
   status: ExcludeEnum<InnovationSupportStatusEnum, InnovationSupportStatusEnum.UNASSIGNED>[];
+  notificationType: 'SUPPORT_UPDATED' | 'SUGGESTED_SUPPORT_UPDATED';
 };
 
 export type ProgressUpdateCreatedResponseDTO = {

--- a/apps/users/v1-notify-me-innovation-subscription-list/index.spec.ts
+++ b/apps/users/v1-notify-me-innovation-subscription-list/index.spec.ts
@@ -43,7 +43,8 @@ const expected = [
     ],
     status: [InnovationSupportStatusEnum.ENGAGING as const],
     subscriptionType: 'INSTANTLY' as const,
-    updatedAt: new Date()
+    updatedAt: new Date(),
+    notificationType: 'SUPPORT_UPDATED' as const
   }
 ];
 const mock = jest.spyOn(NotifyMeService.prototype, 'getInnovationSubscriptions').mockResolvedValue(expected);

--- a/apps/users/v1-notify-me-subscription-create/index.spec.ts
+++ b/apps/users/v1-notify-me-subscription-create/index.spec.ts
@@ -32,7 +32,8 @@ const exampleDTO = {
     preConditions: {
       status: [InnovationSupportStatusEnum.ENGAGING as const],
       units: [randUuid()]
-    }
+    },
+    notificationType: 'SUPPORT_UPDATED' as const
   }
 };
 

--- a/apps/users/v1-notify-me-subscription-get/index.spec.ts
+++ b/apps/users/v1-notify-me-subscription-get/index.spec.ts
@@ -42,7 +42,8 @@ const expected = {
   ],
   status: [InnovationSupportStatusEnum.ENGAGING as const],
   subscriptionType: 'INSTANTLY' as const,
-  updatedAt: new Date()
+  updatedAt: new Date(),
+  notificationType: 'SUPPORT_UPDATED' as const
 };
 const mock = jest.spyOn(NotifyMeService.prototype, 'getSubscription').mockResolvedValue(expected);
 

--- a/apps/users/v1-notify-me-subscription-update/index.spec.ts
+++ b/apps/users/v1-notify-me-subscription-update/index.spec.ts
@@ -30,7 +30,8 @@ const exampleDTO = {
   preConditions: {
     status: [InnovationSupportStatusEnum.ENGAGING as const],
     units: [randUuid()]
-  }
+  },
+  notificationType: 'SUPPORT_UPDATED' as const
 };
 
 afterEach(() => {

--- a/libs/shared/enums/notification.enums.ts
+++ b/libs/shared/enums/notification.enums.ts
@@ -79,7 +79,13 @@ export const NotificationTypes = {
     'AU09_TRANSFER_EXPIRED',
     'AU10_ACCESSOR_IDLE_ENGAGING_SUPPORT_FOR_SIX_WEEKS'
   ] as const,
-  NOTIFY_ME: ['SUPPORT_UPDATED', 'PROGRESS_UPDATE_CREATED', 'INNOVATION_RECORD_UPDATED', 'REMINDER'] as const
+  NOTIFY_ME: [
+    'SUPPORT_UPDATED',
+    'PROGRESS_UPDATE_CREATED',
+    'INNOVATION_RECORD_UPDATED',
+    'REMINDER',
+    'SUGGESTED_SUPPORT_UPDATED'
+  ] as const
 };
 export type NotificationTypes = typeof NotificationTypes;
 export const NotificationCategoryType = Object.keys(NotificationTypes).map(v => v);

--- a/libs/shared/tests/scenarios/complete-scenario.builder.ts
+++ b/libs/shared/tests/scenarios/complete-scenario.builder.ts
@@ -693,7 +693,8 @@ export class CompleteScenarioBuilder {
           preConditions: {
             status: [InnovationSupportStatusEnum.ENGAGING],
             units: [medTechOrgUnit.id]
-          }
+          },
+          notificationType: 'SUPPORT_UPDATED'
         })
         .save();
 
@@ -708,7 +709,8 @@ export class CompleteScenarioBuilder {
           preConditions: {
             status: [InnovationSupportStatusEnum.ENGAGING],
             units: [medTechOrgUnit.id]
-          }
+          },
+          notificationType: 'SUPPORT_UPDATED'
         })
         .save();
 
@@ -786,7 +788,8 @@ export class CompleteScenarioBuilder {
           preConditions: {
             status: [InnovationSupportStatusEnum.ENGAGING],
             units: [medTechOrgUnit.id]
-          }
+          },
+          notificationType: 'SUPPORT_UPDATED'
         })
         .save();
 

--- a/libs/shared/types/notify-me.types.ts
+++ b/libs/shared/types/notify-me.types.ts
@@ -23,7 +23,7 @@ export type SupportUpdated = {
     units: string[];
     status: ExcludeEnum<InnovationSupportStatusEnum, InnovationSupportStatusEnum.UNASSIGNED>[];
   };
-  //  notificationType: 'SUPPORT_UPDATED' | 'SUGGESTED_SUPPORT_UPDATED';
+  notificationType: 'SUPPORT_UPDATED' | 'SUGGESTED_SUPPORT_UPDATED';
 };
 
 export type ProgressUpdateCreated = {

--- a/libs/shared/types/notify-me.types.ts
+++ b/libs/shared/types/notify-me.types.ts
@@ -68,6 +68,7 @@ export type EventPayloads = {
   SUPPORT_UPDATED: {
     status: InnovationSupportStatusEnum;
     units: string;
+    message: string;
   };
   PROGRESS_UPDATE_CREATED: {
     units: string;


### PR DESCRIPTION
- add support for the suggested organisations status update
- add notifications with different notification templates for the same event

Closes: [AB#171764](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/171764), [AB#172358](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/172358)