### PR TITLE
feat: add mechanism to lock subSections and questions

### DIFF
--- a/libs/shared/schemas/innovation-record/202407/document.types.ts
+++ b/libs/shared/schemas/innovation-record/202407/document.types.ts
@@ -1,0 +1,85 @@
+type OtherKeyValues = { [key: string]: any };
+
+export type InnovationRecordDocumentType = {
+  version: number;
+  INNOVATION_DESCRIPTION: {
+    name: string; // N
+    description?: string; // N
+    postcode?: string; // N
+    countryName?: string; // N
+    categories?: string[]; // N
+    otherCategoryDescription?: string; // N
+    mainCategory?: string; // N
+    areas?: string[]; // N
+    careSettings?: string[]; // N
+    otherCareSetting?: string; // N
+    involvedAACProgrammes?: string[]; // N
+  } & OtherKeyValues;
+  UNDERSTANDING_OF_NEEDS: {
+    diseasesConditionsImpact?: string[]; // N
+    keyHealthInequalities?: string[]; // N
+  } & OtherKeyValues;
+  EVIDENCE_OF_EFFECTIVENESS: {
+    hasEvidence?: string;
+    currentlyCollectingEvidence?: string;
+    summaryOngoingEvidenceGathering?: string;
+    needsSupportAnyArea?: string[];
+  } & OtherKeyValues;
+  MARKET_RESEARCH: OtherKeyValues;
+  CURRENT_CARE_PATHWAY: OtherKeyValues;
+  TESTING_WITH_USERS: {
+    userTests?: { kind: string; feedback?: string }[]; // N
+  } & OtherKeyValues;
+  REGULATIONS_AND_STANDARDS: {
+    standards?: { type: string; hasMet?: string }[]; // N
+  } & OtherKeyValues;
+  INTELLECTUAL_PROPERTY: OtherKeyValues;
+  REVENUE_MODEL: OtherKeyValues;
+  COST_OF_INNOVATION: OtherKeyValues;
+  DEPLOYMENT: OtherKeyValues;
+  evidences?: {
+    id: string;
+    evidenceSubmitType: string;
+    evidenceType?: string;
+    description?: string;
+    summary: string;
+  }[];
+};
+
+// Required Sections/Questions
+export const requiredSectionsAndQuestions = new Map([
+  [
+    'INNOVATION_DESCRIPTION',
+    [
+      'name',
+      'description',
+      'postcode',
+      // 'countryName', // TODO: Enable this after doing the calculatedFields
+      'categories',
+      'otherCategoryDescription',
+      'mainCategory',
+      'areas',
+      'careSettings',
+      'otherCareSetting',
+      'involvedAACProgrammes'
+    ]
+  ],
+  ['UNDERSTANDING_OF_NEEDS', ['diseasesConditionsImpact', 'keyHealthInequalities']],
+  [
+    'EVIDENCE_OF_EFFECTIVENESS',
+    ['hasEvidence', 'currentlyCollectingEvidence', 'summaryOngoingEvidenceGathering', 'needsSupportAnyArea']
+  ],
+  ['MARKET_RESEARCH', []],
+  ['CURRENT_CARE_PATHWAY', []],
+  ['TESTING_WITH_USERS', ['userTests']],
+  [
+    'REGULATIONS_AND_STANDARDS',
+    [
+      // 'standards' // TODO: Enable this after solving the fields-groups
+    ]
+  ],
+  ['INTELLECTUAL_PROPERTY', []],
+  ['REVENUE_MODEL', []],
+  ['COST_OF_INNOVATION', []],
+  ['DEPLOYMENT', []]
+]);

--- a/libs/shared/schemas/innovation-record/index.ts
+++ b/libs/shared/schemas/innovation-record/index.ts
@@ -19,6 +19,8 @@ export type CurrentDocumentType = DocumentType202304;
 export type CurrentEvidenceType = NonNullable<CurrentDocumentType['evidences']>[number];
 export const CurrentEvidenceSchema = EvidenceSchema202304;
 
+export { InnovationRecordDocumentType, requiredSectionsAndQuestions } from './202407/document.types';
+
 // Helpers
 export type DocumentTypeFromVersion<V extends DocumentType['version']> = V extends '202304'
   ? CurrentDocumentType


### PR DESCRIPTION
**Description:**
This PR adds a structure to handle the type of required fields and an associated structure that stores the required sections and questions.

Notes:
- The current placement will be changed after removing the older IR versions.
- Some of the locked questions are commented since are depending on other tasks to unlock them.

**Related tickets:**
-  Closes [AB#171821](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/171821).
- US: [AB#171057](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/171057).