### PR TITLE
Task/update fields group validator

### DIFF
--- a/libs/shared/models/schema-engine/question.validator.ts
+++ b/libs/shared/models/schema-engine/question.validator.ts
@@ -108,6 +108,11 @@ export class CheckboxArrayValidator implements QuestionTypeValidator<CheckboxArr
 
 export class FieldGroupValidator implements QuestionTypeValidator<FieldsGroup> {
   validate(question: FieldsGroup): Joi.Schema {
+    // When addQuestion is not defined the payload is a string array.
+    if(!question.addQuestion) {
+      return JoiHelper.AppCustomJoi().stringArray().required();
+    }
+
     let validation = Joi.array();
     const obj: { [key: string]: any } = {};
     if (question.field) {

--- a/libs/shared/models/schema-engine/question.validator.ts
+++ b/libs/shared/models/schema-engine/question.validator.ts
@@ -109,8 +109,8 @@ export class CheckboxArrayValidator implements QuestionTypeValidator<CheckboxArr
 export class FieldGroupValidator implements QuestionTypeValidator<FieldsGroup> {
   validate(question: FieldsGroup): Joi.Schema {
     // When addQuestion is not defined the payload is a string array.
-    if(!question.addQuestion) {
-      return JoiHelper.AppCustomJoi().stringArray().required();
+    if (!question.addQuestion) {
+      return JoiHelper.AppCustomJoi().stringArray().items(Joi.string()).required();
     }
 
     let validation = Joi.array();


### PR DESCRIPTION
**Description:**
Since the fields-group has a different behavior, this commit updates the validator for the update section.
- If `addQuestion` is defined it means the validator needs to validate an array of objects.
- If `addQuestion` is not defined it means the validator needs to validate an string array.

**Related tickets:**
- US: [AB#171057](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/171057).