### PR TITLE
Task/add calculated fields to subsections

### DIFF
--- a/apps/innovations/v1-innovation-section-update/index.ts
+++ b/apps/innovations/v1-innovation-section-update/index.ts
@@ -43,7 +43,10 @@ class V1InnovationSectionUpdate {
 
       // Validate Payload
       const validation = irSchemaService.getPayloadValidation(params.sectionKey, request.body['data']);
-      const body = JoiHelper.Validate<{ [key: string]: any }>(validation, request.body['data']);
+      const body = {
+        ...JoiHelper.Validate<{ [key: string]: any }>(validation, request.body['data']),
+        ...irSchemaService.getCalculatedFields(params.sectionKey, request.body['data'])
+      }
 
       const result = await innovationSectionsService.updateInnovationSectionInfo(
         auth.getContext(),

--- a/libs/shared/models/schema-engine/schema.model.ts
+++ b/libs/shared/models/schema-engine/schema.model.ts
@@ -16,12 +16,15 @@ export type InnovationRecordSubSectionType = {
   id: string;
   title: string;
   steps: InnovationRecordStepType[];
+  calculatedFields?: Record<string, Condition[]>;
 };
 
 export type InnovationRecordStepType = {
   questions: Question[];
-  condition?: { id: string; options: string[] };
+  condition?: Condition;
 };
+
+type Condition = { id: string; options: string[] };
 
 export type SchemaValidationError = {
   message: string;
@@ -102,7 +105,11 @@ export class SchemaModel {
     }
   }
 
-  private validateCondition(step: InnovationRecordStepType, path: string, idList: { [key: string]: any }) {
+  private validateCondition(
+    step: InnovationRecordStepType | { condition: Condition },
+    path: string,
+    idList: { [key: string]: any }
+  ) {
     const condition = step.condition;
     if (condition) {
       if (idList[condition.id]) {
@@ -249,6 +256,18 @@ export class SchemaModel {
         subSection.steps?.forEach((step, k: number) => {
           this.validateStep(subSection.id, step, `sections[${i}].subSections[${j}].steps[${k}]`, questionList);
         });
+
+        if (subSection.calculatedFields) {
+          Object.entries(subSection.calculatedFields).forEach(([field, conditions]) => {
+            conditions.forEach(condition => {
+              this.validateCondition(
+                { condition },
+                `sections[${i}].subSections[${j}].calculatedFields[${field}]`,
+                questionList
+              );
+            });
+          });
+        }
       });
     });
 

--- a/libs/shared/models/schema-engine/schema.model.ts
+++ b/libs/shared/models/schema-engine/schema.model.ts
@@ -86,6 +86,7 @@ export class SchemaModel {
         const cur = payload[condition.id];
         if (cur && (condition.options.includes(cur) || !condition.options.length)) {
           out[field] = Array.isArray(cur) ? cur[0] : cur;
+          break;
         }
       }
     }

--- a/libs/shared/models/schema-engine/schema.validations.ts
+++ b/libs/shared/models/schema-engine/schema.validations.ts
@@ -107,7 +107,8 @@ const questions = Joi.array().items(text, textArea, radioGroup, autocompleteArra
 const subSection = Joi.object({
   id,
   title: Joi.string().min(1).required(),
-  steps: Joi.array().items(Joi.object({ questions: questions, condition: condition.optional() }))
+  steps: Joi.array().items(Joi.object({ questions: questions, condition: condition.optional() })),
+  calculatedFields: Joi.object()
 });
 
 const section = Joi.object({

--- a/libs/shared/services/storage/ir-schema.service.ts
+++ b/libs/shared/services/storage/ir-schema.service.ts
@@ -51,6 +51,13 @@ export class IRSchemaService {
     return this.model.getSubSectionPayloadValidation(subSectionId, payload);
   }
 
+  getCalculatedFields(subSectionId: string, payload: { [key: string]: any }) {
+    if (!this.model) {
+      throw new NotFoundError(InnovationErrorsEnum.INNOVATION_RECORD_SCHEMA_NOT_FOUND);
+    }
+    return this.model.getCalculatedFields(subSectionId, payload);
+  }
+
   /**
    * Orchestrate the update of a schema, this includes validating the schema,
    * creating a new schema in the DB, and lastly update the in-memory schema and model.


### PR DESCRIPTION
**Description:**
This PR introduces the `calculatedFields` to the subsection, this first version enables that some fields can be calculated from others. In this case is for the field `countryName` that depending on the choices of the user on the `officeLocation` and `countryLocation` the countryName has different values.

Note: In this version the calculatedFields has to be composed of conditions, but it can be extended to other approaches like concatenate different strings without the need of conditions (e.g., `fullAddress = '{{ officeLocation }}, {{ postcode}}'`).

**Related tickets:**
- Closes [AB#172374](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/172374).
- US: [AB#171057](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/171057).