### PR TITLE
task: hasFiles directly on schema

### DIFF
--- a/apps/innovations/_services/innovation-file.service.ts
+++ b/apps/innovations/_services/innovation-file.service.ts
@@ -22,9 +22,7 @@ import {
 } from '@innovations/shared/errors';
 import { TranslationHelper, type PaginationQueryParamsType } from '@innovations/shared/helpers';
 import { CurrentDocumentConfig } from '@innovations/shared/schemas/innovation-record';
-import { allowFileUploads } from '@innovations/shared/schemas/innovation-record/202304/document.config';
-import type { DocumentType202304 } from '@innovations/shared/schemas/innovation-record/202304/document.types';
-import type { FileStorageService, IdentityProviderService, NotifierService } from '@innovations/shared/services';
+import type { FileStorageService, IdentityProviderService, IRSchemaService, NotifierService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import {
   isAccessorDomainContextType,
@@ -49,6 +47,7 @@ export class InnovationFileService extends BaseService {
     @inject(SHARED_SYMBOLS.FileStorageService) private fileStorageService: FileStorageService,
     @inject(SHARED_SYMBOLS.IdentityProviderService) private identityProviderService: IdentityProviderService,
     @inject(SHARED_SYMBOLS.NotifierService) private notifierService: NotifierService,
+    @inject(SHARED_SYMBOLS.IRSchemaService) private irSchemaService: IRSchemaService,
     @inject(SYMBOLS.InnovationDocumentService) private innovationDocumentService: InnovationDocumentService
   ) {
     super();
@@ -366,7 +365,7 @@ export class InnovationFileService extends BaseService {
     if (
       innovationStatus === InnovationStatusEnum.CREATED &&
       data.context.type === InnovationFileContextTypeEnum.INNOVATION_SECTION &&
-      !allowFileUploads.has(data.context.id as keyof DocumentType202304)
+      !this.irSchemaService.canUploadFiles(data.context.id)
     ) {
       throw new UnprocessableEntityError(InnovationErrorsEnum.INNOVATION_FILE_FORBIDDEN_SECTION);
     }

--- a/libs/shared/models/schema-engine/schema.model.spec.ts
+++ b/libs/shared/models/schema-engine/schema.model.spec.ts
@@ -1,6 +1,9 @@
 import { IRSchemaType, SchemaModel } from './schema.model';
+import { requiredSectionsAndQuestions } from '../../schemas/innovation-record';
 
 describe('models / schema-engine / schema.model.ts', () => {
+  beforeAll(() => { requiredSectionsAndQuestions.clear() });
+
   it('should give error when schema format is not right', () => {
     const body: any = { sections: [{ id: 'id1', subSections: [] }] };
 
@@ -8,7 +11,7 @@ describe('models / schema-engine / schema.model.ts', () => {
 
     const { errors } = schema.runRules();
 
-    expect(errors).toStrictEqual([ { context: undefined, message: '"sections[0].title" is required' } ]);
+    expect(errors).toStrictEqual([{ context: undefined, message: '"sections[0].title" is required' }]);
   });
 
   it('should give an error when two sections have the same id', () => {
@@ -239,9 +242,7 @@ describe('models / schema-engine / schema.model.ts', () => {
             {
               id: 'subId1',
               title: 'Subsection 1.1',
-              steps: [
-                { questions: [ { id: 'q1', dataType: 'text', label: 'Label 1', validations: {} } ] }
-              ]
+              steps: [{ questions: [{ id: 'q1', dataType: 'text', label: 'Label 1', validations: {} }] }]
             }
           ]
         }
@@ -361,7 +362,7 @@ describe('models / schema-engine / schema.model.ts', () => {
                     ]
                   },
                   {
-                    questions: [ { id: 'q2', dataType: 'text', label: 'Label 2' } ],
+                    questions: [{ id: 'q2', dataType: 'text', label: 'Label 2' }],
                     condition: { id: 'q1', options: ['basedOutsideUk', 'basedOutsideUs'] }
                   }
                 ]
@@ -376,9 +377,10 @@ describe('models / schema-engine / schema.model.ts', () => {
 
       expect(errors).toStrictEqual([
         {
-          message: 'sections[0].subSections[0].steps[1].condition references a wrong option (basedOutsideUk,basedOutsideUs)',
+          message:
+            'sections[0].subSections[0].steps[1].condition references a wrong option (basedOutsideUk,basedOutsideUs)',
           context: {
-            questions: [ { id: 'q2', dataType: 'text', label: 'Label 2' } ],
+            questions: [{ id: 'q2', dataType: 'text', label: 'Label 2' }],
             condition: { id: 'q1', options: ['basedOutsideUk', 'basedOutsideUs'] }
           }
         }
@@ -396,9 +398,9 @@ describe('models / schema-engine / schema.model.ts', () => {
                 id: 'subId1',
                 title: 'Subsection 1.1',
                 steps: [
-                  { questions: [ { id: 'q1', dataType: 'text', label: 'Question 1' } ] },
+                  { questions: [{ id: 'q1', dataType: 'text', label: 'Question 1' }] },
                   {
-                    questions: [ { id: 'q2', dataType: 'text', label: 'Label 2' } ],
+                    questions: [{ id: 'q2', dataType: 'text', label: 'Label 2' }],
                     condition: { id: 'q1', options: ['basedOutsideUk'] }
                   }
                 ]
@@ -415,7 +417,7 @@ describe('models / schema-engine / schema.model.ts', () => {
         {
           message: 'sections[0].subSections[0].steps[1].condition references non-tipified dataType (q1)',
           context: {
-            questions: [ { id: 'q2', dataType: 'text', label: 'Label 2' } ],
+            questions: [{ id: 'q2', dataType: 'text', label: 'Label 2' }],
             condition: { id: 'q1', options: ['basedOutsideUk'] }
           }
         }
@@ -434,7 +436,7 @@ describe('models / schema-engine / schema.model.ts', () => {
                 title: 'Subsection 1.1',
                 steps: [
                   {
-                    questions: [ { id: 'q2', dataType: 'text', label: 'Label 2' } ],
+                    questions: [{ id: 'q2', dataType: 'text', label: 'Label 2' }],
                     condition: { id: 'q1', options: ['basedOutsideUk'] }
                   },
                   {
@@ -461,11 +463,50 @@ describe('models / schema-engine / schema.model.ts', () => {
         {
           message: 'sections[0].subSections[0].steps[0].condition must reference a previous question (q1)',
           context: {
-            questions: [ { id: 'q2', dataType: 'text', label: 'Label 2' } ],
+            questions: [{ id: 'q2', dataType: 'text', label: 'Label 2' }],
             condition: { id: 'q1', options: ['basedOutsideUk'] }
           }
         }
       ]);
+    });
+  });
+
+  describe('canUploadFiles', () => {
+    it('should return true if section can upload files', () => {
+      const body: IRSchemaType = {
+        sections: [
+          {
+            id: 'id1',
+            title: 'Section 1',
+            subSections: [
+              {
+                id: 'subId1',
+                title: 'Subsection 1.1',
+                hasFiles: true,
+                steps: []
+              }
+            ]
+          }
+        ]
+      };
+      const schema = new SchemaModel(body);
+      schema.runRules();
+      expect(schema.canUploadFiles('subId1')).toBe(true);
+    });
+
+    it('should return false if section cannot upload files', () => {
+      const body: IRSchemaType = {
+        sections: [
+          {
+            id: 'id1',
+            title: 'Section 1',
+            subSections: [{ id: 'subId1', title: 'Subsection 1.1', steps: [], hasFiles: false }]
+          }
+        ]
+      };
+      const schema = new SchemaModel(body);
+      schema.runRules();
+      expect(schema.canUploadFiles('subId1')).toBe(false);
     });
   });
 });

--- a/libs/shared/models/schema-engine/schema.model.ts
+++ b/libs/shared/models/schema-engine/schema.model.ts
@@ -17,6 +17,7 @@ export type InnovationRecordSubSectionType = {
   title: string;
   steps: InnovationRecordStepType[];
   calculatedFields?: Record<string, Condition[]>;
+  hasFiles?: boolean;
 };
 
 export type InnovationRecordStepType = {
@@ -38,6 +39,7 @@ export class SchemaModel {
   private subSections = new Map<string, string[]>();
   private questions = new Map<string, Question>();
   private conditions = new Map<string, Record<string, Condition[]>>();
+  private allowFileUploads = new Set<string>();
 
   constructor(schema: any) {
     this.errorList = [];
@@ -71,6 +73,10 @@ export class SchemaModel {
 
   isSubsectionValid(subSectionId: string): boolean {
     return this.subSections.has(subSectionId);
+  }
+
+  canUploadFiles(subSectionId: string): boolean {
+    return this.allowFileUploads.has(subSectionId);
   }
 
   /**
@@ -290,6 +296,10 @@ export class SchemaModel {
           });
           this.conditions.set(subSection.id, subSection.calculatedFields);
         }
+
+        if(subSection.hasFiles) {
+          this.allowFileUploads.add(subSection.id);
+        }
       });
     });
 
@@ -300,6 +310,7 @@ export class SchemaModel {
       this.subSections.clear();
       this.questions.clear();
       this.conditions.clear();
+      this.allowFileUploads.clear();
     }
 
     return { schema, errors: this.errorList };

--- a/libs/shared/models/schema-engine/schema.validations.ts
+++ b/libs/shared/models/schema-engine/schema.validations.ts
@@ -108,7 +108,8 @@ const subSection = Joi.object({
   id,
   title: Joi.string().min(1).required(),
   steps: Joi.array().items(Joi.object({ questions: questions, condition: condition.optional() })),
-  calculatedFields: Joi.object()
+  calculatedFields: Joi.object(),
+  hasFiles: Joi.boolean()
 });
 
 const section = Joi.object({

--- a/libs/shared/services/storage/ir-schema.service.ts
+++ b/libs/shared/services/storage/ir-schema.service.ts
@@ -78,6 +78,10 @@ export class IRSchemaService {
     return this.model?.isSubsectionValid(subSectionId) ?? false;
   }
 
+  canUploadFiles(subSectionId: string): boolean {
+    return this.model?.canUploadFiles(subSectionId) ?? false;
+  }
+
   /**
    * This method is responsible for getting from the DB the schema version.
    */


### PR DESCRIPTION
**Description:**
Sections that can upload files were hardcoded in the code, by having a schema that defined the IR rules this needed to be changed in order to be truly dynamic. This commit adds a property `hasFiles` to the subsections that can be used to defined if it accepts file uploads while is not shared or not.

**Related tickets:**
- Closes [AB#172614](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/172614).
- US: [AB#171057](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/171057).