### PR TITLE
task: checkbox array accepts an array of objects

### DIFF
--- a/libs/shared/models/schema-engine/question.types.ts
+++ b/libs/shared/models/schema-engine/question.types.ts
@@ -48,6 +48,8 @@ export type CheckboxArray = Base & {
     | { id: string; label: string; group?: string; conditional?: string; exclusive?: boolean }
   )[];
   size?: 'small' | 'normal';
+  addQuestion?: Question;
+  checkboxAnswerId?: string;
 };
 
 export type AutocompleteArray = Base & {

--- a/libs/shared/models/schema-engine/question.validator.ts
+++ b/libs/shared/models/schema-engine/question.validator.ts
@@ -83,7 +83,7 @@ export class AutocompleteArrayValidator implements QuestionTypeValidator<Autocom
 
 export class CheckboxArrayValidator implements QuestionTypeValidator<CheckboxArray> {
   validate(question: CheckboxArray): Joi.Schema {
-    let validation = JoiHelper.AppCustomJoi().stringArray();
+    let checkboxValidation = JoiHelper.AppCustomJoi().stringArray();
     const validItems = [];
     for (const item of question.items) {
       if ('id' in item) {
@@ -91,18 +91,28 @@ export class CheckboxArrayValidator implements QuestionTypeValidator<CheckboxArr
       }
     }
     if (validItems.length) {
-      validation = validation.items(Joi.string().valid(...validItems));
+      checkboxValidation = checkboxValidation.items(Joi.string().valid(...validItems));
     }
     if (question.validations?.max) {
-      validation = validation.max(question.validations.max.length);
+      checkboxValidation = checkboxValidation.max(question.validations.max.length);
     }
     if (question.validations?.min) {
-      validation = validation.min(question.validations.min.length);
+      checkboxValidation = checkboxValidation.min(question.validations.min.length);
     }
     if (question.validations?.isRequired) {
-      validation = validation.required();
+      checkboxValidation = checkboxValidation.required();
     }
-    return validation;
+
+    // This means its an array of objects (e.g., standards)
+    if(question.addQuestion) {
+      const objectTypeSchema = Joi.object({
+        [question.checkboxAnswerId ?? question.id]: checkboxValidation,
+        [question.addQuestion.id]: QuestionValidatorFactory.validate(question.addQuestion)
+      });
+      return Joi.array().items(objectTypeSchema).min(1);
+    }
+
+    return checkboxValidation;
   }
 }
 

--- a/libs/shared/models/schema-engine/schema.validations.ts
+++ b/libs/shared/models/schema-engine/schema.validations.ts
@@ -76,6 +76,7 @@ const checkboxArray = Joi.object({
   label: Joi.string().min(1).required(),
   description: Joi.string().min(1).optional(),
   validations: Joi.object({ isRequired, max, min }),
+  checkboxAnswerId: id.optional(),
   items: Joi.array()
     .items(
       Joi.object({ type: 'separator' }),
@@ -88,7 +89,7 @@ const checkboxArray = Joi.object({
       })
     )
     .required(),
-  addQuestion: Joi.alternatives(text, textArea, radioGroup)
+  addQuestion: Joi.alternatives(text, textArea, radioGroup),
 });
 
 const fieldsGroup = Joi.object({


### PR DESCRIPTION
**Description:**
This PR enables `checkbox-arrays` to accept an array of objects when `addQuestion` is defined. Additionally an `checkboxAnswerId` can be defined to override the checkboxId.

Taking into consideration this question schema definition:
```
{
  id: 'standards',
  dataType: 'checkbox-array',
  label: 'Which regulations, standards and certifications apply to your innovation?',
  addQuestion: {
    id: 'hasMet',
    dataType: 'radio-group',
    label: 'Do you have a certification for {{item}}',
    items: [{ id: 'YES', label: 'Yes' }]
  },
  items: [
    {
      id: 'CE_UKCA_NON_MEDICAL',
      label: 'Non-medical device',
      group: 'UKCA / CE'
    }
  ]
}
```

The outbound payload for this question would be something of the following:
```
{
  standards: [
    { standards: 'CE_UKCA_CLASS_I', hasMet: 'IN_PROGRESS' }
  ]
}
```

On the other hand, if the `checkboxAnswerId` is defined as `type` the result would be:
```
{
  standards: [
    { type: 'CE_UKCA_CLASS_I', hasMet: 'IN_PROGRESS' }
  ]
}
```

**Related tickets:**
- Closes [AB#172645](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/172645).
- US: [AB#171057](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/171057).