### PR TITLE
allow innovation to have multiple assessments

### DIFF
--- a/apps/innovations/_services/innovation-assessments.service.spec.ts
+++ b/apps/innovations/_services/innovation-assessments.service.spec.ts
@@ -188,6 +188,21 @@ describe('Innovation Assessments Suite', () => {
         )
       ).rejects.toThrowError(new UnprocessableEntityError(InnovationErrorsEnum.INNOVATION_ASSESSMENT_ALREADY_EXISTS));
     });
+
+    it('should update the innovation current assessment', async () => {
+      const assessment = await sut.createInnovationAssessment(
+        DTOsHelper.getUserRequestContext(scenario.users.paulNeedsAssessor),
+        innovationWithoutAssessment.id,
+        { message: 'test assessment' },
+        em
+      );
+
+      const innovation = await em
+        .getRepository(InnovationEntity)
+        .findOne({ where: { id: innovationWithoutAssessment.id }, relations: ['currentAssessment'] });
+
+      expect(innovation?.currentAssessment?.id).toBe(assessment.id);
+    });
   });
 
   describe('updateInnovationAssessment', () => {

--- a/apps/innovations/_services/innovation-assessments.service.ts
+++ b/apps/innovations/_services/innovation-assessments.service.ts
@@ -38,9 +38,9 @@ import type { InnovationAssessmentType } from '../_types/innovation.types';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { EntityManager } from 'typeorm';
 import { BaseService } from './base.service';
+import type { InnovationDocumentService } from './innovation-document.service';
 import type { InnovationThreadsService } from './innovation-threads.service';
 import SYMBOLS from './symbols';
-import type { InnovationDocumentService } from './innovation-document.service';
 
 @injectable()
 export class InnovationAssessmentsService extends BaseService {
@@ -404,6 +404,7 @@ export class InnovationAssessmentsService extends BaseService {
     data: { updatedInnovationRecord: YesOrNoCatalogueType; description: string },
     entityManager?: EntityManager
   ): Promise<{ assessment: { id: string }; reassessment: { id: string } }> {
+    if (1 < Number(5)) throw new Error('TODO');
     const connection = entityManager ?? this.sqlConnection.manager;
 
     const innovation = await connection

--- a/apps/innovations/_services/innovation-assessments.service.ts
+++ b/apps/innovations/_services/innovation-assessments.service.ts
@@ -65,9 +65,6 @@ export class InnovationAssessmentsService extends BaseService {
       .leftJoinAndSelect('assessment.assignTo', 'assignTo')
       .leftJoinAndSelect('assessment.organisationUnits', 'organisationUnit')
       .leftJoinAndSelect('organisationUnit.organisation', 'organisation')
-      // Deleted assessments are necessary for history / activity log purposes.
-      // This query will retrieve deleted records from InnovationAssessmentEntity and InnovationReassessmentRequestEntity.
-      .withDeleted()
       .leftJoinAndSelect('assessment.reassessmentRequest', 'reassessmentRequest')
       .where('assessment.id = :assessmentId', { assessmentId })
       .getOne();

--- a/apps/innovations/_services/innovations.service.ts
+++ b/apps/innovations/_services/innovations.service.ts
@@ -1274,20 +1274,20 @@ export class InnovationsService extends BaseService {
       .getRawOne();
 
     // Fetch users names.
-    const assessmentUsersIds = innovation.currentAssessment?.assignTo?.id ?? [];
+    const assessmentUsersId = innovation.currentAssessment?.assignTo?.id;
     const categories = documentData.categories ? JSON.parse(documentData.categories) : [];
-    let usersInfo = [];
+    let usersInfo: Awaited<ReturnType<DomainService['users']['getUsersList']>> = [];
     let ownerInfo = undefined;
     let ownerPreferences = undefined;
 
     if (innovation.owner && innovation.owner.status !== UserStatusEnum.DELETED) {
       ownerPreferences = await this.domainService.users.getUserPreferences(innovation.owner.id);
       usersInfo = await this.domainService.users.getUsersList({
-        userIds: [...assessmentUsersIds, ...[innovation.owner.id]]
+        userIds: [innovation.owner.id, ...(assessmentUsersId ? [assessmentUsersId] : [])]
       });
       ownerInfo = usersInfo.find(item => item.id === innovation.owner?.id);
-    } else {
-      usersInfo = await this.domainService.users.getUsersList({ userIds: [...assessmentUsersIds] });
+    } else if (assessmentUsersId) {
+      usersInfo = await this.domainService.users.getUsersList({ userIds: [assessmentUsersId] });
     }
 
     // Assessment parsing.

--- a/apps/users/_services/statistics.service.ts
+++ b/apps/users/_services/statistics.service.ts
@@ -27,7 +27,7 @@ export class StatisticsService extends BaseService {
 
     const query = await em
       .createQueryBuilder(InnovationEntity, 'innovation')
-      .leftJoinAndSelect('innovation.assessments', 'assessments')
+      .leftJoin('innovation.currentAssessment', 'currentAssessment')
       .where('innovation.status IN (:...assessmentInnovationStatus)', {
         assessmentInnovationStatus: [InnovationStatusEnum.WAITING_NEEDS_ASSESSMENT]
       })
@@ -35,11 +35,11 @@ export class StatisticsService extends BaseService {
 
     const overdueCount = await em
       .createQueryBuilder(InnovationEntity, 'innovation')
-      .leftJoinAndSelect('innovation.assessments', 'assessments')
+      .leftJoin('innovation.currentAssessment', 'currentAssessment')
       .where('innovation.status IN (:...assessmentInnovationStatus)', {
         assessmentInnovationStatus: [InnovationStatusEnum.WAITING_NEEDS_ASSESSMENT]
       })
-      .andWhere(`DATEDIFF(day, innovation.submitted_at, GETDATE()) > 7 AND assessments.finished_at IS NULL`)
+      .andWhere(`DATEDIFF(day, innovation.submitted_at, GETDATE()) > 7 AND currentAssessment.finished_at IS NULL`)
       .getCount();
 
     return {
@@ -56,8 +56,8 @@ export class StatisticsService extends BaseService {
 
     const count = await em
       .createQueryBuilder(InnovationEntity, 'innovation')
-      .leftJoinAndSelect('innovation.assessments', 'assessments')
-      .leftJoinAndSelect('assessments.assignTo', 'assignTo')
+      .leftJoin('innovation.currentAssessment', 'currentAssessment')
+      .leftJoin('currentAssessment.assignTo', 'assignTo')
       .where('innovation.status IN (:...assessmentInnovationStatus)', {
         assessmentInnovationStatus: [InnovationStatusEnum.NEEDS_ASSESSMENT]
       })
@@ -66,22 +66,21 @@ export class StatisticsService extends BaseService {
 
     const total = await em
       .createQueryBuilder(InnovationEntity, 'innovation')
-      .leftJoinAndSelect('innovation.assessments', 'assessments')
-      .leftJoinAndSelect('assessments.assignTo', 'assignTo')
+      .leftJoin('innovation.currentAssessment', 'currentAssessment')
+      .leftJoin('currentAssessment.assignTo', 'assignTo')
       .where('innovation.status IN (:...assessmentInnovationStatus)', {
         assessmentInnovationStatus: [InnovationStatusEnum.NEEDS_ASSESSMENT]
       })
-
       .getCount();
 
     const overdueCount = await em
       .createQueryBuilder(InnovationEntity, 'innovation')
-      .leftJoinAndSelect('innovation.assessments', 'assessments')
-      .leftJoinAndSelect('assessments.assignTo', 'assignTo')
+      .leftJoin('innovation.currentAssessment', 'currentAssessment')
+      .leftJoin('currentAssessment.assignTo', 'assignTo')
       .where('innovation.status IN (:...assessmentInnovationStatus)', {
         assessmentInnovationStatus: [InnovationStatusEnum.NEEDS_ASSESSMENT]
       })
-      .andWhere(`DATEDIFF(day, innovation.submitted_at, GETDATE()) > 7 AND assessments.finished_at IS NULL`)
+      .andWhere(`DATEDIFF(day, innovation.submitted_at, GETDATE()) > 7 AND currentAssessment.finished_at IS NULL`)
       .andWhere('assignTo.id = :userId', { userId })
       .getCount();
 
@@ -173,8 +172,8 @@ export class StatisticsService extends BaseService {
               'innovationSupports.innovation_id = innovations.id AND innovationSupports.organisation_unit_id = :organisationUnit',
               { organisationUnit }
             )
-            .leftJoin('innovations.assessments', 'assessments')
-            .leftJoin('assessments.organisationUnits', 'assessmentOrganisationUnits')
+            .leftJoin('innovations.currentAssessment', 'currentAssessment')
+            .leftJoin('currentAssessment.organisationUnits', 'assessmentOrganisationUnits')
             .leftJoin('innovations.innovationSupportLogs', 'supportLogs', 'supportLogs.type = :supportLogType', {
               supportLogType: InnovationSupportLogTypeEnum.ACCESSOR_SUGGESTION
             })

--- a/libs/data-access/migrations/1721135878744-alter-tables-innovation-assessment-add-current-previous.ts
+++ b/libs/data-access/migrations/1721135878744-alter-tables-innovation-assessment-add-current-previous.ts
@@ -14,6 +14,22 @@ export class alterTableInnovationAssessmentAddCurrentPrevious1721135878744 imple
         WHERE id IN (select innovation_assessment_id from innovation_reassessment_request);
     `);
 
+    // Set the current assessment id
+    await queryRunner.query(`
+      UPDATE innovation SET current_assessment_id = t2.id
+      FROM innovation i
+      INNER JOIN (
+        SELECT a.innovation_id, id
+        FROM innovation_assessment a
+        INNER JOIN  (
+          SELECT innovation_id, MAX(created_at) as created_at
+          FROM innovation_assessment
+          WHERE deleted_at IS NULL
+          GROUP by innovation_id) t on t.innovation_id = a.innovation_id AND t.created_at = a.created_at
+      ) t2 ON i.id = t2.innovation_id;
+    `);
+
+    // Set the previous assessment id
     await queryRunner.query(`
       WITH previous AS (
         SELECT innovation_id, id, created_at,

--- a/libs/data-access/migrations/1721135878744-alter-tables-innovation-assessment-add-current-previous.ts
+++ b/libs/data-access/migrations/1721135878744-alter-tables-innovation-assessment-add-current-previous.ts
@@ -1,0 +1,45 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class alterTableInnovationAssessmentAddCurrentPrevious1721135878744 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "innovation" ADD current_assessment_id uniqueidentifier;
+      ALTER TABLE "innovation_assessment" ADD previous_assessment_id uniqueidentifier;
+      
+      DROP INDEX "idx_innovation_id_deleted_at_null" ON "innovation_assessment";
+      
+      -- Recover only the assessments that are related to reassessment requests
+      -- at least in production once there was an assessment that got deleted because it was created duplicate
+      UPDATE innovation_assessment SET DELETED_AT=NULL
+        WHERE id IN (select innovation_assessment_id from innovation_reassessment_request);
+    `);
+
+    await queryRunner.query(`
+      WITH previous AS (
+        SELECT innovation_id, id, created_at,
+        LAG(id) OVER (PARTITION BY innovation_id ORDER BY created_at ASC) AS previous_assessment_id
+        FROM innovation_assessment
+        WHERE deleted_at IS NULL
+      ) UPDATE innovation_assessment
+      SET previous_assessment_id = p.previous_assessment_id
+      FROM innovation_assessment a
+      INNER JOIN previous p ON a.id = p.id
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "innovation" DROP COLUMN current_assessment_id;
+      ALTER TABLE "innovation_assessment" DROP COLUMN previous_assessment_id;
+
+      UPDATE innovation_assessment SET DELETED_AT=GETDATE()
+        WHERE id IN (select innovation_assessment_id from innovation_reassessment_request);
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "idx_innovation_id_deleted_at_null"
+      ON innovation_assessment (innovation_id)
+      WHERE deleted_at IS NULL;
+    `);
+  }
+}

--- a/libs/data-access/migrations/1721223997621-alter-view-innovation-list-add-last-assessment-request.ts
+++ b/libs/data-access/migrations/1721223997621-alter-view-innovation-list-add-last-assessment-request.ts
@@ -1,6 +1,6 @@
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AlterViewInnovationListAddLastAssessmentRequest1712228260385 implements MigrationInterface {
+export class AlterViewInnovationListAddLastAssessmentRequest1721223997621 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
     CREATE OR ALTER VIEW innovation_list_view AS
@@ -15,6 +15,7 @@ export class AlterViewInnovationListAddLastAssessmentRequest1712228260385 implem
       i.updated_at,
       i.archived_status,
       i.status_updated_at,
+      i.current_assessment_id,
       i.last_assessment_request_at,
       gs.grouped_status as grouped_status
       FROM innovation i

--- a/libs/shared/entities/innovation/innovation-assessment.entity.ts
+++ b/libs/shared/entities/innovation/innovation-assessment.entity.ts
@@ -134,6 +134,12 @@ export class InnovationAssessmentEntity extends BaseEntity {
   })
   organisationUnits: OrganisationUnitEntity[];
 
+  @OneToOne(() => InnovationAssessmentEntity, record => record.previousAssessment, {
+    nullable: true
+  })
+  @JoinColumn({ name: 'previous_assessment_id' })
+  previousAssessment: InnovationAssessmentEntity | null;
+
   static new(data: Partial<InnovationAssessmentEntity>): InnovationAssessmentEntity {
     const instance = new InnovationAssessmentEntity();
     Object.assign(instance, data);

--- a/libs/shared/entities/innovation/innovation.entity.ts
+++ b/libs/shared/entities/innovation/innovation.entity.ts
@@ -77,6 +77,10 @@ export class InnovationEntity extends BaseEntity {
   })
   organisationShares: OrganisationEntity[];
 
+  @ManyToOne(() => InnovationAssessmentEntity, { nullable: true })
+  @JoinColumn({ name: 'current_assessment_id' })
+  currentAssessment: InnovationAssessmentEntity | null;
+
   @OneToMany(() => InnovationAssessmentEntity, record => record.innovation, {
     cascade: ['insert', 'update']
   })

--- a/libs/shared/entities/views/innovation-list-view.entity.ts
+++ b/libs/shared/entities/views/innovation-list-view.entity.ts
@@ -1,4 +1,14 @@
-import { Column, JoinTable, ManyToMany, OneToMany, OneToOne, PrimaryColumn, ViewColumn, ViewEntity } from 'typeorm';
+import {
+  Column,
+  JoinColumn,
+  JoinTable,
+  ManyToMany,
+  OneToMany,
+  OneToOne,
+  PrimaryColumn,
+  ViewColumn,
+  ViewEntity
+} from 'typeorm';
 import type { InnovationGroupedStatusEnum, InnovationStatusEnum } from '../../enums';
 import type {
   catalogCareSettings,
@@ -83,8 +93,9 @@ export class InnovationListView {
   @Column({ name: 'engaging_units', type: 'simple-json' })
   engagingUnits: { unitId: string; name: string; acronym: string; assignedAccessors: string[] | null }[] | null;
 
-  @OneToOne(() => InnovationAssessmentEntity, record => record.innovation)
-  assessment: InnovationAssessmentEntity | null;
+  @OneToOne(() => InnovationAssessmentEntity)
+  @JoinColumn({ name: 'current_assessment_id' })
+  currentAssessment: InnovationAssessmentEntity | null;
 
   @OneToMany(() => InnovationSupportEntity, record => record.innovation)
   supports: InnovationSupportEntity[] | null;

--- a/libs/shared/services/domain/domain-innovations.service.ts
+++ b/libs/shared/services/domain/domain-innovations.service.ts
@@ -899,8 +899,9 @@ export class DomainInnovationsService {
   ): Promise<CurrentElasticSearchDocumentType | undefined | CurrentElasticSearchDocumentType[]> {
     let sql = `WITH
       innovations AS (
-        SELECT i.id, i.status, archived_status, status_updated_at, submitted_at, i.updated_at, last_assessment_request_at, grouped_status,
-          u.id AS owner_id, u.external_id AS owner_external_id, u.status AS owner_status, o.name AS owner_company
+        SELECT i.id, i.status, archived_status, status_updated_at, submitted_at, i.updated_at, i.current_assessment_id, 
+        last_assessment_request_at, grouped_status, u.id AS owner_id, u.external_id AS owner_external_id, 
+        u.status AS owner_status, o.name AS owner_company
         FROM innovation i
           INNER JOIN innovation_grouped_status_view_entity g ON i.id = g.id
           LEFT JOIN [user] u on i.owner_id = u.id AND u.status !='DELETED'
@@ -983,7 +984,7 @@ export class DomainInnovationsService {
       ) AS suggestions
     FROM innovations i
       INNER JOIN innovation_document d ON i.id = d.id
-      LEFT JOIN innovation_assessment a ON i.id = a.innovation_id AND a.deleted_at IS NULL`;
+      LEFT JOIN innovation_assessment a ON i.id = a.innovation_id AND i.current_assessment_id = a.id AND a.deleted_at IS NULL`;
 
     if (innovationId) {
       sql += ` WHERE i.id = @0`;

--- a/libs/shared/tests/builders/innovation-assessment.builder.ts
+++ b/libs/shared/tests/builders/innovation-assessment.builder.ts
@@ -1,6 +1,6 @@
 import { randProductDescription, randText } from '@ngneat/falso';
 import type { DeepPartial, EntityManager } from 'typeorm';
-import { InnovationAssessmentEntity } from '../../entities/innovation/innovation-assessment.entity';
+import { InnovationAssessmentEntity, InnovationEntity } from '../../entities';
 import type { MaturityLevelCatalogueType, YesPartiallyNoCatalogueType } from '../../enums/index';
 import { BaseBuilder } from './base.builder';
 import type { TestOrganisationUnitType } from './organisation-unit.builder';
@@ -93,6 +93,12 @@ export class InnovationAssessmentBuilder extends BaseBuilder {
       .createQueryBuilder(InnovationAssessmentEntity, 'assessment')
       .where('assessment.id = :id', { id: savedAssessment.id })
       .getOne();
+
+    await this.getEntityManager().update(
+      InnovationEntity,
+      { id: this.assessment.innovation?.id },
+      { currentAssessment: { id: savedAssessment.id } }
+    );
 
     if (!result) {
       throw new Error('Error saving/retriving assessment information.');


### PR DESCRIPTION
Changes to the underlying schema so that an innovation can have multiple assessments including:
- ability to get current assessment
- ability to see previous assessment
- migration and recovery of previous data

Closes: [AB#172876](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/172876), [AB#172877](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/172877)
Related: [AB#170983](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/170983)