### PR TITLE
task: persist schema in redis

### DIFF
--- a/apps/innovations/_services/innovation-file.service.ts
+++ b/apps/innovations/_services/innovation-file.service.ts
@@ -366,10 +366,11 @@ export class InnovationFileService extends BaseService {
   ): Promise<{ id: string }> {
     const connection = entityManager ?? this.sqlConnection.manager;
 
+    const schema = await this.irSchemaService.getSchema();
     if (
       innovationStatus === InnovationStatusEnum.CREATED &&
       data.context.type === InnovationFileContextTypeEnum.INNOVATION_SECTION &&
-      !this.irSchemaService.canUploadFiles(data.context.id)
+      !schema.model.canUploadFiles(data.context.id)
     ) {
       throw new UnprocessableEntityError(InnovationErrorsEnum.INNOVATION_FILE_FORBIDDEN_SECTION);
     }

--- a/apps/innovations/v1-innovation-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-create/index.spec.ts
@@ -7,8 +7,8 @@ import { randProductDescription, randProductName, randUuid } from '@ngneat/falso
 import { InnovationsService } from '../_services/innovations.service';
 import type { ResponseDTO } from './transformation.dtos';
 import type { BodyType } from './validation.schemas';
-import { IRSchemaService } from '@innovations/shared/services';
 import Joi from 'joi';
+import { SchemaModel } from '@innovations/shared/models';
 
 jest.mock('@innovations/shared/decorators', () => ({
   JwtDecoder: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
@@ -36,9 +36,10 @@ const sampleBody = {
 const expected = { id: randUuid() };
 const mock = jest.spyOn(InnovationsService.prototype, 'createInnovation').mockResolvedValue(expected);
 const calculatedFieldsMock = jest
-  .spyOn(IRSchemaService.prototype, 'getCalculatedFields')
+  .spyOn(SchemaModel.prototype, 'getCalculatedFields')
   .mockReturnValue({ countryName: 'England' });
-const payloadValidationMock = jest.spyOn(IRSchemaService.prototype, 'getPayloadValidation')
+const payloadValidationMock = jest
+  .spyOn(SchemaModel.prototype, 'getSubSectionPayloadValidation')
   .mockReturnValue(Joi.object());
 
 afterEach(() => {

--- a/apps/innovations/v1-innovation-create/index.ts
+++ b/apps/innovations/v1-innovation-create/index.ts
@@ -38,10 +38,11 @@ class V1InnovationCreate {
       const requestBody = JoiHelper.Validate<BodyType>(BodySchema, request.body);
 
       // Validate Payload
-      const validation = irSchemaService.getPayloadValidation('INNOVATION_DESCRIPTION', requestBody);
+      const schema = await irSchemaService.getSchema();
+      const validation = schema.model.getSubSectionPayloadValidation('INNOVATION_DESCRIPTION', requestBody);
       const body = JoiHelper.Validate<BodySchemaAfterCalculatedFieldsType>(BodySchemaAfterCalculatedFieldsSchema, {
         ...JoiHelper.Validate<BodyType>(validation, requestBody),
-        ...irSchemaService.getCalculatedFields('INNOVATION_DESCRIPTION', requestBody)
+        ...schema.model.getCalculatedFields('INNOVATION_DESCRIPTION', requestBody)
       });
 
       const auth = await authorizationService.validate(context).checkInnovatorType().verify();

--- a/apps/innovations/v1-innovation-section-update/index.ts
+++ b/apps/innovations/v1-innovation-section-update/index.ts
@@ -37,15 +37,15 @@ class V1InnovationSectionUpdate {
         throw new ConflictError(InnovationErrorsEnum.INNOVATION_RECORD_SCHEMA_VERSION_MISMATCH);
       }
 
-      if (!irSchemaService.isSubsectionValid(params.sectionKey)) {
+      if (!schema.model.isSubsectionValid(params.sectionKey)) {
         throw new InternalServerError(InnovationErrorsEnum.INNOVATION_SECTIONS_CONFIG_UNAVAILABLE);
       }
 
       // Validate Payload
-      const validation = irSchemaService.getPayloadValidation(params.sectionKey, request.body['data']);
+      const validation = schema.model.getSubSectionPayloadValidation(params.sectionKey, request.body['data']);
       const body = {
         ...JoiHelper.Validate<{ [key: string]: any }>(validation, request.body['data']),
-        ...irSchemaService.getCalculatedFields(params.sectionKey, request.body['data'])
+        ...schema.model.getCalculatedFields(params.sectionKey, request.body['data'])
       };
 
       const result = await innovationSectionsService.updateInnovationSectionInfo(

--- a/apps/innovations/v1-ir-schema-info/index.spec.ts
+++ b/apps/innovations/v1-ir-schema-info/index.spec.ts
@@ -5,6 +5,7 @@ import type { TestUserType } from '@innovations/shared/tests/builders/user.build
 import type { ErrorResponseType } from '@innovations/shared/types';
 import type { ResponseDTO } from './transformation.dtos';
 import { IRSchemaService } from '@innovations/shared/services';
+import { SchemaModel } from '@innovations/shared/models';
 
 jest.mock('@innovations/shared/decorators', () => ({
   JwtDecoder: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => descriptor),
@@ -18,13 +19,12 @@ beforeAll(async () => {
   await testsHelper.init();
 });
 
-const expected = {
-  version: 1,
-  schema: [
-    { id: 'id1', title: 'Section 1', subSections: [] },
-    { id: 'id2', title: 'Section 2', subSections: [] }
-  ]
-};
+const model = new SchemaModel([
+  { id: 'id1', title: 'Section 1', subSections: [] },
+  { id: 'id2', title: 'Section 2', subSections: [] }
+]);
+model.runRules();
+const expected = { version: 1, model };
 const mock = jest.spyOn(IRSchemaService.prototype, 'getSchema').mockResolvedValue(expected as any);
 
 afterEach(() => {
@@ -38,7 +38,7 @@ describe('v1-innovations-search Suite', () => {
         .setAuth(scenario.users.aliceQualifyingAccessor)
         .call<ResponseDTO>(azureFunction);
 
-      expect(result.body).toStrictEqual(expected);
+      expect(result.body).toStrictEqual({ version: expected.version, schema: expected.model.schema });
       expect(result.status).toBe(200);
       expect(mock).toHaveBeenCalledTimes(1);
     });

--- a/apps/innovations/v1-ir-schema-info/index.ts
+++ b/apps/innovations/v1-ir-schema-info/index.ts
@@ -28,7 +28,7 @@ class V1IrSchemaInfo {
 
       const schema = await irSchemaService.getSchema();
 
-      context.res = ResponseHelper.Ok<ResponseDTO>(schema);
+      context.res = ResponseHelper.Ok<ResponseDTO>({ version: schema.version, schema: schema.model.schema });
       return;
     } catch (error) {
       context.res = ResponseHelper.Error(context, error);

--- a/libs/shared/services/storage/cache.service.ts
+++ b/libs/shared/services/storage/cache.service.ts
@@ -15,6 +15,7 @@ import { RedisCache } from './redis-cache.service';
  */
 export type CacheConfigType = {
   IdentityUserInfo: RedisCache<IdentityUserInfo>;
+  IrSchema: RedisCache<number>; // Saves de latest version
 };
 
 @injectable()
@@ -34,7 +35,8 @@ export class CacheService {
     this.redis = this.redisService.client;
     // Setting the cacheConfigMap here before connecting so that it's already available at injection time
     this.cacheConfigMap = {
-      IdentityUserInfo: new RedisCache<IdentityUserInfo>(this.redis, this.logger, 'IdentityUserInfo')
+      IdentityUserInfo: new RedisCache<IdentityUserInfo>(this.redis, this.logger, 'IdentityUserInfo'),
+      IrSchema: new RedisCache<number>(this.redis, this.logger, 'IrSchema')
     };
   }
 


### PR DESCRIPTION
**Description:**
Changed the schema persistence mechanism from in-memory, introduced in #346, to using Redis. This change enhances the system's robustness and prepares it for horizontal scaling. With in-memory persistence, schema versions might not sync between instances, leading to potential inconsistencies.

Additionally, a refactor was conducted to simplify the responsibilities of the service and the model.

**Related tickets:**
- Closes AB#172665.
- US: AB#172720.