### PR TITLE
multiple create reassessment fixes

### DIFF
--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -2134,7 +2134,12 @@ paths:
           application/json:
             schema:
               type: object
-              properties: {}
+              properties:
+                description:
+                  type: string
+                  maxLength: 2000
+              required:
+                - description
               additionalProperties: false
               oneOf:
                 - type: object
@@ -2144,21 +2149,8 @@ paths:
                       enum:
                         - YES
                         - NO
-                    description:
-                      type: string
-                      maxLength: 2000
                   required:
                     - updatedInnovationRecord
-                    - description
-                  additionalProperties: false
-                  x-required: true
-                - type: object
-                  properties:
-                    description:
-                      type: string
-                      maxLength: 2000
-                  required:
-                    - description
                   additionalProperties: false
                   x-required: true
       responses:

--- a/apps/innovations/_services/innovation-assessments.service.ts
+++ b/apps/innovations/_services/innovation-assessments.service.ts
@@ -559,8 +559,6 @@ export class InnovationAssessmentsService extends BaseService {
 
       await this.documentService.syncDocumentVersions(domainContext, innovationId, transaction, { updatedAt: now });
 
-      await transaction.softDelete(InnovationAssessmentEntity, { id: assessment.id });
-
       const assessmentClone = await transaction.save(
         InnovationAssessmentEntity,
         (({
@@ -575,8 +573,14 @@ export class InnovationAssessmentsService extends BaseService {
           exemptedAt,
           exemptedReason,
           exemptedMessage,
+          previousAssessment,
           ...item
-        }) => ({ ...item, createdBy: domainContext.id, updatedBy: domainContext.id }))(assessment) // Clones assessment variable, without some keys (id, finishedAt, ...).
+        }) => ({
+          ...item,
+          createdBy: domainContext.id,
+          updatedBy: domainContext.id,
+          previousAssessment: { id: assessment.id }
+        }))(assessment) // Clones assessment variable, without some keys (id, finishedAt, ...).
       );
 
       await transaction.update(

--- a/apps/innovations/_services/innovation-assessments.service.ts
+++ b/apps/innovations/_services/innovation-assessments.service.ts
@@ -464,7 +464,7 @@ export class InnovationAssessmentsService extends BaseService {
         'support.archiveSnapshot'
       ])
       .leftJoin('innovation.owner', 'innovationOwner')
-      .innerJoin('innovation.innovationSupports', 'support')
+      .leftJoin('innovation.innovationSupports', 'support')
       .where('innovation.id = :innovationId', { innovationId })
       .getOne();
 


### PR DESCRIPTION
Fixes:
- create reassessment as NA for innovations without support
- missing current assessment update
- missing link to previous assessment 
- deleting previous assessment

![image](https://github.com/user-attachments/assets/2c85bee6-0823-44fa-b223-f20268c753e7)
