### PR TITLE
task: cleanup ir document using the schema definition

### DIFF
--- a/libs/shared/services/domain/domain.service.ts
+++ b/libs/shared/services/domain/domain.service.ts
@@ -4,6 +4,7 @@ import type { DataSource } from 'typeorm';
 import { GenericErrorsEnum, ServiceUnavailableError } from '../../errors';
 import type { IdentityProviderService } from '../integrations/identity-provider.service';
 import type { NotifierService } from '../integrations/notifier.service';
+import type { IRSchemaService } from '../storage/ir-schema.service';
 import type { SqlProvider } from '../storage/sql-connection.provider';
 import SHARED_SYMBOLS from '../symbols';
 import { DomainInnovationsService } from './domain-innovations.service';
@@ -34,9 +35,9 @@ export class DomainService {
     @inject(SHARED_SYMBOLS.IdentityProviderService)
     private identityProviderService: IdentityProviderService,
     @inject(SHARED_SYMBOLS.SqlProvider) public sqlProvider: SqlProvider,
-    @inject(SHARED_SYMBOLS.NotifierService)
-    private notifierService: NotifierService,
-  ) {}
+    @inject(SHARED_SYMBOLS.NotifierService) private notifierService: NotifierService,
+    @inject(SHARED_SYMBOLS.IRSchemaService) private irSchemaService: IRSchemaService
+  ) { }
 
   setConnection(connection: DataSource): void {
     this._users = new DomainUsersService(connection, this.identityProviderService);
@@ -44,7 +45,8 @@ export class DomainService {
       connection,
       this.identityProviderService,
       this.notifierService,
-      this._users
+      this._users,
+      this.irSchemaService
     );
   }
 }


### PR DESCRIPTION
**Description:**
This PR introduces a dynamic approach to cleaning an IR document. Previously, this was done by using Joi, but since the IR schema is now dynamic, a new cleanup method was required.

This feature is necessary to prevent old/deprecated IR fields from being sent to the ElasticSearch index.

**Related tickets:**
- Closes AB#173074.
- US: AB#172720.