### PR TITLE
task: autocomplete-array with size 1 should be string

### DIFF
--- a/libs/shared/models/schema-engine/question.validator.ts
+++ b/libs/shared/models/schema-engine/question.validator.ts
@@ -69,6 +69,11 @@ export class AutocompleteArrayValidator implements QuestionTypeValidator<Autocom
       validation = validation.items(Joi.string().valid(...validItems));
     }
     if (question.validations?.max) {
+      if (question.validations.max.length === 1) {
+        return Joi.string()
+          .valid(...validItems)
+          .required();
+      }
       validation = validation.max(question.validations.max.length);
     }
     if (question.validations?.min) {


### PR DESCRIPTION
**Description:**
The `autocomplete-array` type should be treated as a single string when its max size is 1.