### PR TITLE
Task/add versioning to assessments

### DIFF
--- a/libs/data-access/migrations/1722417284459-remove-na-created-reassessments.ts
+++ b/libs/data-access/migrations/1722417284459-remove-na-created-reassessments.ts
@@ -1,0 +1,57 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class removeNaCreatedReAssessments1722417284459 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      -- Turn OFF history from assessment table
+      ALTER TABLE innovation_assessment SET (SYSTEM_VERSIONING = OFF)
+
+      -- Variables to save the current ids
+      DECLARE @reassessment_id  UNIQUEIDENTIFIER;
+      DECLARE @assessment_id UNIQUEIDENTIFIER;
+      DECLARE @innovation_id UNIQUEIDENTIFIER;
+
+      DECLARE reassessment_cursor CURSOR FOR
+      SELECT id as reasessment_id, innovation_assessment_id as assessment_id, innovation_id as innovation_id
+      FROM innovation_reassessment_request
+      WHERE updated_innovation_record IS NULL -- The ones created by NA doesn't have this column answered
+
+      OPEN reassessment_cursor;
+
+      FETCH NEXT FROM reassessment_cursor INTO @reassessment_id, @assessment_id, @innovation_id;
+
+      -- Loop over the cursor
+      WHILE @@FETCH_STATUS = 0
+      BEGIN
+          -- Delete the row from the reasseassment request
+          DELETE FROM innovation_reassessment_request
+          WHERE id = @reassessment_id;
+
+          -- Delete the row from the assessment request
+          DELETE FROM innovation_assessment
+          WHERE id = @assessment_id;
+
+          -- Get the new "current_assessment" after removing the invalid one.
+          UPDATE innovation
+          SET current_assessment_id = (
+              SELECT TOP 1 id
+              FROM innovation_assessment
+              WHERE innovation_id = @innovation_id
+              ORDER BY started_at DESC
+          )
+          WHERE id = @innovation_id
+
+          -- Fetch the next row
+          FETCH NEXT FROM reassessment_cursor INTO @reassessment_id, @assessment_id, @innovation_id;
+      END
+
+      CLOSE reassessment_cursor;
+      DEALLOCATE reassessment_cursor;
+
+      -- Turn ON history from assessment table
+      ALTER TABLE innovation_assessment SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[innovation_assessment_history]));
+    `);
+  }
+
+  public async down(): Promise<void> {}
+}

--- a/libs/data-access/migrations/1722419269520-add-versioning-to-asessments.ts
+++ b/libs/data-access/migrations/1722419269520-add-versioning-to-asessments.ts
@@ -1,0 +1,72 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class addVersioningToAssessments1722419269520 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create versioning columns
+    await queryRunner.query(`
+      ALTER TABLE innovation_assessment ADD [major_version] smallint NOT NULL CONSTRAINT DF_innovation_assessment_major_version DEFAULT 0;
+      ALTER TABLE innovation_assessment ADD [minor_version] smallint NOT NULL CONSTRAINT DF_innovation_assessment_minor_version DEFAULT 0;
+    `);
+
+    // Populate versioning columns
+    await queryRunner.query(`
+      -- Declare variables to keep track of versions
+      DECLARE @current_innovation_id UNIQUEIDENTIFIER = '00000000-0000-0000-0101-000000000000';
+      DECLARE @major_version INT = 0;
+      DECLARE @minor_version INT = 0;
+
+      -- Variables to hold cursor info
+      DECLARE @id UNIQUEIDENTIFIER;
+      DECLARE @innovation_id UNIQUEIDENTIFIER;
+
+      DECLARE assessment_cursor CURSOR FOR
+      SELECT id, innovation_id
+      FROM innovation_assessment
+      ORDER BY innovation_id, created_at;
+
+      OPEN assessment_cursor;
+
+      FETCH NEXT FROM assessment_cursor INTO @id, @innovation_id;
+
+      -- Loop over the cursor
+      WHILE @@FETCH_STATUS = 0
+      BEGIN
+          -- Check if we are still on the same innovation_id
+          IF @current_innovation_id != @innovation_id
+          BEGIN
+              -- Reset versions and current innovation id
+              SET @current_innovation_id = @innovation_id;
+              SET @major_version = 1;
+              SET @minor_version = 0;
+          END
+
+          -- Update the table with the new versions
+          UPDATE innovation_assessment
+          SET "major_version" = @major_version, "minor_version" = @minor_version
+          WHERE id = @id;
+
+          -- Increment major version
+          SET @major_version = @major_version + 1;
+
+          -- Fetch the next row
+          FETCH NEXT FROM assessment_cursor INTO @id, @innovation_id;
+      END
+
+      CLOSE assessment_cursor;
+      DEALLOCATE assessment_cursor;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE innovation_assessment SET (SYSTEM_VERSIONING = OFF);
+      ALTER TABLE innovation_assessment DROP CONSTRAINT DF_innovation_assessment_major_version;
+      ALTER TABLE innovation_assessment DROP CONSTRAINT DF_innovation_assessment_minor_version;
+      ALTER TABLE innovation_assessment DROP COLUMN [major_version];
+      ALTER TABLE innovation_assessment DROP COLUMN [minor_version];
+      ALTER TABLE innovation_assessment_history DROP COLUMN [major_version];
+      ALTER TABLE innovation_assessment_history DROP COLUMN [minor_version];
+      ALTER TABLE innovation_assessment SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[innovation_assessment_history]));
+    `);
+  }
+}

--- a/libs/shared/entities/innovation/innovation-assessment.entity.ts
+++ b/libs/shared/entities/innovation/innovation-assessment.entity.ts
@@ -25,10 +25,10 @@ export class InnovationAssessmentEntity extends BaseEntity {
   id: string;
 
   @Column({ name: 'major_version', type: 'smallint' })
-  majorVersion: string;
+  majorVersion: number;
 
   @Column({ name: 'minor_version', type: 'smallint' })
-  minorVersion: string;
+  minorVersion: number;
 
   @Column({ name: 'description', type: 'nvarchar', nullable: true })
   description: null | string;

--- a/libs/shared/entities/innovation/innovation-assessment.entity.ts
+++ b/libs/shared/entities/innovation/innovation-assessment.entity.ts
@@ -24,6 +24,12 @@ export class InnovationAssessmentEntity extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
+  @Column({ name: 'major_version', type: 'smallint' })
+  majorVersion: string;
+
+  @Column({ name: 'minor_version', type: 'smallint' })
+  minorVersion: string;
+
   @Column({ name: 'description', type: 'nvarchar', nullable: true })
   description: null | string;
 


### PR DESCRIPTION
**Description:**
Migrations that remove the assessments and reassessments created by NA on dev and a migration that adds versioning to the assessments table.

**Related tickets:**
- Closes AB#173490.
- US: AB#173336.