### PR TITLE
Task/173517 add new fields to entity and create migration

### DIFF
--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -2106,62 +2106,6 @@ paths:
           description: Ok.
         "400":
           description: Bad request.
-  /v1/{innovationId}/reassessments:
-    post:
-      operationId: v1-innovation-reassessment-request-create
-      description: Create a reassessment request for an innovation.
-      summary: Create a reassessment request for an innovation.
-      tags:
-        - "[v1] Innovation Assessments"
-      parameters:
-        - name: innovationId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        description: Create a reassessment request for an innovation.
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                reassessmentReason:
-                  type: array
-                  items:
-                    type: string
-                  minItems: 1
-                otherReassessmentReason:
-                  type: string
-                  maxLength: 200
-                description:
-                  type: string
-                  maxLength: 1500
-                whatSupportDoYouNeed:
-                  type: string
-                  maxLength: 1500
-              required:
-                - reassessmentReason
-                - description
-                - whatSupportDoYouNeed
-              additionalProperties: false
-      responses:
-        "200":
-          description: Returns the reassessment request and the cloned assessment id
-        "400":
-          description: Bad request
-        "401":
-          description: Unauthorized
-        "403":
-          description: Forbidden
-        "404":
-          description: Not found
-        "422":
-          description: Unprocessable entity
-        "500":
-          description: Internal server error
   /v1/{innovationId}/sections/{sectionKey}:
     get:
       description: Get an innovation section info.

--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -2128,24 +2128,25 @@ paths:
             schema:
               type: object
               properties:
+                reassessmentReason:
+                  type: array
+                  items:
+                    type: string
+                  minItems: 1
+                otherReassessmentReason:
+                  type: string
+                  maxLength: 200
                 description:
                   type: string
-                  maxLength: 2000
+                  maxLength: 1500
+                whatSupportDoYouNeed:
+                  type: string
+                  maxLength: 1500
               required:
+                - reassessmentReason
                 - description
+                - whatSupportDoYouNeed
               additionalProperties: false
-              oneOf:
-                - type: object
-                  properties:
-                    updatedInnovationRecord:
-                      type: string
-                      enum:
-                        - YES
-                        - NO
-                  required:
-                    - updatedInnovationRecord
-                  additionalProperties: false
-                  x-required: true
       responses:
         "200":
           description: Returns the reassessment request and the cloned assessment id

--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -2106,6 +2106,67 @@ paths:
           description: Ok.
         "400":
           description: Bad request.
+  /v1/{innovationId}/reassessments:
+    post:
+      operationId: v1-innovation-reassessment-request-create
+      description: Create a reassessment request for an innovation.
+      summary: Create a reassessment request for an innovation.
+      tags:
+        - "[v1] Innovation Assessments"
+      parameters:
+        - name: innovationId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: Create a reassessment request for an innovation.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reassessmentReason:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - NO_SUPPORT
+                      - PREVIOUSLY_ARCHIVED
+                      - HAS_PROGRESSED_SIGNIFICANTLY
+                      - OTHER
+                  minItems: 1
+                otherReassessmentReason:
+                  type: string
+                  maxLength: 200
+                description:
+                  type: string
+                  maxLength: 1500
+                whatSupportDoYouNeed:
+                  type: string
+                  maxLength: 1500
+              required:
+                - reassessmentReason
+                - description
+                - whatSupportDoYouNeed
+              additionalProperties: false
+      responses:
+        "200":
+          description: Returns the reassessment request and the cloned assessment id
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not found
+        "422":
+          description: Unprocessable entity
+        "500":
+          description: Internal server error
   /v1/{innovationId}/sections/{sectionKey}:
     get:
       description: Get an innovation section info.

--- a/apps/innovations/_services/innovation-assessments.service.spec.ts
+++ b/apps/innovations/_services/innovation-assessments.service.spec.ts
@@ -418,7 +418,7 @@ describe('Innovation Assessments Suite', () => {
       const innovationReassessment = await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
         innovationWithAssessment.id,
-        { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
+        { reassessmentReason: ['NO_SUPPORT'], description: randText(), whatSupportDoYouNeed: randText() },
         em
       );
 
@@ -447,7 +447,7 @@ describe('Innovation Assessments Suite', () => {
       await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
         innovationWithAssessment.id,
-        { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
+        { reassessmentReason: ['NO_SUPPORT'], description: randText(), whatSupportDoYouNeed: randText() },
         em
       );
 
@@ -480,7 +480,7 @@ describe('Innovation Assessments Suite', () => {
         sut.createInnovationReassessment(
           DTOsHelper.getUserRequestContext(scenario.users.paulNeedsAssessor),
           innovationWithoutAssessment.id,
-          { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
+          { reassessmentReason: ['NO_SUPPORT'], description: randText(), whatSupportDoYouNeed: randText() },
           em
         )
       ).rejects.toThrow(new NotFoundError(InnovationErrorsEnum.INNOVATION_ASSESSMENT_NOT_FOUND));
@@ -491,7 +491,7 @@ describe('Innovation Assessments Suite', () => {
         sut.createInnovationReassessment(
           DTOsHelper.getUserRequestContext(scenario.users.janeInnovator),
           innovationWithArchivedStatus.id,
-          { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
+          { reassessmentReason: ['NO_SUPPORT'], description: randText(), whatSupportDoYouNeed: randText() },
           em
         )
       ).rejects.toThrow(new ForbiddenError(InnovationErrorsEnum.INNOVATION_COLLABORATOR_MUST_BE_OWNER));
@@ -502,7 +502,7 @@ describe('Innovation Assessments Suite', () => {
         sut.createInnovationReassessment(
           DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
           innovationWithAssessment.id,
-          { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
+          { reassessmentReason: ['NO_SUPPORT'], description: randText(), whatSupportDoYouNeed: randText() },
           em
         )
       ).rejects.toThrow(new UnprocessableEntityError(InnovationErrorsEnum.INNOVATION_CANNOT_REQUEST_REASSESSMENT));
@@ -513,7 +513,7 @@ describe('Innovation Assessments Suite', () => {
         sut.createInnovationReassessment(
           DTOsHelper.getUserRequestContext(scenario.users.paulNeedsAssessor),
           innovationWithArchivedStatus.id,
-          { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
+          { reassessmentReason: ['NO_SUPPORT'], description: randText(), whatSupportDoYouNeed: randText() },
           em
         )
       ).rejects.toThrow(new UnprocessableEntityError(InnovationErrorsEnum.INNOVATION_CANNOT_REQUEST_REASSESSMENT));
@@ -528,7 +528,7 @@ describe('Innovation Assessments Suite', () => {
       const innovationReassessment = await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.paulNeedsAssessor),
         innovationWithAssessment.id,
-        { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
+        { reassessmentReason: ['NO_SUPPORT'], description: randText(), whatSupportDoYouNeed: randText() },
         em
       );
 
@@ -556,7 +556,7 @@ describe('Innovation Assessments Suite', () => {
         const innovationReassessment = await sut.createInnovationReassessment(
           DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
           innovationWithAssessment.id,
-          { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
+          { reassessmentReason: ['NO_SUPPORT'], description: randText(), whatSupportDoYouNeed: randText() },
           em
         );
 
@@ -582,7 +582,7 @@ describe('Innovation Assessments Suite', () => {
       const { assessment } = await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
         innovationWithAssessment.id,
-        { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
+        { reassessmentReason: ['NO_SUPPORT'], description: randText(), whatSupportDoYouNeed: randText() },
         em
       );
 
@@ -600,7 +600,7 @@ describe('Innovation Assessments Suite', () => {
       const { assessment } = await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
         innovationWithAssessment.id,
-        { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
+        { reassessmentReason: ['NO_SUPPORT'], description: randText(), whatSupportDoYouNeed: randText() },
         em
       );
 
@@ -620,7 +620,7 @@ describe('Innovation Assessments Suite', () => {
       const { assessment } = await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
         innovationWithAssessment.id,
-        { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
+        { reassessmentReason: ['NO_SUPPORT'], description: randText(), whatSupportDoYouNeed: randText() },
         em
       );
 

--- a/apps/innovations/_services/innovation-assessments.service.spec.ts
+++ b/apps/innovations/_services/innovation-assessments.service.spec.ts
@@ -416,7 +416,7 @@ describe('Innovation Assessments Suite', () => {
       const innovationReassessment = await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
         innovationWithAssessment.id,
-        { updatedInnovationRecord: 'YES', description: randText() },
+        { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
         em
       );
 
@@ -445,7 +445,7 @@ describe('Innovation Assessments Suite', () => {
       await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
         innovationWithAssessment.id,
-        { updatedInnovationRecord: 'YES', description: randText() },
+        { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
         em
       );
 
@@ -478,7 +478,7 @@ describe('Innovation Assessments Suite', () => {
         sut.createInnovationReassessment(
           DTOsHelper.getUserRequestContext(scenario.users.paulNeedsAssessor),
           innovationWithoutAssessment.id,
-          { description: randText() },
+          { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
           em
         )
       ).rejects.toThrow(new NotFoundError(InnovationErrorsEnum.INNOVATION_ASSESSMENT_NOT_FOUND));
@@ -489,7 +489,7 @@ describe('Innovation Assessments Suite', () => {
         sut.createInnovationReassessment(
           DTOsHelper.getUserRequestContext(scenario.users.janeInnovator),
           innovationWithArchivedStatus.id,
-          { updatedInnovationRecord: 'YES', description: randText() },
+          { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
           em
         )
       ).rejects.toThrow(new ForbiddenError(InnovationErrorsEnum.INNOVATION_COLLABORATOR_MUST_BE_OWNER));
@@ -500,7 +500,7 @@ describe('Innovation Assessments Suite', () => {
         sut.createInnovationReassessment(
           DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
           innovationWithAssessment.id,
-          { updatedInnovationRecord: 'YES', description: randText() },
+          { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
           em
         )
       ).rejects.toThrow(new UnprocessableEntityError(InnovationErrorsEnum.INNOVATION_CANNOT_REQUEST_REASSESSMENT));
@@ -511,7 +511,7 @@ describe('Innovation Assessments Suite', () => {
         sut.createInnovationReassessment(
           DTOsHelper.getUserRequestContext(scenario.users.paulNeedsAssessor),
           innovationWithArchivedStatus.id,
-          { description: randText() },
+          { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
           em
         )
       ).rejects.toThrow(new UnprocessableEntityError(InnovationErrorsEnum.INNOVATION_CANNOT_REQUEST_REASSESSMENT));
@@ -526,7 +526,7 @@ describe('Innovation Assessments Suite', () => {
       const innovationReassessment = await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.paulNeedsAssessor),
         innovationWithAssessment.id,
-        { description: randText() },
+        { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
         em
       );
 
@@ -554,7 +554,7 @@ describe('Innovation Assessments Suite', () => {
         const innovationReassessment = await sut.createInnovationReassessment(
           DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
           innovationWithAssessment.id,
-          { updatedInnovationRecord: 'YES', description: randText() },
+          { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
           em
         );
 
@@ -580,7 +580,7 @@ describe('Innovation Assessments Suite', () => {
       const { assessment } = await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
         innovationWithAssessment.id,
-        { updatedInnovationRecord: 'YES', description: randText() },
+        { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
         em
       );
 
@@ -598,7 +598,7 @@ describe('Innovation Assessments Suite', () => {
       const { assessment } = await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
         innovationWithAssessment.id,
-        { updatedInnovationRecord: 'YES', description: randText() },
+        { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
         em
       );
 
@@ -618,7 +618,7 @@ describe('Innovation Assessments Suite', () => {
       const { assessment } = await sut.createInnovationReassessment(
         DTOsHelper.getUserRequestContext(scenario.users.johnInnovator),
         innovationWithAssessment.id,
-        { updatedInnovationRecord: 'YES', description: randText() },
+        { reassessmentReason: [], description: randText(), whatSupportDoYouNeed: randText() },
         em
       );
 

--- a/apps/innovations/_services/innovation-assessments.service.ts
+++ b/apps/innovations/_services/innovation-assessments.service.ts
@@ -610,31 +610,6 @@ export class InnovationAssessmentsService extends BaseService {
 
       await this.documentService.syncDocumentVersions(domainContext, innovationId, transaction, { updatedAt: now });
 
-      // const assessmentClone = await transaction.save(
-      //   InnovationAssessmentEntity,
-      //   (({
-      //     id,
-      //     finishedAt,
-      //     startedAt,
-      //     createdAt,
-      //     createdBy,
-      //     updatedAt,
-      //     updatedBy,
-      //     deletedAt,
-      //     assignTo,
-      //     exemptedAt,
-      //     exemptedReason,
-      //     exemptedMessage,
-      //     previousAssessment,
-      //     ...item
-      //   }) => ({
-      //     ...item,
-      //     createdBy: domainContext.id,
-      //     updatedBy: domainContext.id,
-      //     previousAssessment: { id: assessment.id }
-      //   }))(assessment) // Clones assessment variable, without some keys (id, finishedAt, ...).
-      // );
-
       const assessment = await transaction.save(
         InnovationAssessmentEntity,
         InnovationAssessmentEntity.new({

--- a/apps/innovations/_services/innovation-assessments.service.ts
+++ b/apps/innovations/_services/innovation-assessments.service.ts
@@ -99,6 +99,10 @@ export class InnovationAssessmentsService extends BaseService {
         'previousAssessment.id',
         'reassessmentRequest.updatedInnovationRecord',
         'reassessmentRequest.description',
+        'reassessmentRequest.reassessmentReason',
+        'reassessmentRequest.otherReassessmentReason',
+        'reassessmentRequest.whatSupportDoYouNeed',
+        'reassessmentRequest.createdAt',
         'innovation.id',
         'currentAssessment.id'
       ])
@@ -137,10 +141,16 @@ export class InnovationAssessmentsService extends BaseService {
       id: assessment.id,
       ...(assessment.reassessmentRequest && {
         reassessment: {
+          createdAt: assessment.reassessmentRequest.createdAt,
           ...(assessment.reassessmentRequest.updatedInnovationRecord && {
             updatedInnovationRecord: assessment.reassessmentRequest.updatedInnovationRecord
           }),
+          reassessmentReason: assessment.reassessmentRequest.reassessmentReason,
+          ...(assessment.reassessmentRequest.otherReassessmentReason && {
+            otherReassessmentReason: assessment.reassessmentRequest.otherReassessmentReason
+          }),
           description: assessment.reassessmentRequest.description,
+          whatSupportDoYouNeed: assessment.reassessmentRequest.whatSupportDoYouNeed,
           previousAssessmentId: assessment.previousAssessment!.id, // It's safe to assume that previousAssessment is not null here as it was validated before
           sectionsUpdatedSinceLastAssessment: await this.getSectionsUpdatedSincePreviousAssessment(
             assessment.id,
@@ -637,8 +647,10 @@ export class InnovationAssessmentsService extends BaseService {
         InnovationReassessmentRequestEntity.new({
           assessment: InnovationAssessmentEntity.new({ id: assessmentClone.id }),
           innovation: InnovationEntity.new({ id: innovationId }),
-          ...('updatedInnovationRecord' in data && { updatedInnovationRecord: data.updatedInnovationRecord }),
           description: data.description,
+          reassessmentReason: data.reassessmentReason,
+          ...(data.otherReassessmentReason && { otherReassessmentReason: data.otherReassessmentReason }),
+          whatSupportDoYouNeed: data.whatSupportDoYouNeed,
           createdBy: assessmentClone.createdBy,
           updatedBy: assessmentClone.updatedBy
         })

--- a/apps/innovations/_services/innovation-assessments.service.ts
+++ b/apps/innovations/_services/innovation-assessments.service.ts
@@ -559,9 +559,7 @@ export class InnovationAssessmentsService extends BaseService {
     // Get the latest assessment record.
     const previousAssessment = await connection
       .createQueryBuilder(InnovationAssessmentEntity, 'assessment')
-      .innerJoinAndSelect('assessment.innovation', 'innovation')
-      .leftJoinAndSelect('assessment.assignTo', 'assignTo')
-      .leftJoinAndSelect('assessment.organisationUnits', 'organisationUnits')
+      .select(['assessment.id', 'assessment.majorVersion'])
       .where('innovation.id = :innovationId', { innovationId })
       .orderBy('assessment.createdAt', 'DESC') // Not needed, but it doesn't do any harm.
       .getOne();

--- a/apps/innovations/_services/innovation-assessments.service.ts
+++ b/apps/innovations/_services/innovation-assessments.service.ts
@@ -560,7 +560,7 @@ export class InnovationAssessmentsService extends BaseService {
     const previousAssessment = await connection
       .createQueryBuilder(InnovationAssessmentEntity, 'assessment')
       .select(['assessment.id', 'assessment.majorVersion'])
-      .where('innovation.id = :innovationId', { innovationId })
+      .where('assessment.innovation_id = :innovationId', { innovationId })
       .orderBy('assessment.createdAt', 'DESC') // Not needed, but it doesn't do any harm.
       .getOne();
     if (!previousAssessment) {

--- a/apps/innovations/_types/innovation.types.ts
+++ b/apps/innovations/_types/innovation.types.ts
@@ -22,11 +22,14 @@ export interface InnovationSectionModel {
 }
 
 export type ReassessmentType = {
-  reassessmentReason: string[];
+  reassessmentReason: ReassessmentReasonsType[] | null;
   otherReassessmentReason?: string;
   description: string;
-  whatSupportDoYouNeed: string;
+  whatSupportDoYouNeed: string | null;
 };
+
+export const ReassessmentReasons = ['NO_SUPPORT', 'PREVIOUSLY_ARCHIVED', 'HAS_PROGRESSED_SIGNIFICANTLY', 'OTHER'];
+export type ReassessmentReasonsType = (typeof ReassessmentReasons)[number];
 
 export type InnovationAssessmentType = {
   id: string;

--- a/apps/innovations/_types/innovation.types.ts
+++ b/apps/innovations/_types/innovation.types.ts
@@ -22,17 +22,25 @@ export interface InnovationSectionModel {
 }
 
 export type ReassessmentType =
-  | {
-      updatedInnovationRecord: CurrentCatalogTypes.catalogYesNo;
-      description: string;
-    }
-  | { description: string };
+  // | {
+  //     updatedInnovationRecord: CurrentCatalogTypes.catalogYesNo;
+  //     description: string;
+  //   }
+  // | { description: string }
+  // |
+  {
+    reassessmentReason: string[];
+    otherReassessmentReason?: string;
+    description: string;
+    whatSupportDoYouNeed: string;
+  };
 
 export type InnovationAssessmentType = {
   id: string;
   reassessment?: ReassessmentType & {
     previousAssessmentId: string;
     sectionsUpdatedSinceLastAssessment: string[];
+    createdAt: Date;
   };
   summary: null | string;
   description: null | string;

--- a/apps/innovations/_types/innovation.types.ts
+++ b/apps/innovations/_types/innovation.types.ts
@@ -21,19 +21,12 @@ export interface InnovationSectionModel {
   submittedAt: Date | null;
 }
 
-export type ReassessmentType =
-  // | {
-  //     updatedInnovationRecord: CurrentCatalogTypes.catalogYesNo;
-  //     description: string;
-  //   }
-  // | { description: string }
-  // |
-  {
-    reassessmentReason: string[];
-    otherReassessmentReason?: string;
-    description: string;
-    whatSupportDoYouNeed: string;
-  };
+export type ReassessmentType = {
+  reassessmentReason: string[];
+  otherReassessmentReason?: string;
+  description: string;
+  whatSupportDoYouNeed: string;
+};
 
 export type InnovationAssessmentType = {
   id: string;
@@ -44,7 +37,11 @@ export type InnovationAssessmentType = {
     majorVersion: number;
     minorVersion: number;
   };
-  reassessment?: ReassessmentType & { sectionsUpdatedSinceLastAssessment: string[]; createdAt: Date };
+  reassessment?: ReassessmentType & {
+    sectionsUpdatedSinceLastAssessment: string[];
+    createdAt: Date;
+    previousCreatedAt?: Date;
+  };
   summary: null | string;
   description: null | string;
   startedAt: null | Date;

--- a/apps/innovations/v1-innovation-assessment-info/index.spec.ts
+++ b/apps/innovations/v1-innovation-assessment-info/index.spec.ts
@@ -25,7 +25,7 @@ beforeAll(async () => {
 
 const expected = {
   id: randUuid(),
-  //   reassessment?: { updatedInnovationRecord: CurrentCatalogTypes.catalogYesNo; description: string },
+  // reassessment?: { updatedInnovationRecord: CurrentCatalogTypes.catalogYesNo; description: string },
   summary: randText(),
   description: randText(),
   startedAt: randPastDate(),
@@ -87,8 +87,9 @@ describe('v1-innovation-assessment-info', () => {
       const expectedWithReassessment = {
         ...expected,
         reassessment: {
-          updatedInnovationRecord: 'YES' as const,
+          reassessmentReason: [],
           description: randText(),
+          whatSupportDoYouNeed: randText(),
           previousAssessmentId: randUuid(),
           sectionsUpdatedSinceLastAssessment: []
         }

--- a/apps/innovations/v1-innovation-assessment-info/index.spec.ts
+++ b/apps/innovations/v1-innovation-assessment-info/index.spec.ts
@@ -30,7 +30,7 @@ const expected = {
   previousAssessment: { id: '', majorVersion: 0, minorVersion: 0 },
   reassessment: {
     description: randText(),
-    reassessmentReason: [],
+    reassessmentReason: ['NO_SUPPORT'],
     otherReassessmentReason: randText(),
     whatSupportDoYouNeed: randText(),
     sectionsUpdatedSinceLastAssessment: [],
@@ -98,7 +98,7 @@ describe('v1-innovation-assessment-info', () => {
       const expectedWithReassessment = {
         ...expected,
         reassessment: {
-          reassessmentReason: [],
+          reassessmentReason: ['NO_SUPPORT'],
           createdAt: new Date(),
           previousCreatedAt: new Date(),
           description: randText(),

--- a/apps/innovations/v1-innovation-assessment-info/index.spec.ts
+++ b/apps/innovations/v1-innovation-assessment-info/index.spec.ts
@@ -25,10 +25,18 @@ beforeAll(async () => {
 
 const expected = {
   id: randUuid(),
-  majorVersion: 0,
+  majorVersion: 1,
   minorVersion: 0,
   previousAssessment: { id: '', majorVersion: 0, minorVersion: 0 },
-  //   reassessment?: { updatedInnovationRecord: CurrentCatalogTypes.catalogYesNo; description: string },
+  reassessment: {
+    description: randText(),
+    reassessmentReason: [''],
+    otherReassessmentReason: randText(),
+    whatSupportDoYouNeed: randText(),
+    sectionsUpdatedSinceLastAssessment: [],
+    createdAt: new Date(),
+    previousCreatedAt: new Date()
+  },
   summary: randText(),
   description: randText(),
   startedAt: randPastDate(),
@@ -92,6 +100,7 @@ describe('v1-innovation-assessment-info', () => {
         reassessment: {
           reassessmentReason: [],
           createdAt: new Date(),
+          previousCreatedAt: new Date(),
           description: randText(),
           whatSupportDoYouNeed: randText(),
           previousAssessmentId: randUuid(),

--- a/apps/innovations/v1-innovation-assessment-info/index.spec.ts
+++ b/apps/innovations/v1-innovation-assessment-info/index.spec.ts
@@ -30,7 +30,7 @@ const expected = {
   previousAssessment: { id: '', majorVersion: 0, minorVersion: 0 },
   reassessment: {
     description: randText(),
-    reassessmentReason: [''],
+    reassessmentReason: [],
     otherReassessmentReason: randText(),
     whatSupportDoYouNeed: randText(),
     sectionsUpdatedSinceLastAssessment: [],

--- a/apps/innovations/v1-innovation-reassessment-request-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/index.spec.ts
@@ -1,9 +1,9 @@
 import azureFunction from '.';
 
 import { AzureHttpTriggerBuilder, TestsHelper } from '@innovations/shared/tests';
-import type { TestUserType } from '@innovations/shared/tests/builders/user.builder';
-import type { ErrorResponseType } from '@innovations/shared/types';
-import { randBoolean, randText, randUuid } from '@ngneat/falso';
+// import type { TestUserType } from '@innovations/shared/tests/builders/user.builder';
+// import type { ErrorResponseType } from '@innovations/shared/types';
+import { randText, randUuid } from '@ngneat/falso';
 import { InnovationAssessmentsService } from '../_services/innovation-assessments.service';
 import type { ResponseDTO } from './transformation.dtos';
 import type { BodyType, ParamsType } from './validation.schemas';
@@ -44,7 +44,10 @@ describe('v1-innovation-reassessment-request-create Suite', () => {
         })
         .setBody<BodyType>({
           description: randText(),
-          updatedInnovationRecord: randBoolean() ? 'YES' : 'NO'
+          whatSupportDoYouNeed: randText(),
+          reassessmentReason: ['NO_SUPPORT']
+
+          // updatedInnovationRecord: randBoolean() ? 'YES' : 'NO'
         })
         .call<ResponseDTO>(azureFunction);
 
@@ -59,7 +62,9 @@ describe('v1-innovation-reassessment-request-create Suite', () => {
           innovationId: scenario.users.johnInnovator.innovations.johnInnovation.id
         })
         .setBody<BodyType>({
-          description: randText()
+          description: randText(),
+          whatSupportDoYouNeed: randText(),
+          reassessmentReason: ['NO_SUPPORT']
         })
         .call<ResponseDTO>(azureFunction);
 
@@ -69,27 +74,27 @@ describe('v1-innovation-reassessment-request-create Suite', () => {
     });
   });
 
-  describe('Access', () => {
-    it.each([
-      ['Admin', 403, scenario.users.allMighty],
-      ['QA', 403, scenario.users.aliceQualifyingAccessor],
-      ['NA', 200, scenario.users.paulNeedsAssessor],
-      ['Innovator owner', 200, scenario.users.johnInnovator],
-      ['Innovator collaborator', 200, scenario.users.janeInnovator],
-      ['Innovator other', 403, scenario.users.ottoOctaviusInnovator]
-    ])('access with user %s should give %i', async (role: string, status: number, user: TestUserType) => {
-      const result = await new AzureHttpTriggerBuilder()
-        .setAuth(user)
-        .setParams<ParamsType>({
-          innovationId: scenario.users.johnInnovator.innovations.johnInnovation.id
-        })
-        .setBody<BodyType>({
-          description: randText(),
-          ...(role !== 'NA' && { updatedInnovationRecord: randBoolean() ? 'YES' : 'NO' })
-        })
-        .call<ErrorResponseType>(azureFunction);
+  //   describe('Access', () => {
+  //     it.each([
+  //       ['Admin', 403, scenario.users.allMighty],
+  //       ['QA', 403, scenario.users.aliceQualifyingAccessor],
+  //       ['NA', 200, scenario.users.paulNeedsAssessor],
+  //       ['Innovator owner', 200, scenario.users.johnInnovator],
+  //       ['Innovator collaborator', 200, scenario.users.janeInnovator],
+  //       ['Innovator other', 403, scenario.users.ottoOctaviusInnovator]
+  //     ])('access with user %s should give %i', async (role: string, status: number, user: TestUserType) => {
+  //       const result = await new AzureHttpTriggerBuilder()
+  //         .setAuth(user)
+  //         .setParams<ParamsType>({
+  //           innovationId: scenario.users.johnInnovator.innovations.johnInnovation.id
+  //         })
+  //         .setBody<BodyType>({
+  //           description: randText(),
+  //           ...(role !== 'NA' && { updatedInnovationRecord: randBoolean() ? 'YES' : 'NO' })
+  //         })
+  //         .call<ErrorResponseType>(azureFunction);
 
-      expect(result.status).toBe(status);
-    });
-  });
+  //       expect(result.status).toBe(status);
+  //     });
+  //   });
 });

--- a/apps/innovations/v1-innovation-reassessment-request-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/index.spec.ts
@@ -45,7 +45,7 @@ describe('v1-innovation-reassessment-request-create Suite', () => {
         .setBody<BodyType>({
           description: randText(),
           whatSupportDoYouNeed: randText(),
-          reassessmentReason: ['NO_SUPPORT']
+          reassessmentReason: []
         })
         .call<ResponseDTO>(azureFunction);
 

--- a/apps/innovations/v1-innovation-reassessment-request-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/index.spec.ts
@@ -45,23 +45,6 @@ describe('v1-innovation-reassessment-request-create Suite', () => {
         .setBody<BodyType>({
           description: randText(),
           whatSupportDoYouNeed: randText(),
-          reassessmentReason: []
-        })
-        .call<ResponseDTO>(azureFunction);
-
-      expect(result.body).toStrictEqual({ id: expected.assessment.id });
-      expect(result.status).toBe(200);
-      expect(mock).toHaveBeenCalledTimes(1);
-    });
-    it('should create a new reassessment request from an needs accessor', async () => {
-      const result = await new AzureHttpTriggerBuilder()
-        .setAuth(scenario.users.paulNeedsAssessor)
-        .setParams<ParamsType>({
-          innovationId: scenario.users.johnInnovator.innovations.johnInnovation.id
-        })
-        .setBody<BodyType>({
-          description: randText(),
-          whatSupportDoYouNeed: randText(),
           reassessmentReason: ['NO_SUPPORT']
         })
         .call<ResponseDTO>(azureFunction);
@@ -76,7 +59,7 @@ describe('v1-innovation-reassessment-request-create Suite', () => {
     it.each([
       ['Admin', 403, scenario.users.allMighty],
       ['QA', 403, scenario.users.aliceQualifyingAccessor],
-      ['NA', 200, scenario.users.paulNeedsAssessor],
+      ['NA', 403, scenario.users.paulNeedsAssessor],
       ['Innovator owner', 200, scenario.users.johnInnovator],
       ['Innovator collaborator', 200, scenario.users.janeInnovator],
       ['Innovator other', 403, scenario.users.ottoOctaviusInnovator]
@@ -88,7 +71,7 @@ describe('v1-innovation-reassessment-request-create Suite', () => {
         })
         .setBody<BodyType>({
           description: randText(),
-          reassessmentReason: [],
+          reassessmentReason: ['NO_SUPPORT'],
           whatSupportDoYouNeed: randText()
         })
         .call<ErrorResponseType>(azureFunction);

--- a/apps/innovations/v1-innovation-reassessment-request-create/index.spec.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/index.spec.ts
@@ -3,7 +3,7 @@ import azureFunction from '.';
 import { AzureHttpTriggerBuilder, TestsHelper } from '@innovations/shared/tests';
 import type { TestUserType } from '@innovations/shared/tests/builders/user.builder';
 import type { ErrorResponseType } from '@innovations/shared/types';
-import { rand, randText, randUuid } from '@ngneat/falso';
+import { randText, randUuid } from '@ngneat/falso';
 import { InnovationAssessmentsService } from '../_services/innovation-assessments.service';
 import type { ResponseDTO } from './transformation.dtos';
 import type { BodyType, ParamsType } from './validation.schemas';
@@ -46,8 +46,6 @@ describe('v1-innovation-reassessment-request-create Suite', () => {
           description: randText(),
           whatSupportDoYouNeed: randText(),
           reassessmentReason: ['NO_SUPPORT']
-
-          // updatedInnovationRecord: randBoolean() ? 'YES' : 'NO'
         })
         .call<ResponseDTO>(azureFunction);
 
@@ -82,7 +80,7 @@ describe('v1-innovation-reassessment-request-create Suite', () => {
       ['Innovator owner', 200, scenario.users.johnInnovator],
       ['Innovator collaborator', 200, scenario.users.janeInnovator],
       ['Innovator other', 403, scenario.users.ottoOctaviusInnovator]
-    ])('access with user %s should give %i', async (role: string, status: number, user: TestUserType) => {
+    ])('access with user %s should give %i', async (_role: string, status: number, user: TestUserType) => {
       const result = await new AzureHttpTriggerBuilder()
         .setAuth(user)
         .setParams<ParamsType>({

--- a/apps/innovations/v1-innovation-reassessment-request-create/validation.schemas.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/validation.schemas.ts
@@ -18,7 +18,10 @@ export type BodyType = {
 };
 
 export const BodySchema = Joi.object<BodyType>({
-  reassessmentReason: Joi.array().items(Joi.string().valid(ReassessmentReasons)).min(1).required(),
+  reassessmentReason: Joi.array()
+    .items(Joi.string().valid(...ReassessmentReasons))
+    .min(1)
+    .required(),
   otherReassessmentReason: Joi.string().max(TEXTAREA_LENGTH_LIMIT.xs).optional(),
   description: Joi.string().max(TEXTAREA_LENGTH_LIMIT.l).required(),
   whatSupportDoYouNeed: Joi.string().max(TEXTAREA_LENGTH_LIMIT.l).required()

--- a/apps/innovations/v1-innovation-reassessment-request-create/validation.schemas.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/validation.schemas.ts
@@ -1,6 +1,7 @@
 import Joi from 'joi';
 
 import { TEXTAREA_LENGTH_LIMIT } from '@innovations/shared/constants';
+import { ReassessmentReasons, type ReassessmentReasonsType } from '../_types/innovation.types';
 
 export type ParamsType = {
   innovationId: string;
@@ -10,14 +11,14 @@ export const ParamsSchema = Joi.object<ParamsType>({
 }).required();
 
 export type BodyType = {
-  reassessmentReason: string[];
+  reassessmentReason: ReassessmentReasonsType[];
   otherReassessmentReason?: string;
   description: string;
   whatSupportDoYouNeed: string;
 };
 
 export const BodySchema = Joi.object<BodyType>({
-  reassessmentReason: Joi.array().items(Joi.string()).min(1).required(),
+  reassessmentReason: Joi.array().items(Joi.string().valid(ReassessmentReasons)).min(1).required(),
   otherReassessmentReason: Joi.string().max(TEXTAREA_LENGTH_LIMIT.xs).optional(),
   description: Joi.string().max(TEXTAREA_LENGTH_LIMIT.l).required(),
   whatSupportDoYouNeed: Joi.string().max(TEXTAREA_LENGTH_LIMIT.l).required()

--- a/apps/innovations/v1-innovation-reassessment-request-create/validation.schemas.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/validation.schemas.ts
@@ -1,7 +1,6 @@
 import Joi from 'joi';
 
 import { TEXTAREA_LENGTH_LIMIT } from '@innovations/shared/constants';
-import { ServiceRoleEnum, YesOrNoCatalogueType } from '@innovations/shared/enums';
 
 export type ParamsType = {
   innovationId: string;
@@ -11,19 +10,15 @@ export const ParamsSchema = Joi.object<ParamsType>({
 }).required();
 
 export type BodyType = {
-  updatedInnovationRecord?: YesOrNoCatalogueType;
+  reassessmentReason: string[];
+  otherReassessmentReason?: string;
   description: string;
+  whatSupportDoYouNeed: string;
 };
 
 export const BodySchema = Joi.object<BodyType>({
-  description: Joi.string().max(TEXTAREA_LENGTH_LIMIT.xl).required()
-}).when('$userRole', [
-  {
-    is: ServiceRoleEnum.INNOVATOR,
-    then: Joi.object({
-      updatedInnovationRecord: Joi.string()
-        .valid(...Object.values(YesOrNoCatalogueType))
-        .required()
-    }).required()
-  }
-]);
+  reassessmentReason: Joi.array().items(Joi.string()).min(1).required(),
+  otherReassessmentReason: Joi.string().max(TEXTAREA_LENGTH_LIMIT.xs).optional(),
+  description: Joi.string().max(TEXTAREA_LENGTH_LIMIT.l).required(),
+  whatSupportDoYouNeed: Joi.string().max(TEXTAREA_LENGTH_LIMIT.l).required()
+});

--- a/libs/data-access/migrations/1722348805603-alter-innov-reassessment-request-add-new-columns.ts
+++ b/libs/data-access/migrations/1722348805603-alter-innov-reassessment-request-add-new-columns.ts
@@ -1,0 +1,25 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class alterInnovAddNewColumnsReassessmentRequestTable1722348805603 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "innovation_reassessment_request" ADD reassessment_reason nvarchar(150) NULL`);
+    await queryRunner.query(
+      `ALTER TABLE "innovation_reassessment_request" ADD other_reassessment_reason nvarchar(100) NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "innovation_reassessment_request" ADD what_support_do_you_need nvarchar(1500) NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "innovation_reassessment_request" ALTER COLUMN description nvarchar(1500) NOT NULL`
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "innovation_reassessment_request" DROP COLUMN "reassessment_reason"`);
+    await queryRunner.query(`ALTER TABLE "innovation_reassessment_request" DROP COLUMN "other_reassessment_reason"`);
+    await queryRunner.query(`ALTER TABLE "innovation_reassessment_request" DROP COLUMN "what_support_do_you_need"`);
+    await queryRunner.query(
+      `ALTER TABLE "innovation_reassessment_request" ALTER COLUMN description nvarchar(200) NOT NULL`
+    );
+  }
+}

--- a/libs/shared/entities/innovation/innovation-reassessment-request.entity.ts
+++ b/libs/shared/entities/innovation/innovation-reassessment-request.entity.ts
@@ -5,7 +5,6 @@ import { BaseEntity } from '../base.entity';
 import type { YesOrNoCatalogueType } from '../../../shared/enums';
 import { InnovationAssessmentEntity } from './innovation-assessment.entity';
 import { InnovationEntity } from './innovation.entity';
-
 @Entity('innovation_reassessment_request')
 export class InnovationReassessmentRequestEntity extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
@@ -17,14 +16,14 @@ export class InnovationReassessmentRequestEntity extends BaseEntity {
   @Column({ name: 'description', type: 'nvarchar' })
   description: string;
 
-  @Column({ name: 'reassessment_reason', type: 'simple-array' })
-  reassessmentReason: string[];
+  @Column({ name: 'reassessment_reason', type: 'simple-array', nullable: true })
+  reassessmentReason: string[] | null;
 
-  @Column({ name: 'other_reassessment_reason', type: 'nvarchar' })
-  otherReassessmentReason: string;
+  @Column({ name: 'other_reassessment_reason', type: 'nvarchar', nullable: true })
+  otherReassessmentReason: string | null;
 
-  @Column({ name: 'what_support_do_you_need', type: 'nvarchar' })
-  whatSupportDoYouNeed: string;
+  @Column({ name: 'what_support_do_you_need', type: 'nvarchar', nullable: true })
+  whatSupportDoYouNeed: string | null;
 
   @ManyToOne(() => InnovationEntity, { nullable: false })
   @JoinColumn({ name: 'innovation_id' })

--- a/libs/shared/entities/innovation/innovation-reassessment-request.entity.ts
+++ b/libs/shared/entities/innovation/innovation-reassessment-request.entity.ts
@@ -17,6 +17,15 @@ export class InnovationReassessmentRequestEntity extends BaseEntity {
   @Column({ name: 'description', type: 'nvarchar' })
   description: string;
 
+  @Column({ name: 'reassessment_reason', type: 'simple-array' })
+  reassessmentReason: string[];
+
+  @Column({ name: 'other_reassessment_reason', type: 'nvarchar' })
+  otherReassessmentReason: string;
+
+  @Column({ name: 'what_support_do_you_need', type: 'nvarchar' })
+  whatSupportDoYouNeed: string;
+
   @ManyToOne(() => InnovationEntity, { nullable: false })
   @JoinColumn({ name: 'innovation_id' })
   innovation: InnovationEntity;

--- a/libs/shared/tests/builders/innovation-reassessment-request.builder.ts
+++ b/libs/shared/tests/builders/innovation-reassessment-request.builder.ts
@@ -78,9 +78,11 @@ export class InnovationReassessmentRequestBuilder extends BaseBuilder {
 
     return {
       id: result.id,
-      reassessment: result.updatedInnovationRecord
-        ? { description: result.description, updatedInnovationRecord: result.updatedInnovationRecord }
-        : { description: result.description }
+      reassessment: {
+        description: result.description,
+        reassessmentReason: result.reassessmentReason,
+        whatSupportDoYouNeed: result.whatSupportDoYouNeed
+      }
     };
   }
 }


### PR DESCRIPTION
Description:
- Adds new fields to `innovation_reassessment_request` table, and the migration script to update it.
- Retrieves new fields on `InnovationAssessmentsService.getInnovationAssessmentInfo()`
- Updates `InnovationAssessmentsService.createInnovationReassessment()` to calculate `majorVersion` field, and removes cloning previous information to the new one.


Related tickets:

Closes [AB#173517](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/173517) & [AB#173748](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/173748)

US: [AB#168231](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/168231) & [AB#168243](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/168243)
