### PR TITLE
task: add versioning fields to innovation list

### DIFF
--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -1110,6 +1110,8 @@ paths:
                 - otherCategoryDescription
                 - postcode
                 - assessment.id
+                - assessment.majorVersion
+                - assessment.minorVersion
                 - assessment.isExempt
                 - assessment.assignedTo
                 - assessment.updatedAt
@@ -4823,6 +4825,8 @@ paths:
                 - otherCategoryDescription
                 - postcode
                 - assessment.id
+                - assessment.majorVersion
+                - assessment.minorVersion
                 - assessment.isExempt
                 - assessment.assignedTo
                 - assessment.updatedAt

--- a/apps/innovations/_services/innovations.service.ts
+++ b/apps/innovations/_services/innovations.service.ts
@@ -89,6 +89,8 @@ export const InnovationListSelectType = [
   'postcode',
   // Relation fields
   'assessment.id',
+  'assessment.majorVersion',
+  'assessment.minorVersion',
   'assessment.isExempt',
   'assessment.assignedTo',
   'assessment.updatedAt',


### PR DESCRIPTION
**Description:**
Adds the `majorVersion` and `minorVersion` to the possible select fields from innovation list. Currently needed to calculate assessment KPIs.

**Related tickets:**
- Closes AB#173795.
- US: AB#173367.