### PR TITLE
refactor: simplify announcement params

### DIFF
--- a/apps/admin/_services/announcements.schemas.ts
+++ b/apps/admin/_services/announcements.schemas.ts
@@ -10,7 +10,7 @@ export const AnnouncementJoiLinkValidation = Joi.object({
 export type AnnouncementScheduledBodyType = {
   title: string;
   userRoles: ServiceRoleEnum[];
-  params: AnnouncementParamsType[keyof AnnouncementParamsType];
+  params: AnnouncementParamsType;
   startsAt: Date;
   expiresAt?: Date;
   type: AnnouncementTypeEnum;
@@ -26,17 +26,11 @@ export const AnnouncementScheduledBodySchema = Joi.object<AnnouncementScheduledB
     )
     .min(1),
 
-  params: Joi.alternatives([
-    Joi.object<AnnouncementParamsType['GENERIC']>({
-      content: Joi.string().required(),
-      link: AnnouncementJoiLinkValidation.optional()
-    }),
-    Joi.object<AnnouncementParamsType['FILTERED']>({
-      content: Joi.string().required(),
-      link: AnnouncementJoiLinkValidation.optional(),
-      filters: Joi.object().required()
-    })
-  ]),
+  params: Joi.object<AnnouncementScheduledBodyType['params']>({
+    content: Joi.string().required(),
+    link: AnnouncementJoiLinkValidation.optional(),
+    filters: Joi.object().optional()
+  }),
 
   startsAt: Joi.date().required(),
   expiresAt: Joi.date().greater(Joi.ref('startsAt')).optional(),

--- a/apps/admin/_services/announcements.service.spec.ts
+++ b/apps/admin/_services/announcements.service.spec.ts
@@ -5,12 +5,7 @@ import SYMBOLS from './symbols';
 import type { AnnouncementsService } from './announcements.service';
 import { AnnouncementEntity, AnnouncementUserEntity } from '@admin/shared/entities';
 import { randFutureDate, randPastDate, randText, randUuid } from '@ngneat/falso';
-import {
-  AnnouncementStatusEnum,
-  AnnouncementTemplateType,
-  AnnouncementTypeEnum,
-  ServiceRoleEnum
-} from '@admin/shared/enums';
+import { AnnouncementStatusEnum, AnnouncementTypeEnum, ServiceRoleEnum } from '@admin/shared/enums';
 import { AnnouncementErrorsEnum, BadRequestError, NotFoundError, UnprocessableEntityError } from '@admin/shared/errors';
 import { DTOsHelper } from '@admin/shared/tests/helpers/dtos.helper';
 import type { EntityManager } from 'typeorm';
@@ -41,7 +36,6 @@ describe('Admin / _services / announcements service suite', () => {
     it('should get the list of announcements', async () => {
       const activeAnnouncement = await em.getRepository(AnnouncementEntity).save({
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.ACCESSOR, ServiceRoleEnum.QUALIFYING_ACCESSOR],
         params: { content: randText() },
         startsAt: new Date('01/01/2023'),
@@ -50,7 +44,6 @@ describe('Admin / _services / announcements service suite', () => {
 
       const scheduledAnnouncement = await em.getRepository(AnnouncementEntity).save({
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.INNOVATOR],
         params: { content: randText() },
         startsAt: randFutureDate(),
@@ -59,7 +52,6 @@ describe('Admin / _services / announcements service suite', () => {
 
       const doneAnnouncement = await em.getRepository(AnnouncementEntity).save({
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.INNOVATOR],
         params: { content: randText() },
         startsAt: new Date('01/01/2022'),
@@ -109,7 +101,6 @@ describe('Admin / _services / announcements service suite', () => {
     it('should get the announcement info', async () => {
       const announcement = await em.getRepository(AnnouncementEntity).save({
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.ACCESSOR, ServiceRoleEnum.QUALIFYING_ACCESSOR],
         params: { content: randText() },
         startsAt: randPastDate(),
@@ -209,7 +200,6 @@ describe('Admin / _services / announcements service suite', () => {
     it('should update an announcement', async () => {
       const announcement = await em.getRepository(AnnouncementEntity).save({
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.ACCESSOR, ServiceRoleEnum.QUALIFYING_ACCESSOR],
         params: { content: randText() },
         startsAt: randFutureDate(),
@@ -245,7 +235,6 @@ describe('Admin / _services / announcements service suite', () => {
     it('should throw an error if the announcement is in DONE status', async () => {
       const announcement = await em.getRepository(AnnouncementEntity).save({
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.ACCESSOR, ServiceRoleEnum.QUALIFYING_ACCESSOR],
         params: { content: randText() },
         startsAt: randPastDate(),
@@ -271,7 +260,6 @@ describe('Admin / _services / announcements service suite', () => {
     it('should throw an error if the announcement is in SCHEDULEDED status and new expiration date is before activation date', async () => {
       const announcement = await em.getRepository(AnnouncementEntity).save({
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.ACCESSOR, ServiceRoleEnum.QUALIFYING_ACCESSOR],
         params: { content: randText() },
         startsAt: randFutureDate(),
@@ -297,7 +285,6 @@ describe('Admin / _services / announcements service suite', () => {
     it('should throw an error if the announcement is in ACTIVE status and arguments other than expiration date are passed', async () => {
       const announcement = await em.getRepository(AnnouncementEntity).save({
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.ACCESSOR, ServiceRoleEnum.QUALIFYING_ACCESSOR],
         params: { content: randText() },
         startsAt: randPastDate(),
@@ -323,7 +310,6 @@ describe('Admin / _services / announcements service suite', () => {
     it('should throw an error if the announcement is in ACTIVE status and new expiration date is before activation date', async () => {
       const announcement = await em.getRepository(AnnouncementEntity).save({
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.ACCESSOR, ServiceRoleEnum.QUALIFYING_ACCESSOR],
         params: { content: randText() },
         startsAt: randPastDate(),
@@ -357,7 +343,6 @@ describe('Admin / _services / announcements service suite', () => {
     it('should delete an announcement', async () => {
       const announcement = await em.getRepository(AnnouncementEntity).save({
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.ACCESSOR, ServiceRoleEnum.QUALIFYING_ACCESSOR],
         params: { content: randText() },
         startsAt: randPastDate(),
@@ -386,7 +371,6 @@ describe('Admin / _services / announcements service suite', () => {
     it('should throw an error if the announcement is in DONE status', async () => {
       const announcement = await em.getRepository(AnnouncementEntity).save({
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.ACCESSOR, ServiceRoleEnum.QUALIFYING_ACCESSOR],
         params: { content: randText() },
         startsAt: randPastDate(),

--- a/apps/admin/_services/announcements.service.ts
+++ b/apps/admin/_services/announcements.service.ts
@@ -126,7 +126,7 @@ export class AnnouncementsService extends BaseService {
     data: {
       title: string;
       userRoles: ServiceRoleEnum[];
-      params: AnnouncementParamsType[keyof AnnouncementParamsType];
+      params: AnnouncementParamsType;
       startsAt: Date;
       expiresAt?: Date;
       type: AnnouncementTypeEnum;
@@ -143,7 +143,6 @@ export class AnnouncementsService extends BaseService {
     return await em.transaction(async transaction => {
       const savedAnnouncement = await transaction.save(AnnouncementEntity, {
         title: data.title,
-        template: 'filters' in data.params ? 'FILTERED' : 'GENERIC',
         userRoles: data.userRoles,
         params: data.params ?? null,
         startsAt: data.startsAt,
@@ -178,7 +177,7 @@ export class AnnouncementsService extends BaseService {
     data: {
       title?: string;
       userRoles?: ServiceRoleEnum[];
-      params?: AnnouncementParamsType[keyof AnnouncementParamsType];
+      params?: AnnouncementParamsType;
       startsAt?: Date;
       expiresAt?: Date;
       type?: AnnouncementTypeEnum;

--- a/apps/admin/_services/organisations.service.ts
+++ b/apps/admin/_services/organisations.service.ts
@@ -12,7 +12,6 @@ import {
   UserRoleEntity
 } from '@admin/shared/entities';
 import {
-  AnnouncementTypeEnum,
   InnovationSupportLogTypeEnum,
   InnovationSupportStatusEnum,
   InnovationTaskStatusEnum,
@@ -23,23 +22,19 @@ import {
 } from '@admin/shared/enums';
 import { NotFoundError, OrganisationErrorsEnum, UnprocessableEntityError } from '@admin/shared/errors';
 import { DatesHelper } from '@admin/shared/helpers';
-import { UrlModel } from '@admin/shared/models';
 import type { DomainService, IdentityProviderService, NotifierService } from '@admin/shared/services';
 import type { DomainContextType } from '@admin/shared/types';
 
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
-import { ENV } from '../_config';
-import type { AnnouncementsService } from './announcements.service';
 import { BaseService } from './base.service';
-import SYMBOLS from './symbols';
 
 @injectable()
 export class OrganisationsService extends BaseService {
   constructor(
     @inject(SHARED_SYMBOLS.DomainService) private domainService: DomainService,
     @inject(SHARED_SYMBOLS.NotifierService) private notifierService: NotifierService,
-    @inject(SHARED_SYMBOLS.IdentityProviderService) private identityProviderService: IdentityProviderService,
-    @inject(SYMBOLS.AnnouncementsService) private announcementsService: AnnouncementsService
+    @inject(SHARED_SYMBOLS.IdentityProviderService) private identityProviderService: IdentityProviderService
+    // @inject(SYMBOLS.AnnouncementsService) private announcementsService: AnnouncementsService
   ) {
     super();
   }
@@ -293,12 +288,13 @@ export class OrganisationsService extends BaseService {
 
         // Just send the announcement if this is the first time the organization has been activated.
         if (DatesHelper.isDateEqual(unit.organisation.createdAt, unit.organisation.inactivatedAt)) {
-          await this.createOrganisationAnnouncement(
-            domainContext,
-            unit.organisation.id,
-            unit.organisation.name,
-            transaction
-          );
+          // TODO: Change this when new copy arrives.
+          // await this.createOrganisationAnnouncement(
+          //   domainContext,
+          //   unit.organisation.id,
+          //   unit.organisation.name,
+          //   transaction
+          // );
         }
       }
 
@@ -569,6 +565,7 @@ export class OrganisationsService extends BaseService {
     return savedUnit;
   }
 
+  /**
   private async createOrganisationAnnouncement(
     requestUser: DomainContextType,
     _organisationId: string,
@@ -642,5 +639,5 @@ export class OrganisationsService extends BaseService {
       {},
       transaction
     );
-  }
+  } */
 }

--- a/apps/admin/v1-announcement-info/index.ts
+++ b/apps/admin/v1-announcement-info/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@admin/shared/decorators';
-import { AnnouncementTemplateType, ServiceRoleEnum } from '@admin/shared/enums';
+import { ServiceRoleEnum } from '@admin/shared/enums';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@admin/shared/helpers';
 import type { AuthorizationService } from '@admin/shared/services';
 import type { CustomContextType } from '@admin/shared/types';
@@ -59,7 +59,6 @@ export default openApi(V1AnnouncementsInfo.httpTrigger as AzureFunction, '/v1/an
               type: 'object',
               properties: {
                 id: { type: 'string', format: 'uuid' },
-                template: { type: 'string', enum: [...AnnouncementTemplateType] },
                 userRoles: { type: 'array', items: { type: 'string', enum: Object.keys(ServiceRoleEnum) } },
                 params: { type: 'object' },
                 createdAt: { type: 'string', format: 'date-time' },

--- a/apps/admin/v1-announcement-update/validation.schemas.ts
+++ b/apps/admin/v1-announcement-update/validation.schemas.ts
@@ -23,17 +23,11 @@ export const BodySchema = Joi.object<BodyType>({
 
   userRoles: Joi.array().optional(),
 
-  params: Joi.alternatives([
-    Joi.object<AnnouncementParamsType['GENERIC']>({
-      content: Joi.string().optional(),
-      link: AnnouncementJoiLinkValidation.optional(),
-    }),
-    Joi.object<AnnouncementParamsType['FILTERED']>({
-      content: Joi.string().optional(),
-      link: AnnouncementJoiLinkValidation.optional(),
-      filters: Joi.object().optional()
-    })
-  ]),
+  params: Joi.object<BodyType['params']>({
+    content: Joi.string().optional(),
+    link: AnnouncementJoiLinkValidation.optional(),
+    filters: Joi.object().optional()
+  }),
 
   startsAt: Joi.date().optional(),
   expiresAt: Joi.date().optional(),

--- a/apps/admin/v1-announcements-list/index.ts
+++ b/apps/admin/v1-announcements-list/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@admin/shared/decorators';
-import { AnnouncementTemplateType, ServiceRoleEnum } from '@admin/shared/enums';
+import { ServiceRoleEnum } from '@admin/shared/enums';
 import { JoiHelper, ResponseHelper } from '@admin/shared/helpers';
 import type { AuthorizationService } from '@admin/shared/services';
 import type { CustomContextType } from '@admin/shared/types';
@@ -62,7 +62,6 @@ export default openApi(V1AnnouncementsList.httpTrigger as AzureFunction, '/v1/an
                 type: 'object',
                 properties: {
                   id: { type: 'string', format: 'uuid' },
-                  template: { type: 'string', enum: [...AnnouncementTemplateType] },
                   userRoles: { type: 'array', items: { type: 'string', enum: Object.keys(ServiceRoleEnum) } },
                   params: { type: 'object' },
                   createdAt: { type: 'string', format: 'date-time' },

--- a/apps/users/_services/announcements.service.spec.ts
+++ b/apps/users/_services/announcements.service.spec.ts
@@ -6,7 +6,7 @@ import type { EntityManager } from 'typeorm';
 import type { AnnouncementsService } from './announcements.service';
 import { AnnouncementEntity, AnnouncementUserEntity } from '@users/shared/entities';
 import { randBetweenDate, randText, randUuid } from '@ngneat/falso';
-import { AnnouncementTemplateType, ServiceRoleEnum } from '@users/shared/enums';
+import { ServiceRoleEnum } from '@users/shared/enums';
 import { DTOsHelper } from '@users/shared/tests/helpers/dtos.helper';
 import { AnnouncementErrorsEnum, NotFoundError } from '@users/shared/errors';
 
@@ -36,7 +36,6 @@ describe('Users / _services / announcements service suite', () => {
       // create announcements
       const announcement = {
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.ACCESSOR],
         startsAt: randBetweenDate({
           from: new Date(scenario.users.samAccessor.createdAt),
@@ -50,7 +49,6 @@ describe('Users / _services / announcements service suite', () => {
       // save other announcement for other role
       await em.getRepository(AnnouncementEntity).save({
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.INNOVATOR],
         startsAt: randBetweenDate({
           from: new Date(scenario.users.samAccessor.createdAt),
@@ -66,7 +64,6 @@ describe('Users / _services / announcements service suite', () => {
         {
           id: savedAnnouncement.id,
           title: savedAnnouncement.title,
-          template: savedAnnouncement.template,
           params: savedAnnouncement.params,
           startsAt: savedAnnouncement.startsAt,
           expiresAt: savedAnnouncement.expiresAt
@@ -86,7 +83,6 @@ describe('Users / _services / announcements service suite', () => {
       // create announcement
       const announcement = {
         title: randText({ charCount: 10 }),
-        template: AnnouncementTemplateType[0],
         userRoles: [ServiceRoleEnum.ACCESSOR],
         startsAt: randBetweenDate({
           from: new Date(scenario.users.samAccessor.createdAt),

--- a/apps/users/_services/announcements.service.ts
+++ b/apps/users/_services/announcements.service.ts
@@ -2,7 +2,7 @@ import { injectable } from 'inversify';
 import type { EntityManager } from 'typeorm';
 
 import { AnnouncementEntity, AnnouncementUserEntity, UserEntity, UserRoleEntity } from '@users/shared/entities';
-import type { AnnouncementTypeEnum, AnnouncementTemplateType } from '@users/shared/enums';
+import type { AnnouncementTypeEnum } from '@users/shared/enums';
 import type { DomainContextType } from '@users/shared/types';
 
 import { BaseService } from './base.service';
@@ -24,7 +24,6 @@ export class AnnouncementsService extends BaseService {
     {
       id: string;
       title: string;
-      template: AnnouncementTemplateType;
       startsAt: Date;
       expiresAt: null | Date;
       params: null | Record<string, unknown>;
@@ -48,7 +47,6 @@ export class AnnouncementsService extends BaseService {
       .select([
         'announcement.id',
         'announcement.title',
-        'announcement.template',
         'announcement.startsAt',
         'announcement.expiresAt',
         'announcement.params'
@@ -73,7 +71,6 @@ export class AnnouncementsService extends BaseService {
     return announcements.map(announcement => ({
       id: announcement.id,
       title: announcement.title,
-      template: announcement.template,
       params: announcement.params,
       startsAt: announcement.startsAt,
       expiresAt: announcement.expiresAt

--- a/apps/users/v1-me-announcements/index.spec.ts
+++ b/apps/users/v1-me-announcements/index.spec.ts
@@ -28,7 +28,6 @@ const expected = [
   {
     id: randUuid(),
     title: randText(),
-    template: 'GENERIC' as const,
     startsAt: randPastDate(),
     expiresAt: randFutureDate(),
     params: {}
@@ -36,7 +35,6 @@ const expected = [
   {
     id: randUuid(),
     title: randText(),
-    template: 'GENERIC' as const,
     startsAt: randPastDate(),
     expiresAt: null,
     params: {}

--- a/apps/users/v1-me-announcements/index.ts
+++ b/apps/users/v1-me-announcements/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@users/shared/decorators';
-import { AnnouncementTemplateType, ServiceRoleEnum } from '@users/shared/enums';
+import { ServiceRoleEnum } from '@users/shared/enums';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
@@ -41,7 +41,6 @@ class V1MeAnnouncements {
         announcements.map(announcement => ({
           id: announcement.id,
           title: announcement.title,
-          template: announcement.template,
           startsAt: announcement.startsAt,
           expiresAt: announcement.expiresAt,
           params: announcement.params
@@ -73,7 +72,6 @@ export default openApi(V1MeAnnouncements.httpTrigger as AzureFunction, '/v1/me/a
                 properties: {
                   id: { type: 'string', format: 'uuid' },
                   title: { type: 'string' },
-                  template: { type: 'string', enum: [...AnnouncementTemplateType] },
                   userRoles: { type: 'array', items: { type: 'string', enum: Object.keys(ServiceRoleEnum) } },
                   createdAt: { type: 'string', format: 'date-time' },
                   params: { type: 'object' }

--- a/apps/users/v1-me-announcements/transformation.dtos.ts
+++ b/apps/users/v1-me-announcements/transformation.dtos.ts
@@ -1,9 +1,6 @@
-import type { AnnouncementTemplateType } from '@users/shared/enums';
-
 export type ResponseDTO = {
   id: string;
   title: string;
-  template: AnnouncementTemplateType;
   startsAt: Date;
   expiresAt: null | Date;
   params: null | Record<string, unknown>;

--- a/libs/shared/entities/user/announcement.entity.ts
+++ b/libs/shared/entities/user/announcement.entity.ts
@@ -3,7 +3,7 @@ import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { BaseEntity } from '../base.entity';
 
 import type { ServiceRoleEnum } from '../../enums/user.enums';
-import { AnnouncementTemplateType, AnnouncementTypeEnum } from '../../enums/announcement.enums';
+import { AnnouncementParamsType, AnnouncementTypeEnum } from '../../enums/announcement.enums';
 
 import { AnnouncementUserEntity } from './announcement-user.entity';
 
@@ -15,9 +15,6 @@ export class AnnouncementEntity extends BaseEntity {
   @Column({ name: 'title', type: 'nvarchar', length: 100 })
   title: string;
 
-  @Column({ name: 'template', type: 'simple-enum', length: 100, enum: AnnouncementTemplateType })
-  template: AnnouncementTemplateType;
-
   @Column({ name: 'user_roles', type: 'simple-array' })
   userRoles: ServiceRoleEnum[];
 
@@ -28,7 +25,7 @@ export class AnnouncementEntity extends BaseEntity {
   expiresAt: null | Date;
 
   @Column({ name: 'params', type: 'simple-json', nullable: true })
-  params: null | Record<string, unknown>;
+  params: null | AnnouncementParamsType;
 
   @Column({ name: 'type', type: 'simple-enum', enum: AnnouncementTypeEnum })
   type: AnnouncementTypeEnum;


### PR DESCRIPTION
**Description:**
Remove the capability of having multiple types of announcements.
Create migration to update legacy announcements.

**Related tickets:**
- Closes AB#174304