### PR TITLE
task: update announcement data model to account with innovations

### DIFF
--- a/apps/admin/v1-announcement-info/transformation.dtos.ts
+++ b/apps/admin/v1-announcement-info/transformation.dtos.ts
@@ -1,5 +1,5 @@
 import type { AnnouncementStatusEnum, ServiceRoleEnum } from '@admin/shared/enums';
-import { FilterPayload } from '@admin/shared/models/schema-engine/schema.model';
+import type { FilterPayload } from '@admin/shared/models/schema-engine/schema.model';
 
 export type ResponseDTO = {
   id: string;

--- a/libs/data-access/migrations/1724765148066-alter-announcement-user-table-to-add-innovation.ts
+++ b/libs/data-access/migrations/1724765148066-alter-announcement-user-table-to-add-innovation.ts
@@ -1,0 +1,16 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class alterAnnouncementUserTableToAddInnovation1724765148066 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "announcement_user" ADD "innovation_id" uniqueidentifier NULL`);
+
+    await queryRunner.query(`
+      ALTER TABLE "announcement_user" ADD CONSTRAINT "fk_announcement_user_innovation_id" FOREIGN KEY ("innovation_id") REFERENCES "innovation"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "announcement_user" DROP COLUMN "fk_announcement_user_innovation_id"`);
+    await queryRunner.query(`ALTER TABLE "announcement_user" DROP COLUMN "innovation_id"`);
+  }
+}

--- a/libs/shared/entities/user/announcement-user.entity.ts
+++ b/libs/shared/entities/user/announcement-user.entity.ts
@@ -1,6 +1,7 @@
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 
 import { BaseEntity } from '../base.entity';
+import { InnovationEntity } from '../innovation/innovation.entity';
 
 import { AnnouncementEntity } from './announcement.entity';
 import { UserEntity } from './user.entity';
@@ -20,6 +21,10 @@ export class AnnouncementUserEntity extends BaseEntity {
   @ManyToOne(() => UserEntity)
   @JoinColumn({ name: 'user_id' })
   user: UserEntity;
+
+  @ManyToOne(() => InnovationEntity)
+  @JoinColumn({ name: 'innovation_id' })
+  innovation: InnovationEntity;
 
   static new(data: Partial<AnnouncementUserEntity>): AnnouncementUserEntity {
     const instance = new AnnouncementUserEntity();


### PR DESCRIPTION
**Description:**
Adds `innovation_id` to `announcement_user` for two reasons:
- We can infer the innovations associated with an announcement through this relation.
- Allow the same user to have an announcement tied to multiple innovations, making each relationship unique.
    - User1 | Announcement1 | Innovation1  -> `read = false`
    - User1 | Announcement1 | Innovation2 -> `read = true`
    - User1 | Announcement1 | Innovation3 -> `read = false`

**Related tickets:**
- Closes [AB#174572](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/174572)
- US: [AB#174308](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/174308)