### PR TITLE
task: preload announcement users logic

### DIFF
--- a/apps/admin/.apim/swagger.yaml
+++ b/apps/admin/.apim/swagger.yaml
@@ -979,10 +979,6 @@ paths:
                         url:
                           type: string
                       additionalProperties: false
-                    filters:
-                      type: object
-                      properties: {}
-                      additionalProperties: false
                   required:
                     - content
                   additionalProperties: false
@@ -1016,6 +1012,9 @@ paths:
                       - question
                       - answers
                     additionalProperties: false
+                sendEmail:
+                  type: boolean
+                  default: false
               required:
                 - title
                 - startsAt
@@ -1109,7 +1108,7 @@ paths:
             format: uuid
       responses:
         "200":
-          description: Announcement created.
+          description: Announcement info retrieved.
           content:
             application/json:
               schema:
@@ -1136,6 +1135,23 @@ paths:
                   expiresAt:
                     type: string
                     format: date-time
+                  status:
+                    type: string
+                  filters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        section:
+                          type: string
+                        question:
+                          type: string
+                        answers:
+                          type: array
+                          items:
+                            type: string
+                  sendEmail:
+                    type: boolean
         "400":
           description: Bad request
         "401":
@@ -1178,10 +1194,6 @@ paths:
                         url:
                           type: string
                       additionalProperties: false
-                    filters:
-                      type: object
-                      properties: {}
-                      additionalProperties: false
                   additionalProperties: false
                 startsAt:
                   type: string
@@ -1194,6 +1206,27 @@ paths:
                   enum:
                     - LOG_IN
                     - HOMEPAGE
+                filters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      section:
+                        type: string
+                      question:
+                        type: string
+                      answers:
+                        type: array
+                        items:
+                          type: string
+                        minItems: 1
+                    required:
+                      - section
+                      - question
+                      - answers
+                    additionalProperties: false
+                sendEmail:
+                  type: boolean
               additionalProperties: false
       responses:
         "200":

--- a/apps/admin/_services/announcements.service.ts
+++ b/apps/admin/_services/announcements.service.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { EntityManager, In } from 'typeorm';
 
 import { AnnouncementEntity, AnnouncementUserEntity, UserEntity } from '@admin/shared/entities';
@@ -6,7 +6,9 @@ import {
   AnnouncementParamsType,
   AnnouncementStatusEnum,
   AnnouncementTypeEnum,
-  ServiceRoleEnum
+  InnovationCollaboratorStatusEnum,
+  ServiceRoleEnum,
+  UserStatusEnum
 } from '@admin/shared/enums';
 import { AnnouncementErrorsEnum, BadRequestError, NotFoundError, UnprocessableEntityError } from '@admin/shared/errors';
 import { JoiHelper, PaginationQueryParamsType } from '@admin/shared/helpers';
@@ -20,10 +22,14 @@ import {
 } from './announcements.schemas';
 import { BaseService } from './base.service';
 import type { FilterPayload } from '@admin/shared/models/schema-engine/schema.model';
+import { AdminErrorsEnum } from '@admin/shared/errors/errors.enums';
+import { InnovationEntity } from '@admin/shared/entities';
+import SHARED_SYMBOLS from '@admin/shared/services/symbols';
+import type { DomainService } from '@admin/shared/services';
 
 @injectable()
 export class AnnouncementsService extends BaseService {
-  constructor() {
+  constructor(@inject(SHARED_SYMBOLS.DomainService) private domainService: DomainService) {
     super();
   }
 
@@ -163,19 +169,11 @@ export class AnnouncementsService extends BaseService {
         sendEmail: data.sendEmail ?? false
       });
 
-      if (config?.usersToExclude && config.usersToExclude.length > 0) {
-        await em.save(
-          AnnouncementUserEntity,
-          config.usersToExclude.map(userId =>
-            AnnouncementUserEntity.new({
-              announcement: savedAnnouncement,
-              user: UserEntity.new({ id: userId }),
-              readAt: new Date(),
-              createdBy: requestContext.id,
-              updatedBy: requestContext.id
-            })
-          )
-        );
+      const today = new Date();
+      if (data.startsAt.toDateString() === today.toDateString()) {
+        await this.addAnnouncementUsers(savedAnnouncement, { usersToExclude: config?.usersToExclude }, transaction);
+        // TODO: Add notification call.
+        if (data.sendEmail) {}
       }
 
       return { id: savedAnnouncement.id };
@@ -259,6 +257,100 @@ export class AnnouncementsService extends BaseService {
         await transaction.softDelete(AnnouncementUserEntity, { id: In(announcementUsers.map(u => u.id)) });
       }
     });
+  }
+
+  async addAnnouncementUsers(
+    announcement: string | AnnouncementEntity,
+    options: { usersToExclude?: string[] },
+    transaction: EntityManager
+  ): Promise<void> {
+    // Get announcement info
+    let announcementInfo: AnnouncementEntity;
+    if (typeof announcement === 'string') {
+      const dbAnnouncement = await transaction
+        .createQueryBuilder(AnnouncementEntity, 'announcement')
+        .where('announcement.id = :announcementId', { announcementId: announcement })
+        .getOne();
+      if (!dbAnnouncement) {
+        throw new NotFoundError(AdminErrorsEnum.ADMIN_ANNOUNCEMENT_NOT_FOUND);
+      }
+      announcementInfo = dbAnnouncement;
+    } else {
+      announcementInfo = announcement;
+    }
+
+    // userId::innovationId
+    const targetedInnovators = new Set<string>(); // Saves the userIds from the Innovators and their associated innovations
+    const targetRolesUserIds = new Set<string>(); // Saves the userIds that are not bound to a innovation
+
+    // If its type innovation filtered get all the collaborators + owners for all the targetted innovations.
+    if (announcementInfo.filters) {
+      const innovations = await this.domainService.innovations.getInnovationsFiltered(
+        announcementInfo.filters,
+        { onlySubmitted: true },
+        transaction
+      );
+
+      if (innovations.length) {
+        const ownerAndCollaboratorInfo = await transaction
+          .createQueryBuilder(InnovationEntity, 'innovation')
+          .select(['innovation.id', 'owner.id', 'collaborator.id', 'collaboratorUser.id'])
+          .leftJoin('innovation.owner', 'owner', 'owner.status <> :deleted ', { deleted: UserStatusEnum.DELETED })
+          .leftJoin('innovation.collaborators', 'collaborator', 'collaborator.status = :active', {
+            active: InnovationCollaboratorStatusEnum.ACTIVE
+          })
+          .leftJoin('collaborator.user', 'collaboratorUser', 'collaboratorUser.status <> :deleted', { deleted: UserStatusEnum.DELETED })
+          .where('innovation.id IN (:...innovationIds)', { innovationIds: innovations.map(i => i.id) })
+          .getMany();
+        ownerAndCollaboratorInfo.forEach(i => {
+          if (i.owner) {
+            targetedInnovators.add(`${i.owner.id}::${i.id}`);
+          }
+          i.collaborators.forEach(c => c.user && targetedInnovators.add(`${c.user.id}::${i.id}`));
+        });
+      }
+    }
+
+    // This filter is needed since if its of type INNOVATOR + filtered we already got the Innovators in the query before.
+    const targetRoles = announcementInfo.userRoles.filter(
+      r => r !== ServiceRoleEnum.INNOVATOR || (r === ServiceRoleEnum.INNOVATOR && !announcementInfo.filters)
+    );
+    if (targetRoles.length) {
+      const users = await transaction
+        .createQueryBuilder(UserEntity, 'user')
+        .select(['user.id'])
+        .innerJoin('user.serviceRoles', 'role')
+        .where('role.role IN (:...targetRoles)', { targetRoles })
+        .andWhere('role.isActive = 1')
+        .getMany();
+      users.forEach(u => targetRolesUserIds.add(u.id));
+    }
+
+    // Add users to the announcementUsers table.
+    const targetedUsers: { id: string; innovationId?: string }[] = [];
+    targetRolesUserIds.forEach(id => targetedUsers.push({ id }));
+    targetRolesUserIds.clear();
+    targetedInnovators.forEach(value => {
+      const [userId, innovationId] = value.split('::');
+      if (userId && innovationId) {
+        targetedUsers.push({ id: userId, innovationId });
+      }
+    });
+    targetedInnovators.clear();
+
+    await transaction.save(
+      AnnouncementUserEntity,
+      targetedUsers.map(u =>
+        AnnouncementUserEntity.new({
+          announcement: announcementInfo,
+          user: UserEntity.new({ id: u.id }),
+          ...(u.innovationId && { innovation: InnovationEntity.new({ id: u.innovationId }) }),
+          createdBy: announcementInfo.createdBy,
+          updatedBy: announcementInfo.createdBy,
+          ...(options.usersToExclude && options.usersToExclude.includes(u.id) && { readAt: new Date() })
+        })
+      ), { chunk: 500 }
+    );
   }
 
   private validateAnnouncementBody(

--- a/libs/shared/errors/errors.enums.ts
+++ b/libs/shared/errors/errors.enums.ts
@@ -159,7 +159,9 @@ export enum EmailErrorsEnum {
 }
 
 export enum AdminErrorsEnum {
-  ADMIN_TERMS_OF_USE_NOT_FOUND = 'AT.0001'
+  ADMIN_TERMS_OF_USE_NOT_FOUND = 'AT.0001',
+
+  ADMIN_ANNOUNCEMENT_NOT_FOUND = 'AN.0001'
 }
 
 export enum AnnouncementErrorsEnum {

--- a/libs/shared/services/domain/domain-innovations.service.ts
+++ b/libs/shared/services/domain/domain-innovations.service.ts
@@ -49,6 +49,7 @@ import type { IdentityProviderService } from '../integrations/identity-provider.
 import type { NotifierService } from '../integrations/notifier.service';
 import type { IRSchemaService } from '../storage/ir-schema.service';
 import type { DomainUsersService } from './domain-users.service';
+import type { FilterPayload } from '../../models/schema-engine/schema.model';
 
 export class DomainInnovationsService {
   innovationRepository: Repository<InnovationEntity>;
@@ -908,7 +909,7 @@ export class DomainInnovationsService {
    * * (filter1 === 'A' AND filter2 === 'B') OR filter2 === 'C'
    */
   async getInnovationsFiltered(
-    filters: any[], // TODO: Change this to FilterPayload when "feature" PR is merged
+    filters: FilterPayload[],
     options: { onlySubmitted?: boolean },
     entityManager?: EntityManager
   ): Promise<{ id: string; name: string }[]> {


### PR DESCRIPTION
**Description:**
This PR introduces the raw version of:
- Add announcement users when the announcement is to be shown instantly.
- A function `addAnnouncementUsers` that can be reused by the scheduler and the `createAnnouncement` function.

**Related tickets:**
- AB#174660
- US: AB#174308