### PR TITLE
task: add migration to turn read_at null

### DIFF
--- a/libs/data-access/migrations/1724922476734-alter-announcement-user-table-to-change-read-at-type.ts
+++ b/libs/data-access/migrations/1724922476734-alter-announcement-user-table-to-change-read-at-type.ts
@@ -1,0 +1,11 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class alterAnnouncementUserTableToChangeReadAtType1724922476734 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE announcement_user ALTER COLUMN read_at datetime2 NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE announcement_user ALTER COLUMN read_at datetime2 NOT NULL`);
+  }
+}


### PR DESCRIPTION
**Description:**
Now that we pre-load the announcement_users once again the `read_at` flag needs to be nullable in order for it to work.