### PR TITLE
task: add new logic related with read announcements

### DIFF
--- a/apps/notifications/_services/recipients.service.spec.ts
+++ b/apps/notifications/_services/recipients.service.spec.ts
@@ -1397,7 +1397,10 @@ describe('Notifications / _services / recipients service suite', () => {
         em
       );
       expect(res).toMatchObject(
-        new Map([[scenario.users.johnInnovator.id, [scenario.users.johnInnovator.innovations.johnInnovation.name]]])
+        new Map([
+          [scenario.users.johnInnovator.id, [scenario.users.johnInnovator.innovations.johnInnovation.name]],
+          [scenario.users.adamInnovator.id, [scenario.users.adamInnovator.innovations.adamInnovation.name]]
+        ])
       );
     });
   });

--- a/apps/users/.apim/swagger.yaml
+++ b/apps/users/.apim/swagger.yaml
@@ -248,6 +248,12 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: innovationId
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
       responses:
         "204":
           description: Success
@@ -779,7 +785,8 @@ paths:
                       - INNOVATION_RECORD_UPDATED
                       - REMINDER
                       - SUGGESTED_SUPPORT_UPDATED
-                      - AN01_NEW_ANNOUNCEMENT
+                      - AP10_NEW_ANNOUNCEMENT
+                      - AP11_NEW_ANNOUNCEMENT_WITH_INNOVATIONS_NAME
                   default: []
                 dismissAll:
                   type: boolean
@@ -993,7 +1000,8 @@ paths:
                             - INNOVATION_RECORD_UPDATED
                             - REMINDER
                             - SUGGESTED_SUPPORT_UPDATED
-                            - AN01_NEW_ANNOUNCEMENT
+                            - AP10_NEW_ANNOUNCEMENT
+                            - AP11_NEW_ANNOUNCEMENT_WITH_INNOVATIONS_NAME
                           description: The notification context detail
                         contextId:
                           type: string

--- a/apps/users/v1-me-announcement-read/index.ts
+++ b/apps/users/v1-me-announcement-read/index.ts
@@ -10,7 +10,7 @@ import type { CustomContextType } from '@users/shared/types';
 import { container } from '../_config';
 import type { AnnouncementsService } from '../_services/announcements.service';
 import SYMBOLS from '../_services/symbols';
-import { ParamsSchema, ParamsType } from './validation.schemas';
+import { ParamsSchema, ParamsType, QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1MeAnnouncementRead {
   @JwtDecoder()
@@ -19,7 +19,8 @@ class V1MeAnnouncementRead {
     const announcementsService = container.get<AnnouncementsService>(SYMBOLS.AnnouncementsService);
 
     try {
-      const params = JoiHelper.Validate<ParamsType>(ParamsSchema, request.params);
+      const pathParams = JoiHelper.Validate<ParamsType>(ParamsSchema, request.params);
+      const queryParams = JoiHelper.Validate<QueryParamsType>(QueryParamsSchema, request.query);
 
       const auth = await authorizationService
         .validate(context)
@@ -28,7 +29,7 @@ class V1MeAnnouncementRead {
         .checkInnovatorType()
         .verify();
 
-      await announcementsService.readUserAnnouncement(auth.getContext(), params.announcementId);
+      await announcementsService.readUserAnnouncement(auth.getContext(), pathParams.announcementId, queryParams.innovationId);
       context.res = ResponseHelper.NoContent();
       return;
     } catch (error) {
@@ -45,7 +46,7 @@ export default openApi(
     patch: {
       operationId: 'v1-me-announcement-read',
       description: 'Mark an announcement as read.',
-      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema, query: QueryParamsSchema }),
       responses: {
         204: { description: 'Success' },
         404: { description: 'Not found' }

--- a/apps/users/v1-me-announcement-read/validation.schemas.ts
+++ b/apps/users/v1-me-announcement-read/validation.schemas.ts
@@ -6,3 +6,10 @@ export type ParamsType = {
 export const ParamsSchema = Joi.object<ParamsType>({
   announcementId: Joi.string().guid().required()
 }).required();
+
+export type QueryParamsType = {
+  innovationId?: string;
+};
+export const QueryParamsSchema = Joi.object<QueryParamsType>({
+  innovationId: Joi.string().guid()
+});

--- a/libs/shared/tests/scenarios/complete-scenario.builder.ts
+++ b/libs/shared/tests/scenarios/complete-scenario.builder.ts
@@ -23,6 +23,7 @@ import {
   ThreadContextTypeEnum
 } from '../../enums/innovation.enums';
 import { ServiceRoleEnum, UserStatusEnum } from '../../enums/user.enums';
+import { AnnouncementStatusEnum } from '../../enums/announcement.enums';
 import type { Reminder, SupportUpdated } from '../../types';
 import { InnovationAssessmentBuilder } from '../builders/innovation-assessment.builder';
 import { InnovationCollaboratorBuilder } from '../builders/innovation-collaborator.builder';
@@ -957,6 +958,7 @@ export class CompleteScenarioBuilder {
         .setTitle('Announcement for QAs')
         .setStartsAt(randPastDate())
         .setUserRoles([ServiceRoleEnum.QUALIFYING_ACCESSOR])
+        .setStatus(AnnouncementStatusEnum.ACTIVE)
         .save();
 
       const announcementUserAliceQA = await new AnnouncementUserBuilder(entityManager)
@@ -972,11 +974,17 @@ export class CompleteScenarioBuilder {
       const announcementForSpecificInnovations = await new AnnouncementBuilder(entityManager)
         .setTitle('Announcement for Specific Innovations')
         .setUserRoles([ServiceRoleEnum.INNOVATOR])
+        .setStatus(AnnouncementStatusEnum.ACTIVE)
         .save();
 
-      const announcementUsersWithSpecificInnovations = await new AnnouncementUserBuilder(entityManager)
+      const announcementUserForSpecificInnovationsJohnInnovation = await new AnnouncementUserBuilder(entityManager)
         .setAnnouncement(announcementForSpecificInnovations.id)
         .setUserAndInnovation(johnInnovator.id, johnInnovation.id)
+        .save();
+
+      const announcementUserForSpecificInnovationsAdamInnovation = await new AnnouncementUserBuilder(entityManager)
+        .setAnnouncement(announcementForSpecificInnovations.id)
+        .setUserAndInnovation(adamInnovator.id, adamInnovation.id)
         .save();
 
       return {
@@ -1345,7 +1353,10 @@ export class CompleteScenarioBuilder {
           },
           announcementForSpecificInnovations: {
             ...announcementForSpecificInnovations,
-            announcementUsers: announcementUsersWithSpecificInnovations
+            announcementUsers: {
+              announcementUserJohnInnovation: announcementUserForSpecificInnovationsJohnInnovation,
+              announcementUserAdamInnovation: announcementUserForSpecificInnovationsAdamInnovation
+            }
           }
         }
       };


### PR DESCRIPTION
**Description:**
Announcements can now be read on three different contexts:
* Login -> Using only the announcementId
* Homepage -> Using only the announcementId
* Innovation Context -> using flag innovationId

**Related tickets:**
- Closes [AB#174469](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/174469)
- US: [AB#173692](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/173692)