### PR TITLE
task: update the get user announcement to new structure

### DIFF
--- a/apps/users/.apim/swagger.yaml
+++ b/apps/users/.apim/swagger.yaml
@@ -266,20 +266,22 @@ paths:
       tags:
         - "[v1] Announcements"
       parameters:
-        - name: filters
+        - name: type
           in: query
-          required: true
+          required: false
           schema:
-            type: object
-            properties:
-              type:
-                type: array
-                items:
-                  type: string
-                  enum:
-                    - LOG_IN
-                    - HOMEPAGE
-            additionalProperties: false
+            type: array
+            items:
+              type: string
+              enum:
+                - LOG_IN
+                - HOMEPAGE
+        - name: innovationId
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
       responses:
         "200":
           description: Success

--- a/apps/users/v1-me-announcements/index.spec.ts
+++ b/apps/users/v1-me-announcements/index.spec.ts
@@ -7,6 +7,7 @@ import type { ErrorResponseType } from '@users/shared/types';
 import { AnnouncementsService } from '../_services/announcements.service';
 import type { ResponseDTO } from './transformation.dtos';
 import type { QueryParamsType } from './validation.schemas';
+import { AnnouncementTypeEnum } from '@users/shared/enums';
 
 jest.mock('@users/shared/decorators', () => ({
   JwtDecoder: jest.fn().mockImplementation(() => (_: any, __: string, descriptor: PropertyDescriptor) => {
@@ -30,14 +31,14 @@ const expected = [
     title: randText(),
     startsAt: randPastDate(),
     expiresAt: randFutureDate(),
-    params: {}
+    params: null
   },
   {
     id: randUuid(),
     title: randText(),
     startsAt: randPastDate(),
     expiresAt: null,
-    params: {}
+    params: null
   }
 ];
 const mock = jest.spyOn(AnnouncementsService.prototype, 'getUserRoleAnnouncements').mockResolvedValue(expected);
@@ -51,7 +52,7 @@ describe('v1-me-announcements Suite', () => {
     it('should return the announcements', async () => {
       const result = await new AzureHttpTriggerBuilder()
         .setAuth(scenario.users.johnInnovator)
-        .setQuery<QueryParamsType>({ filters: {} })
+        .setQuery<QueryParamsType>({ type: [AnnouncementTypeEnum.LOG_IN] })
         .call<ResponseDTO>(azureFunction);
 
       expect(result.body).toStrictEqual(expected);
@@ -70,7 +71,7 @@ describe('v1-me-announcements Suite', () => {
     ])('access with user %s should give %i', async (_role: string, status: number, user: TestUserType) => {
       const result = await new AzureHttpTriggerBuilder()
         .setAuth(user)
-        .setQuery<QueryParamsType>({ filters: {} })
+        .setQuery<QueryParamsType>({ type: [AnnouncementTypeEnum.LOG_IN] })
         .call<ErrorResponseType>(azureFunction);
 
       expect(result.status).toBe(status);

--- a/apps/users/v1-me-announcements/index.ts
+++ b/apps/users/v1-me-announcements/index.ts
@@ -30,12 +30,8 @@ class V1MeAnnouncements {
         .checkAssessmentType()
         .checkInnovatorType()
         .verify();
-      const requestContext = auth.getContext();
 
-      const announcements = await announcementsService.getUserRoleAnnouncements(
-        requestContext.currentRole.id,
-        queryParams.filters
-      );
+      const announcements = await announcementsService.getUserRoleAnnouncements(auth.getContext().id, queryParams);
 
       context.res = ResponseHelper.Ok<ResponseDTO>(
         announcements.map(announcement => ({
@@ -43,7 +39,8 @@ class V1MeAnnouncements {
           title: announcement.title,
           startsAt: announcement.startsAt,
           expiresAt: announcement.expiresAt,
-          params: announcement.params
+          params: announcement.params,
+          ...(announcement.innovations && { innovations: announcement.innovations })
         }))
       );
       return;

--- a/apps/users/v1-me-announcements/transformation.dtos.ts
+++ b/apps/users/v1-me-announcements/transformation.dtos.ts
@@ -1,7 +1,10 @@
+import type { AnnouncementParamsType } from '@users/shared/enums';
+
 export type ResponseDTO = {
   id: string;
   title: string;
   startsAt: Date;
   expiresAt: null | Date;
-  params: null | Record<string, unknown>;
+  params: null | AnnouncementParamsType;
+  innovations?: string[];
 }[];

--- a/apps/users/v1-me-announcements/validation.schemas.ts
+++ b/apps/users/v1-me-announcements/validation.schemas.ts
@@ -1,16 +1,15 @@
-import { AnnouncementTypeEnum } from './../.symlinks/shared/enums/announcement.enums';
+import { AnnouncementTypeEnum } from '@users/shared/enums';
+import { JoiHelper } from '@users/shared/helpers';
 import Joi from 'joi';
 
 export type QueryParamsType = {
-  filters: {
-    type?: AnnouncementTypeEnum[];
-  };
+  type?: AnnouncementTypeEnum[];
+  innovationId?: string;
 };
-
 export const QueryParamsSchema = Joi.object<QueryParamsType>({
-  filters: Joi.object({
-    type: Joi.array()
-      .items(Joi.string().valid(...Object.values(AnnouncementTypeEnum)))
-      .optional()
-  }).required()
-}).required();
+  type: JoiHelper.AppCustomJoi()
+    .stringArray()
+    .items(Joi.string().valid(...Object.values(AnnouncementTypeEnum)))
+    .optional(),
+  innovationId: Joi.string().guid().optional()
+});

--- a/apps/users/v1-me-info/index.ts
+++ b/apps/users/v1-me-info/index.ts
@@ -58,7 +58,7 @@ class V1MeInfo {
           .isAccepted;
         // TO DO: Maybe update variable name
         hasAnnouncements =
-          (await announcementsService.getUserRoleAnnouncements(userRole.id, { type: [AnnouncementTypeEnum.LOG_IN] }))
+          (await announcementsService.getUserRoleAnnouncements(requestUser.id, { type: [AnnouncementTypeEnum.LOG_IN] }))
             .length > 0;
 
         if (userRole.role === ServiceRoleEnum.INNOVATOR) {


### PR DESCRIPTION
**Description:**
This PR updates the existing logic for retrieving the announcements that the user needs to read. The changes include:
- Adding a `type` filter to return only the desired announcement type(s).
- Adding an `innovationId` filter to return only the announcements related to a specific innovation.

**Related tickets:**
- Closes [AB#174939](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/174939)
- US: [AB#173692](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/173692)