### PR TITLE
task: handle announcements for multiple roles

### DIFF
--- a/apps/users/_services/announcements.service.spec.ts
+++ b/apps/users/_services/announcements.service.spec.ts
@@ -8,6 +8,7 @@ import { AnnouncementUserEntity } from '@users/shared/entities';
 import { randUuid } from '@ngneat/falso';
 import { DTOsHelper } from '@users/shared/tests/helpers/dtos.helper';
 import { AnnouncementErrorsEnum, NotFoundError } from '@users/shared/errors';
+import { AnnouncementTypeEnum, ServiceRoleEnum } from '@users/shared/enums';
 
 describe('Users / _services / announcements service suite', () => {
   let sut: AnnouncementsService;
@@ -42,7 +43,7 @@ describe('Users / _services / announcements service suite', () => {
     };
 
     it('should list all announcements for the given roleId with affected innovations', async () => {
-      const result = await sut.getUserRoleAnnouncements(johnInnovator.id, {}, em);
+      const result = await sut.getUserRoleAnnouncements(DTOsHelper.getUserRequestContext(johnInnovator), {}, em);
       expect(result).toMatchObject([
         {
           ...announcementReturn,
@@ -53,7 +54,7 @@ describe('Users / _services / announcements service suite', () => {
 
     it('should only get the announcements for a given innovation', async () => {
       const result = await sut.getUserRoleAnnouncements(
-        johnInnovator.id,
+        DTOsHelper.getUserRequestContext(johnInnovator),
         { innovationId: johnInnovator.innovations.johnInnovation.id },
         em
       );
@@ -62,7 +63,7 @@ describe('Users / _services / announcements service suite', () => {
 
     it('should return an empty array when there are no announcements for the given innovation', async () => {
       const result = await sut.getUserRoleAnnouncements(
-        johnInnovator.id,
+        DTOsHelper.getUserRequestContext(johnInnovator),
         { innovationId: johnInnovator.innovations.johnInnovationEmpty.id },
         em
       );
@@ -70,7 +71,11 @@ describe('Users / _services / announcements service suite', () => {
     });
 
     it('should return an empty array when there are no announcements for the given user', async () => {
-      const result = await sut.getUserRoleAnnouncements(scenario.users.tristanInnovator.id, {}, em);
+      const result = await sut.getUserRoleAnnouncements(
+        DTOsHelper.getUserRequestContext(scenario.users.tristanInnovator),
+        {},
+        em
+      );
       expect(result).toHaveLength(0);
     });
   });
@@ -131,6 +136,17 @@ describe('Users / _services / announcements service suite', () => {
           em
         )
       ).rejects.toThrow(new NotFoundError(AnnouncementErrorsEnum.ANNOUNCEMENT_NOT_FOUND));
+    });
+  });
+
+  describe('hasAnnouncementsToReadByRole', () => {
+    it('should return if the user as announcements for certain role', async () => {
+      const result = await sut.hasAnnouncementsToReadByRole(
+        scenario.users.johnInnovator.id,
+        [AnnouncementTypeEnum.HOMEPAGE],
+        em
+      );
+      expect(result).toStrictEqual({ [ServiceRoleEnum.INNOVATOR]: true });
     });
   });
 });

--- a/apps/users/v1-me-announcements/index.ts
+++ b/apps/users/v1-me-announcements/index.ts
@@ -31,7 +31,7 @@ class V1MeAnnouncements {
         .checkInnovatorType()
         .verify();
 
-      const announcements = await announcementsService.getUserRoleAnnouncements(auth.getContext().id, queryParams);
+      const announcements = await announcementsService.getUserRoleAnnouncements(auth.getContext(), queryParams);
 
       context.res = ResponseHelper.Ok<ResponseDTO>(
         announcements.map(announcement => ({

--- a/apps/users/v1-me-info/index.spec.ts
+++ b/apps/users/v1-me-info/index.spec.ts
@@ -33,13 +33,7 @@ const userInfo = {
   identityId: randUuid(),
   email: randEmail(),
   displayName: randFullName(),
-  roles: [
-    {
-      id: randUuid(),
-      role: ServiceRoleEnum.INNOVATOR,
-      isActive: true
-    }
-  ],
+  roles: [{ id: randUuid(), role: ServiceRoleEnum.INNOVATOR, isActive: true }],
   phone: null,
   isActive: true,
   lockedAt: null,
@@ -79,8 +73,8 @@ const pendingCollaborationsMock = jest
   .spyOn(UsersService.prototype, 'getCollaborationsInvitesList')
   .mockResolvedValue([1] as any);
 const announcementsMock = jest
-  .spyOn(AnnouncementsService.prototype, 'getUserRoleAnnouncements')
-  .mockResolvedValue([1] as any);
+  .spyOn(AnnouncementsService.prototype, 'hasAnnouncementsToReadByRole')
+  .mockResolvedValue({});
 const preferences = {
   contactByEmail: true,
   contactByPhone: true,
@@ -104,7 +98,7 @@ describe('v1-me-info Suite', () => {
       expect(result.body).toStrictEqual({
         ...omit(userInfo, ['identityId', 'lockedAt', 'isActive']),
         ...preferences,
-        hasAnnouncements: true,
+        hasLoginAnnouncements: {},
         hasInnovationCollaborations: true,
         hasInnovationTransfers: true,
         termsOfUseAccepted: terms.isAccepted
@@ -137,13 +131,7 @@ describe('v1-me-info Suite', () => {
     ])("shouldn't return preferences, collaborations and transfers for %s", async (role: ServiceRoleEnum) => {
       mock.mockResolvedValueOnce({
         ...userInfo,
-        roles: [
-          {
-            id: randUuid(),
-            role,
-            isActive: true
-          }
-        ]
+        roles: [{ id: randUuid(), role, isActive: true }]
       });
       const result = await new AzureHttpTriggerBuilder()
         .setAuth(scenario.users.johnInnovator)
@@ -164,13 +152,7 @@ describe('v1-me-info Suite', () => {
     it("shouldn't check announcements and termsOfUse for admin", async () => {
       mock.mockResolvedValueOnce({
         ...userInfo,
-        roles: [
-          {
-            id: randUuid(),
-            role: ServiceRoleEnum.ADMIN,
-            isActive: true
-          }
-        ]
+        roles: [{ id: randUuid(), role: ServiceRoleEnum.ADMIN, isActive: true }]
       });
       const result = await new AzureHttpTriggerBuilder()
         .setAuth(scenario.users.johnInnovator)
@@ -178,7 +160,7 @@ describe('v1-me-info Suite', () => {
       expect(termsOfUseAcceptedMock).toHaveBeenCalledTimes(0);
       expect(announcementsMock).toHaveBeenCalledTimes(0);
       expect(result.body).toMatchObject({
-        hasAnnouncements: false,
+        hasLoginAnnouncements: {},
         termsOfUseAccepted: true
       });
     });
@@ -191,13 +173,7 @@ describe('v1-me-info Suite', () => {
     ])('should check annoucements and termsOfUse for %s', async role => {
       mock.mockResolvedValueOnce({
         ...userInfo,
-        roles: [
-          {
-            id: randUuid(),
-            role,
-            isActive: true
-          }
-        ]
+        roles: [{ id: randUuid(), role, isActive: true }]
       });
       const result = await new AzureHttpTriggerBuilder()
         .setAuth(scenario.users.johnInnovator)
@@ -205,7 +181,7 @@ describe('v1-me-info Suite', () => {
       expect(termsOfUseAcceptedMock).toHaveBeenCalledTimes(1);
       expect(announcementsMock).toHaveBeenCalledTimes(1);
       expect(result.body).toMatchObject({
-        hasAnnouncements: true,
+        hasLoginAnnouncements: {},
         termsOfUseAccepted: terms.isAccepted
       });
     });
@@ -225,7 +201,7 @@ describe('v1-me-info Suite', () => {
       expect(pendingTransfersMock).toHaveBeenCalledTimes(0);
       expect(pendingCollaborationsMock).toHaveBeenCalledTimes(0);
       expect(termsOfUseAcceptedMock).toHaveBeenCalledTimes(0);
-      expect(announcementsMock).toHaveBeenCalledTimes(0);
+      expect(announcementsMock).toHaveBeenCalledTimes(1);
       expect(result.body).toMatchObject({
         contactByEmail: false,
         contactByPhone: false,
@@ -233,7 +209,7 @@ describe('v1-me-info Suite', () => {
         contactDetails: null,
         hasInnovationCollaborations: false,
         hasInnovationTransfers: false,
-        hasAnnouncements: false,
+        hasLoginAnnouncements: {},
         termsOfUseAccepted: true
       });
     });
@@ -250,7 +226,7 @@ describe('v1-me-info Suite', () => {
       expect(result.body).toStrictEqual({
         ...omit(userInfo, ['identityId', 'lockedAt', 'isActive']),
         ...preferences,
-        hasAnnouncements: true,
+        hasLoginAnnouncements: {},
         hasInnovationCollaborations: true,
         hasInnovationTransfers: true,
         termsOfUseAccepted: terms.isAccepted

--- a/apps/users/v1-me-info/index.ts
+++ b/apps/users/v1-me-info/index.ts
@@ -36,7 +36,7 @@ class V1MeInfo {
       let termsOfUseAccepted = true;
       let hasInnovationTransfers = false;
       let hasInnovationCollaborations = false;
-      let hasAnnouncements = false;
+      let hasLoginAnnouncements = {};
       let userPreferences: {
         contactByPhone: boolean;
         contactByEmail: boolean;
@@ -56,16 +56,18 @@ class V1MeInfo {
 
         termsOfUseAccepted = (await termsOfUseService.getActiveTermsOfUseInfo({ id: requestUser.id }, userRole.role))
           .isAccepted;
-        // TO DO: Maybe update variable name
-        hasAnnouncements =
-          (await announcementsService.getUserRoleAnnouncements(requestUser.id, { type: [AnnouncementTypeEnum.LOG_IN] }))
-            .length > 0;
 
         if (userRole.role === ServiceRoleEnum.INNOVATOR) {
           userPreferences = await domainService.users.getUserPreferences(requestUser.id);
           hasInnovationTransfers = (await usersService.getUserPendingInnovationTransfers(requestUser.email)).length > 0;
           hasInnovationCollaborations = (await usersService.getCollaborationsInvitesList(requestUser.email)).length > 0;
         }
+      }
+
+      if (userRoles.length > 0 && userRoles[0]!.role !== ServiceRoleEnum.ADMIN) {
+        hasLoginAnnouncements = await announcementsService.hasAnnouncementsToReadByRole(requestUser.id, [
+          AnnouncementTypeEnum.LOG_IN
+        ]);
       }
 
       context.res = ResponseHelper.Ok<ResponseDTO>({
@@ -83,7 +85,7 @@ class V1MeInfo {
         termsOfUseAccepted,
         hasInnovationTransfers,
         hasInnovationCollaborations,
-        hasAnnouncements,
+        hasLoginAnnouncements,
         organisations: requestUser.organisations! // will exist since we call the userInfo with organisation flag
       });
       return;

--- a/apps/users/v1-me-info/transformation.dtos.ts
+++ b/apps/users/v1-me-info/transformation.dtos.ts
@@ -14,7 +14,7 @@ export type ResponseDTO = {
   termsOfUseAccepted: boolean;
   hasInnovationTransfers: boolean;
   hasInnovationCollaborations: boolean;
-  hasAnnouncements: boolean;
+  hasLoginAnnouncements: { [k: string]: boolean };
   passwordResetAt: null | Date;
   firstTimeSignInAt: null | Date;
   organisations: {


### PR DESCRIPTION
**Description:**
This PR introduces two changes:
- `/me` now returns which role `hasAnnouncements` so FE can differentiate when the user has multiple roles.
-  `/me/announcements` now accounts with the role of the user.