### PR TITLE
Add 'name' field to organisationUnit object

### DIFF
--- a/apps/innovations/v1-innovation-thread-followers/index.spec.ts
+++ b/apps/innovations/v1-innovation-thread-followers/index.spec.ts
@@ -5,7 +5,7 @@ import { DomainInnovationsService } from '@innovations/shared/services';
 import { AzureHttpTriggerBuilder, TestsHelper } from '@innovations/shared/tests';
 import type { TestUserType } from '@innovations/shared/tests/builders/user.builder';
 import type { ErrorResponseType } from '@innovations/shared/types';
-import { randAbbreviation, randBoolean, randFullName, randUuid } from '@ngneat/falso';
+import { randAbbreviation, randBoolean, randCompanyName, randFullName, randUuid } from '@ngneat/falso';
 import type { ResponseDTO } from './transformation.dtos';
 import type { ParamsType } from './validation.schemas';
 
@@ -41,7 +41,7 @@ const expected = [
     locked: randBoolean(),
     isOwner: false,
     userRole: { id: randUuid(), role: ServiceRoleEnum.ACCESSOR },
-    organisationUnit: { id: randUuid(), acronym: randAbbreviation() }
+    organisationUnit: { id: randUuid(), name: randCompanyName(), acronym: randAbbreviation() }
   }
 ];
 
@@ -72,6 +72,7 @@ describe('v1-innovation-thread-followers Suite', () => {
           organisationUnit: follower.organisationUnit
             ? {
                 id: follower.organisationUnit.id,
+                name: follower.organisationUnit.name,
                 acronym: follower.organisationUnit.acronym
               }
             : null

--- a/apps/innovations/v1-innovation-thread-followers/index.ts
+++ b/apps/innovations/v1-innovation-thread-followers/index.ts
@@ -46,6 +46,7 @@ class V1InnovationThreadFollowers {
           organisationUnit: follower.organisationUnit
             ? {
                 id: follower.organisationUnit.id,
+                name: follower.organisationUnit.name,
                 acronym: follower.organisationUnit.acronym
               }
             : null

--- a/apps/innovations/v1-innovation-thread-followers/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-thread-followers/transformation.dtos.ts
@@ -7,6 +7,6 @@ export type ResponseDTO = {
     isLocked: boolean;
     isOwner?: boolean;
     role: { id: string; role: ServiceRoleEnum };
-    organisationUnit: { id: string; acronym: string } | null;
+    organisationUnit: { id: string; name: string; acronym: string } | null;
   }[];
 };

--- a/apps/notifications/_services/recipients.service.spec.ts
+++ b/apps/notifications/_services/recipients.service.spec.ts
@@ -618,6 +618,7 @@ describe('Notifications / _services / recipients service suite', () => {
         },
         organisationUnit: {
           id: scenario.users.aliceQualifyingAccessor.roles.qaRole.organisationUnit!.id,
+          name: scenario.users.aliceQualifyingAccessor.roles.qaRole.organisationUnit!.name,
           acronym: scenario.users.aliceQualifyingAccessor.roles.qaRole.organisationUnit!.acronym
         }
       }

--- a/apps/users/.apim/swagger.yaml
+++ b/apps/users/.apim/swagger.yaml
@@ -100,6 +100,11 @@ paths:
                           enum:
                             - YES
                             - NO
+                        ANNOUNCEMENTS:
+                          type: string
+                          enum:
+                            - YES
+                            - NO
                       required:
                         - SUPPORT
                         - TASK
@@ -107,6 +112,7 @@ paths:
                         - INNOVATION_MANAGEMENT
                         - AUTOMATIC
                         - NOTIFY_ME
+                        - ANNOUNCEMENTS
                       additionalProperties: false
                       x-required: true
                     - type: object

--- a/libs/shared/services/domain/domain-innovations.service.ts
+++ b/libs/shared/services/domain/domain-innovations.service.ts
@@ -646,7 +646,7 @@ export class DomainInnovationsService {
       locked: boolean;
       isOwner?: boolean;
       userRole: { id: string; role: ServiceRoleEnum };
-      organisationUnit: { id: string; acronym: string } | null;
+      organisationUnit: { id: string; name: string; acronym: string } | null;
     }[]
   > {
     const em = entityManager ?? this.sqlConnection.manager;
@@ -673,6 +673,7 @@ export class DomainInnovationsService {
         'followerUserRole.role',
         'followerUserRole.isActive',
         'followerOrganisationUnit.id',
+        'followerOrganisationUnit.name',
         'followerOrganisationUnit.acronym'
       ])
       .innerJoin('thread.innovation', 'innovation')
@@ -749,7 +750,11 @@ export class DomainInnovationsService {
           role: followerRole.role
         },
         organisationUnit: followerRole.organisationUnit
-          ? { id: followerRole.organisationUnit.id, acronym: followerRole.organisationUnit.acronym }
+          ? {
+              id: followerRole.organisationUnit.id,
+              name: followerRole.organisationUnit.name,
+              acronym: followerRole.organisationUnit.acronym
+            }
           : null
       }))
     );


### PR DESCRIPTION
Description: 
- Adds org name to thread followers endpoint

Related tickets:

    Closes [AB#175224](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/175224)
    US: [AB#173888](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/173888)