### PR TITLE
 task 175450/ Create migration for renaming missing units

### DIFF
--- a/libs/data-access/migrations/1726503822588-rename-missing-units.ts
+++ b/libs/data-access/migrations/1726503822588-rename-missing-units.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameMissingUnits1726503822588 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+    UPDATE organisation_unit SET name='Department for Business and Trade (DBT)' WHERE name='Department for Business and Trade';
+    UPDATE organisation_unit SET name='Health Research Authority (HRA)' WHERE name='Health Research Authority';
+    UPDATE organisation_unit SET name='Health Technology Wales (HTW)' WHERE name='Health Technology Wales';
+    UPDATE organisation_unit SET name='Medicines and Healthcare products Regulatory Agency (MHRA)' WHERE name='MHRA';
+    UPDATE organisation_unit SET name='National Institute for Health and Care Excellence (NICE)' WHERE name='NICE';
+    UPDATE organisation_unit SET name='National Institute for Health and Care Research (NIHR)' WHERE name='National Institute for Health and Care Research';
+    UPDATE organisation_unit SET name='Scottish Health Technologies Group (SHTG)' WHERE name='Scottish Health Technologies Group';
+    `);
+  }
+
+  public async down(): Promise<void> {}
+}


### PR DESCRIPTION
Description:
Creates migration to update name and acronyms on missing units on previous migrations

Related tickets:

Closes [AB#175450](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/175450)
US: [AB#173888](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/173888)