### PR TITLE
Story/177060 change all swagger to use swaggerhelpers swagger helper response

### DIFF
--- a/apps/admin/.apim/swagger.yaml
+++ b/apps/admin/.apim/swagger.yaml
@@ -24,7 +24,10 @@ paths:
                     type: string
                     enum:
                       - OK
-                      - WARN
+                      - NOK
+                required:
+                  - status
+                additionalProperties: false
         "401":
           description: Unauthorized
         "403":
@@ -79,10 +82,17 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
                     description: The organisation id.
                   units:
-                    type: string
+                    type: array
+                    items:
+                      type: string
                     description: Ids of the organisation units belonging to the organisation.
+                required:
+                  - id
+                  - units
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -96,10 +106,10 @@ paths:
       parameters:
         - name: organisationId
           in: path
-          description: The organisation id.
           required: true
           schema:
             type: string
+            format: uuid
       requestBody:
         description: New name and acronym for the organisation.
         required: true
@@ -108,9 +118,16 @@ paths:
             schema:
               type: object
               properties:
-                userIds:
+                name:
                   type: string
-                  description: Name and acronym for the organisation.
+                  maxLength: 100
+                acronym:
+                  type: string
+                  maxLength: 10
+              required:
+                - name
+                - acronym
+              additionalProperties: false
       responses:
         "200":
           description: The organisation unit has been updated.
@@ -121,7 +138,11 @@ paths:
                 properties:
                   organisationId:
                     type: string
+                    format: uuid
                     description: The organisation id.
+                required:
+                  - organisationId
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -242,9 +263,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  unitId:
+                  id:
                     type: string
-                    description: Id of the updated terms of use.
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -290,9 +314,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  unitId:
+                  id:
                     type: string
-                    description: Id of the created terms of use.
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -337,7 +364,7 @@ paths:
                 type: object
                 properties:
                   count:
-                    type: number
+                    type: integer
                     description: The total number of terms of use.
                   data:
                     type: array
@@ -356,13 +383,24 @@ paths:
                             - SUPPORT_ORGANISATION
                         summary:
                           type: string
-                        releaseAt:
+                        releasedAt:
                           type: string
                           format: date-time
                           nullable: true
                         createdAt:
                           type: string
                           format: date-time
+                      required:
+                        - id
+                        - name
+                        - touType
+                        - summary
+                        - releasedAt
+                        - createdAt
+                      additionalProperties: false
+                required:
+                  - count
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -376,16 +414,16 @@ paths:
       parameters:
         - name: organisationId
           in: path
-          description: The organisation id.
           required: true
           schema:
             type: string
+            format: uuid
         - name: organisationUnitId
           in: path
-          description: The organisation unit id.
           required: true
           schema:
             type: string
+            format: uuid
       requestBody:
         description: The id of the users to unlock.
         required: true
@@ -395,8 +433,12 @@ paths:
               type: object
               properties:
                 userIds:
-                  type: string
-                  description: Ids of the users to unlock.
+                  type: array
+                  items:
+                    type: string
+              required:
+                - userIds
+              additionalProperties: false
       responses:
         "200":
           description: The organisation unit has been activated.
@@ -407,7 +449,10 @@ paths:
                 properties:
                   unitId:
                     type: string
-                    description: The organisation unit id.
+                    format: uuid
+                required:
+                  - unitId
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -456,9 +501,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  unitId:
+                  id:
                     type: string
-                    description: The organisation id.
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -472,16 +520,16 @@ paths:
       parameters:
         - name: organisationId
           in: path
-          description: The organisation id.
           required: true
           schema:
             type: string
+            format: uuid
         - name: organisationUnitId
           in: path
-          description: The organisation unit id.
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: The organisation unit has been inactivated.
@@ -492,7 +540,10 @@ paths:
                 properties:
                   unitId:
                     type: string
-                    description: The organisation unit id.
+                    format: uuid
+                required:
+                  - unitId
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -508,16 +559,16 @@ paths:
       parameters:
         - name: organisationId
           in: path
-          description: The organisation id.
           required: true
           schema:
             type: string
+            format: uuid
         - name: organisationUnitId
           in: path
-          description: The organisation unit id.
           required: true
           schema:
             type: string
+            format: uuid
       requestBody:
         description: New name and acronym for the unit.
         required: true
@@ -526,9 +577,16 @@ paths:
             schema:
               type: object
               properties:
-                userIds:
+                name:
                   type: string
-                  description: Name and acronym for the unit.
+                  maxLength: 100
+                acronym:
+                  type: string
+                  maxLength: 10
+              required:
+                - name
+                - acronym
+              additionalProperties: false
       responses:
         "200":
           description: The organisation unit has been updated.
@@ -539,7 +597,10 @@ paths:
                 properties:
                   unitId:
                     type: string
-                    description: The organisation unit id.
+                    format: uuid
+                required:
+                  - unitId
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -564,6 +625,57 @@ paths:
       responses:
         "200":
           description: List of innovations assigned to the user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        innovation:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                            name:
+                              type: string
+                          required:
+                            - id
+                            - name
+                          additionalProperties: false
+                        supportedBy:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                                format: uuid
+                              name:
+                                type: string
+                              role:
+                                type: string
+                                enum:
+                                  - ADMIN
+                                  - INNOVATOR
+                                  - ACCESSOR
+                                  - ASSESSMENT
+                                  - QUALIFYING_ACCESSOR
+                            required:
+                              - id
+                              - name
+                            additionalProperties: false
+                      additionalProperties: false
+                required:
+                  - count
+                  - data
+                additionalProperties: false
         "400":
           description: Bad Request
         "401":
@@ -637,7 +749,10 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: The user id.
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -715,9 +830,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  userId:
+                  id:
                     type: string
-                    description: Id of the user.
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -735,13 +853,15 @@ paths:
       parameters:
         - name: userIdOrEmail
           in: path
-          required: true
+          required: false
           schema:
             anyOf:
               - type: string
                 format: uuid
+                x-required: true
               - type: string
                 format: email
+                x-required: true
       responses:
         "200":
           description: Success
@@ -768,6 +888,7 @@ paths:
                       properties:
                         id:
                           type: string
+                          format: uuid
                         role:
                           type: string
                           enum:
@@ -776,10 +897,51 @@ paths:
                             - ACCESSOR
                             - ASSESSMENT
                             - QUALIFYING_ACCESSOR
-                        displayTeam:
-                          type: string
                         isActive:
                           type: boolean
+                        organisation:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                            name:
+                              type: string
+                            acronym:
+                              type: string
+                              nullable: true
+                          required:
+                            - id
+                            - name
+                            - acronym
+                          additionalProperties: false
+                        organisationUnit:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                            name:
+                              type: string
+                            acronym:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - acronym
+                          additionalProperties: false
+                        displayTeam:
+                          type: string
+                      required:
+                        - id
+                        - isActive
+                      additionalProperties: false
+                required:
+                  - id
+                  - email
+                  - name
+                  - isActive
+                additionalProperties: false
         "400":
           description: The request is invalid.
         "401":
@@ -813,10 +975,16 @@ paths:
                   properties:
                     id:
                       type: string
+                      format: uuid
                     name:
                       type: string
                     isOwner:
                       type: boolean
+                  required:
+                    - id
+                    - name
+                    - isOwner
+                  additionalProperties: false
         "400":
           description: Bad request
   /v1/users/{userId}/roles/{roleId}:
@@ -858,7 +1026,10 @@ paths:
                   properties:
                     id:
                       type: string
-                      description: The role id.
+                      format: uuid
+                  required:
+                    - id
+                  additionalProperties: false
         "400":
           description: The request is invalid.
         "401":
@@ -926,7 +1097,11 @@ paths:
                   properties:
                     id:
                       type: string
+                      format: uuid
                       description: The role id.
+                  required:
+                    - id
+                  additionalProperties: false
         "400":
           description: The request is invalid.
         "401":
@@ -956,8 +1131,34 @@ paths:
                 type: object
                 properties:
                   validations:
-                    type: object
-                    description: Validation data.
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        rule:
+                          type: string
+                          enum:
+                            - AssessmentUserIsNotTheOnlyOne
+                            - LastQualifyingAccessorUserOnOrganisationUnit
+                            - NoInnovationsSupportedOnlyByThisUser
+                            - UserHasAnyAdminRole
+                            - UserHasAnyInnovatorRole
+                            - UserHasAnyAssessmentRole
+                            - UserHasAnyAccessorRole
+                            - UserHasAnyQualifyingAccessorRole
+                            - UserHasAnyAccessorRoleInOtherOrganisation
+                            - UserAlreadyHasRoleInUnit
+                            - OrganisationUnitIsActive
+                            - UserIsAccessorInAllUnitsOfOrg
+                            - UserCanHaveAssessmentOrAccessorRole
+                        valid:
+                          type: boolean
+                        details: {}
+                      required:
+                        - rule
+                        - valid
+                      additionalProperties: false
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -1054,6 +1255,10 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad Request
         "401":
@@ -1075,31 +1280,48 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                      format: uuid
-                    userRoles:
-                      type: array
-                      items:
-                        type: string
-                        enum:
-                          - ADMIN
-                          - INNOVATOR
-                          - ACCESSOR
-                          - ASSESSMENT
-                          - QUALIFYING_ACCESSOR
-                    params:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  data:
+                    type: array
+                    items:
                       type: object
-                    createdAt:
-                      type: string
-                      format: date-time
-                    expiresAt:
-                      type: string
-                      format: date-time
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        title:
+                          type: string
+                        startsAt:
+                          type: string
+                          format: date-time
+                        expiresAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        status:
+                          type: string
+                          enum:
+                            - SCHEDULED
+                            - ACTIVE
+                            - DONE
+                            - DELETED
+                        type:
+                          type: string
+                          enum:
+                            - LOG_IN
+                            - HOMEPAGE
+                      required:
+                        - id
+                        - title
+                        - startsAt
+                        - expiresAt
+                      additionalProperties: false
+                required:
+                  - count
+                additionalProperties: false
   /v1/announcements/{announcementId}:
     delete:
       description: Delete an announcement.
@@ -1141,6 +1363,8 @@ paths:
                   id:
                     type: string
                     format: uuid
+                  title:
+                    type: string
                   userRoles:
                     type: array
                     items:
@@ -1153,27 +1377,39 @@ paths:
                         - QUALIFYING_ACCESSOR
                   params:
                     type: object
-                  createdAt:
+                    properties: {}
+                    additionalProperties: false
+                    nullable: true
+                  startsAt:
                     type: string
                     format: date-time
                   expiresAt:
                     type: string
                     format: date-time
+                    nullable: true
                   status:
                     type: string
+                    enum:
+                      - SCHEDULED
+                      - ACTIVE
+                      - DONE
+                      - DELETED
                   filters:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        section:
+                    type: object
+                    properties:
+                      section:
+                        type: string
+                      question:
+                        type: string
+                      answers:
+                        type: array
+                        items:
                           type: string
-                        question:
-                          type: string
-                        answers:
-                          type: array
-                          items:
-                            type: string
+                    required:
+                      - section
+                      - question
+                    additionalProperties: false
+                    nullable: true
                   sendEmail:
                     type: boolean
                   type:
@@ -1181,6 +1417,16 @@ paths:
                     enum:
                       - LOG_IN
                       - HOMEPAGE
+                required:
+                  - id
+                  - title
+                  - userRoles
+                  - params
+                  - startsAt
+                  - expiresAt
+                  - filters
+                  - sendEmail
+                additionalProperties: false
         "400":
           description: Bad request
         "401":
@@ -1315,6 +1561,9 @@ paths:
                       - phone
                   phoneNumber:
                     type: string
+                required:
+                  - type
+                additionalProperties: false
         "400":
           description: Bad Request
         "401":

--- a/apps/admin/v1-admin-health/index.ts
+++ b/apps/admin/v1-admin-health/index.ts
@@ -2,14 +2,14 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@admin/shared/decorators';
-import { ResponseHelper } from '@admin/shared/helpers';
+import { ResponseHelper, SwaggerHelper } from '@admin/shared/helpers';
 import type { AuthorizationService } from '@admin/shared/services';
 import type { CustomContextType } from '@admin/shared/types';
 
 import { container } from '../_config';
 
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
-import type { ResponseDTO } from './transformation';
+import { ResponseBodySchema, type ResponseDTO } from './transformation';
 
 class V1Health {
   @JwtDecoder()
@@ -33,19 +33,9 @@ export default openApi(V1Health.httpTrigger as AzureFunction, '/v1/health', {
     tags: ['[v1] health'],
     parameters: [],
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                status: { type: 'string', enum: ['OK', 'WARN'] }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       401: {
         description: 'Unauthorized'
       },

--- a/apps/admin/v1-admin-health/transformation.ts
+++ b/apps/admin/v1-admin-health/transformation.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   status: 'OK' | 'NOK';
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ status: Joi.string().valid('OK', 'NOK').required() });

--- a/apps/admin/v1-admin-organisation-create/index.ts
+++ b/apps/admin/v1-admin-organisation-create/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import type { OrganisationsService } from '../_services/organisations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType } from './validation.schemas';
 
 class V1AdminOrganisationCreate {
@@ -44,26 +44,9 @@ export default openApi(V1AdminOrganisationCreate.httpTrigger as AzureFunction, '
       description: 'The organisation to be created.'
     }),
     responses: {
-      '200': {
-        description: 'The organisation has been created.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string',
-                  description: 'The organisation id.'
-                },
-                units: {
-                  type: 'string',
-                  description: 'Ids of the organisation units belonging to the organisation.'
-                }
-              }
-            }
-          }
-        }
-      },
+      '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The organisation has been created.'
+      }),
       '400': {
         description: 'Bad request.'
       },

--- a/apps/admin/v1-admin-organisation-create/transformation.dtos.ts
+++ b/apps/admin/v1-admin-organisation-create/transformation.dtos.ts
@@ -1,4 +1,14 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
   units: string[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().description('The organisation id.').required(),
+  units: Joi.array()
+    .items(Joi.string())
+    .description('Ids of the organisation units belonging to the organisation.')
+    .required()
+});

--- a/apps/admin/v1-admin-organisation-update/index.ts
+++ b/apps/admin/v1-admin-organisation-update/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import type { OrganisationsService } from '../_services/organisations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1AdminOrganisationUpdate {
@@ -45,22 +45,9 @@ export default openApi(V1AdminOrganisationUpdate.httpTrigger as AzureFunction, '
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'New name and acronym for the organisation.' }),
     responses: {
-      '200': {
-        description: 'The organisation unit has been updated.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                organisationId: {
-                  type: 'string',
-                  description: 'The organisation id.'
-                }
-              }
-            }
-          }
-        }
-      },
+      '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The organisation unit has been updated.'
+      }),
       '400': {
         description: 'Bad request.'
       },

--- a/apps/admin/v1-admin-organisation-update/index.ts
+++ b/apps/admin/v1-admin-organisation-update/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@admin/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@admin/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@admin/shared/helpers';
 import type { AuthorizationService } from '@admin/shared/services';
 import type { CustomContextType } from '@admin/shared/types';
 
@@ -42,34 +42,8 @@ export default openApi(V1AdminOrganisationUpdate.httpTrigger as AzureFunction, '
   patch: {
     description: 'Update an organisation.',
     operationId: 'v1-admin-organisation-update',
-    parameters: [
-      {
-        name: 'organisationId',
-        in: 'path',
-        description: 'The organisation id.',
-        required: true,
-        schema: {
-          type: 'string'
-        }
-      }
-    ],
-    requestBody: {
-      description: 'New name and acronym for the organisation.',
-      required: true,
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              userIds: {
-                type: 'string',
-                description: 'Name and acronym for the organisation.'
-              }
-            }
-          }
-        }
-      }
-    },
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+    requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'New name and acronym for the organisation.' }),
     responses: {
       '200': {
         description: 'The organisation unit has been updated.',

--- a/apps/admin/v1-admin-organisation-update/transformation.dtos.ts
+++ b/apps/admin/v1-admin-organisation-update/transformation.dtos.ts
@@ -1,3 +1,9 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   organisationId: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  organisationId: Joi.string().uuid().description('The organisation id.').required()
+});

--- a/apps/admin/v1-admin-terms-of-use-create/index.ts
+++ b/apps/admin/v1-admin-terms-of-use-create/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import SYMBOLS from '../_services/symbols';
 import type { TermsOfUseService } from '../_services/terms-of-use.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType } from './validation.schemas';
 
 class V1AdminTermsOfUseCreate {
@@ -43,19 +43,9 @@ export default openApi(V1AdminTermsOfUseCreate.httpTrigger as AzureFunction, '/v
     operationId: 'v1-admin-terms-of-use-create',
     requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'The terms of use to create.' }),
     responses: {
-      '200': {
-        description: 'The terms of use have been created.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                unitId: { type: 'string', description: 'Id of the created terms of use.' }
-              }
-            }
-          }
-        }
-      },
+      '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The terms of use have been created.'
+      }),
       '400': {
         description: 'Bad request.'
       },

--- a/apps/admin/v1-admin-terms-of-use-create/transformation.dtos.ts
+++ b/apps/admin/v1-admin-terms-of-use-create/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/admin/v1-admin-terms-of-use-list/index.ts
+++ b/apps/admin/v1-admin-terms-of-use-list/index.ts
@@ -10,11 +10,10 @@ import type { CustomContextType } from '@admin/shared/types';
 
 import { container } from '../_config';
 
-import { TermsOfUseTypeEnum } from '@admin/shared/enums';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import SYMBOLS from '../_services/symbols';
 import type { TermsOfUseService } from '../_services/terms-of-use.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1AdminTermsOfUseList {
@@ -45,36 +44,9 @@ export default openApi(V1AdminTermsOfUseList.httpTrigger as AzureFunction, '/v1/
     operationId: 'v1-admin-terms-of-use-list',
     parameters: SwaggerHelper.paramJ2S({ query: QueryParamsSchema }),
     responses: {
-      '200': {
-        description: 'The list of terms of use versions.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                count: {
-                  type: 'number',
-                  description: 'The total number of terms of use.'
-                },
-                data: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      id: { type: 'string', format: 'uuid' },
-                      name: { type: 'string' },
-                      touType: { type: 'string', enum: Object.values(TermsOfUseTypeEnum) },
-                      summary: { type: 'string' },
-                      releaseAt: { type: 'string', format: 'date-time', nullable: true },
-                      createdAt: { type: 'string', format: 'date-time' }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The list of terms of use versions.'
+      }),
       '400': {
         description: 'Bad request.'
       },

--- a/apps/admin/v1-admin-terms-of-use-list/transformation.dtos.ts
+++ b/apps/admin/v1-admin-terms-of-use-list/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { TermsOfUseTypeEnum } from '@admin/shared/enums';
+import { TermsOfUseTypeEnum } from '@admin/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   count: number;
@@ -11,3 +12,19 @@ export type ResponseDTO = {
     createdAt: Date;
   }[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  count: Joi.number().integer().description('The total number of terms of use.').required(),
+  data: Joi.array().items(
+    Joi.object({
+      id: Joi.string().uuid().required(),
+      name: Joi.string().required(),
+      touType: Joi.string()
+        .valid(...Object.values(TermsOfUseTypeEnum))
+        .required(),
+      summary: Joi.string().required(),
+      releasedAt: Joi.date().allow(null).required(),
+      createdAt: Joi.date().required()
+    })
+  )
+});

--- a/apps/admin/v1-admin-terms-of-use-update/index.ts
+++ b/apps/admin/v1-admin-terms-of-use-update/index.ts
@@ -13,7 +13,7 @@ import { container } from '../_config';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import SYMBOLS from '../_services/symbols';
 import type { TermsOfUseService } from '../_services/terms-of-use.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1AdminTermsOfUseUpdate {
@@ -51,22 +51,9 @@ export default openApi(V1AdminTermsOfUseUpdate.httpTrigger as AzureFunction, '/v
       description: 'The terms of use to be updated.'
     }),
     responses: {
-      '200': {
-        description: 'The terms of use have been updated.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                unitId: {
-                  type: 'string',
-                  description: 'Id of the updated terms of use.'
-                }
-              }
-            }
-          }
-        }
-      },
+      '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The terms of use have been updated.'
+      }),
       '400': {
         description: 'Bad request.'
       },

--- a/apps/admin/v1-admin-terms-of-use-update/transformation.dtos.ts
+++ b/apps/admin/v1-admin-terms-of-use-update/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/admin/v1-admin-terms-of-use/transformation.dtos.ts
+++ b/apps/admin/v1-admin-terms-of-use/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { TermsOfUseTypeEnum } from '@admin/shared/enums';
+import { TermsOfUseTypeEnum } from '@admin/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
@@ -8,3 +9,12 @@ export type ResponseDTO = {
   releasedAt: Date | null;
   createdAt: Date;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().guid().required(),
+  name: Joi.string().required(),
+  touType: Joi.string().valid(Object.values(TermsOfUseTypeEnum)).required(),
+  summary: Joi.string().required(),
+  releasedAt: Joi.date().allow(null).required(),
+  createdAt: Joi.date().required()
+});

--- a/apps/admin/v1-admin-unit-activate/index.ts
+++ b/apps/admin/v1-admin-unit-activate/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import type { OrganisationsService } from '../_services/organisations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1AdminUnitActivate {
@@ -53,22 +53,9 @@ export default openApi(
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'The id of the users to unlock.' }),
       responses: {
-        '200': {
-          description: 'The organisation unit has been activated.',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  unitId: {
-                    type: 'string',
-                    description: 'The organisation unit id.'
-                  }
-                }
-              }
-            }
-          }
-        },
+        '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'The organisation unit has been activated.'
+        }),
         '400': {
           description: 'Bad request.'
         },

--- a/apps/admin/v1-admin-unit-activate/index.ts
+++ b/apps/admin/v1-admin-unit-activate/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@admin/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@admin/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@admin/shared/helpers';
 import type { AuthorizationService } from '@admin/shared/services';
 import type { CustomContextType } from '@admin/shared/types';
 
@@ -50,43 +50,8 @@ export default openApi(
     patch: {
       description: 'Activate an organisation unit.',
       operationId: 'v1-admin-unit-activate',
-      parameters: [
-        {
-          name: 'organisationId',
-          in: 'path',
-          description: 'The organisation id.',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        },
-        {
-          name: 'organisationUnitId',
-          in: 'path',
-          description: 'The organisation unit id.',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        }
-      ],
-      requestBody: {
-        description: 'The id of the users to unlock.',
-        required: true,
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                userIds: {
-                  type: 'string',
-                  description: 'Ids of the users to unlock.'
-                }
-              }
-            }
-          }
-        }
-      },
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+      requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'The id of the users to unlock.' }),
       responses: {
         '200': {
           description: 'The organisation unit has been activated.',

--- a/apps/admin/v1-admin-unit-activate/transformation.dtos.ts
+++ b/apps/admin/v1-admin-unit-activate/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   unitId: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ unitId: Joi.string().uuid().required() });

--- a/apps/admin/v1-admin-unit-create/index.ts
+++ b/apps/admin/v1-admin-unit-create/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import type { OrganisationsService } from '../_services/organisations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1AdminUnitCreate {
@@ -46,29 +46,16 @@ export default openApi(V1AdminUnitCreate.httpTrigger as AzureFunction, '/v1/orga
       description: 'The organisation unit to be created.'
     }),
     responses: {
-      '200': {
-        description: 'The organisation unit has been created.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                unitId: {
-                  type: 'string',
-                  description: 'The organisation id.'
-                }
-              }
-            }
-          }
-        }
-      },
-      '400': {
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The organisation unit has been created.'
+      }),
+      400: {
         description: 'Bad request.'
       },
-      '401': {
+      401: {
         description: 'The user is not authorized to create an organisation unit.'
       },
-      '500': {
+      500: {
         description: 'An error occurred while creating the organisation unit.'
       }
     }

--- a/apps/admin/v1-admin-unit-create/transformation.dtos.ts
+++ b/apps/admin/v1-admin-unit-create/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/admin/v1-admin-unit-inactivate/index.ts
+++ b/apps/admin/v1-admin-unit-inactivate/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import type { OrganisationsService } from '../_services/organisations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1AdminUnitInactivate {
@@ -47,22 +47,9 @@ export default openApi(
       operationId: 'v1-admin-unit-inactivate',
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        '200': {
-          description: 'The organisation unit has been inactivated.',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  unitId: {
-                    type: 'string',
-                    description: 'The organisation unit id.'
-                  }
-                }
-              }
-            }
-          }
-        },
+        '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'The organisation unit has been inactivated.'
+        }),
         '400': {
           description: 'Bad request.'
         },

--- a/apps/admin/v1-admin-unit-inactivate/index.ts
+++ b/apps/admin/v1-admin-unit-inactivate/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@admin/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@admin/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@admin/shared/helpers';
 import type { AuthorizationService } from '@admin/shared/services';
 import type { CustomContextType } from '@admin/shared/types';
 
@@ -45,26 +45,7 @@ export default openApi(
     patch: {
       description: 'Inactivate an organisation unit.',
       operationId: 'v1-admin-unit-inactivate',
-      parameters: [
-        {
-          name: 'organisationId',
-          in: 'path',
-          description: 'The organisation id.',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        },
-        {
-          name: 'organisationUnitId',
-          in: 'path',
-          description: 'The organisation unit id.',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        }
-      ],
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
         '200': {
           description: 'The organisation unit has been inactivated.',

--- a/apps/admin/v1-admin-unit-inactivate/transformation.dtos.ts
+++ b/apps/admin/v1-admin-unit-inactivate/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   unitId: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ unitId: Joi.string().uuid().required() });

--- a/apps/admin/v1-admin-unit-update/index.ts
+++ b/apps/admin/v1-admin-unit-update/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import type { OrganisationsService } from '../_services/organisations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1AdminUnitUpdate {
@@ -48,22 +48,9 @@ export default openApi(
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'New name and acronym for the unit.' }),
       responses: {
-        '200': {
-          description: 'The organisation unit has been updated.',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  unitId: {
-                    type: 'string',
-                    description: 'The organisation unit id.'
-                  }
-                }
-              }
-            }
-          }
-        },
+        '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'The organisation unit has been updated.'
+        }),
         '400': {
           description: 'Bad request.'
         },

--- a/apps/admin/v1-admin-unit-update/index.ts
+++ b/apps/admin/v1-admin-unit-update/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@admin/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@admin/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@admin/shared/helpers';
 import type { AuthorizationService } from '@admin/shared/services';
 import type { CustomContextType } from '@admin/shared/types';
 
@@ -45,43 +45,8 @@ export default openApi(
     patch: {
       description: 'Update an organisation unit.',
       operationId: 'v1-admin-unit-update',
-      parameters: [
-        {
-          name: 'organisationId',
-          in: 'path',
-          description: 'The organisation id.',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        },
-        {
-          name: 'organisationUnitId',
-          in: 'path',
-          description: 'The organisation unit id.',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        }
-      ],
-      requestBody: {
-        description: 'New name and acronym for the unit.',
-        required: true,
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                userIds: {
-                  type: 'string',
-                  description: 'Name and acronym for the unit.'
-                }
-              }
-            }
-          }
-        }
-      },
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+      requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'New name and acronym for the unit.' }),
       responses: {
         '200': {
           description: 'The organisation unit has been updated.',

--- a/apps/admin/v1-admin-unit-update/transformation.dtos.ts
+++ b/apps/admin/v1-admin-unit-update/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   unitId: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ unitId: Joi.string().uuid().required() });

--- a/apps/admin/v1-admin-user-assigned-innovations/index.ts
+++ b/apps/admin/v1-admin-user-assigned-innovations/index.ts
@@ -7,7 +7,7 @@ import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import type { CustomContextType } from '@admin/shared/types';
 
 import { container } from '../_config';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { JoiHelper, SwaggerHelper } from '@admin/shared/helpers';
 import { ParamsSchema, type ParamsType } from './validation.schemas';
 import type { UsersService } from '../_services/users.service';
@@ -45,7 +45,9 @@ export default openApi(
       tags: ['[v1] Innovations'],
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: { description: 'List of innovations assigned to the user' },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'List of innovations assigned to the user'
+        }),
         400: { description: 'Bad Request' },
         401: { description: 'Unauthorized' },
         403: { description: 'Forbidden' },

--- a/apps/admin/v1-admin-user-assigned-innovations/transformation.dtos.ts
+++ b/apps/admin/v1-admin-user-assigned-innovations/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { ServiceRoleEnum } from '@admin/shared/enums';
+import { ServiceRoleEnum } from '@admin/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   count: number;
@@ -8,3 +9,24 @@ export type ResponseDTO = {
     unit: string;
   }[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  count: Joi.number().integer().required(),
+  data: Joi.array()
+    .items(
+      Joi.object({
+        innovation: Joi.object({
+          id: Joi.string().uuid().required(),
+          name: Joi.string().required()
+        }),
+        supportedBy: Joi.array().items(
+          Joi.object({
+            id: Joi.string().uuid().required(),
+            name: Joi.string().required(),
+            role: Joi.string().valid(...Object.values(ServiceRoleEnum))
+          })
+        )
+      })
+    )
+    .required()
+});

--- a/apps/admin/v1-admin-user-create/index.ts
+++ b/apps/admin/v1-admin-user-create/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import SYMBOLS from '../_services/symbols';
 import type { UsersService } from '../_services/users.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType } from './validation.schemas';
 
 class V1AdminUserCreate {
@@ -45,19 +45,9 @@ export default openApi(V1AdminUserCreate.httpTrigger as AzureFunction, '/v1/user
     parameters: [],
     requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'The user to be created.' }),
     responses: {
-      '201': {
-        description: 'The user has been created.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string', description: 'The user id.' }
-              }
-            }
-          }
-        }
-      },
+      '201': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The user has been created.'
+      }),
       '400': { description: 'Bad request.' },
       '401': { description: 'The user is not authorized to create a user.' },
       '500': { description: 'An error occurred while creating the user.' }

--- a/apps/admin/v1-admin-user-create/transformation.dtos.ts
+++ b/apps/admin/v1-admin-user-create/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/admin/v1-admin-user-info/index.ts
+++ b/apps/admin/v1-admin-user-info/index.ts
@@ -4,7 +4,6 @@ import type { AzureFunction, HttpRequest } from '@azure/functions';
 import { container } from '../_config';
 
 import { JwtDecoder } from '@admin/shared/decorators';
-import { ServiceRoleEnum } from '@admin/shared/enums';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@admin/shared/helpers';
 import type { AuthorizationService } from '@admin/shared/services';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
@@ -12,7 +11,7 @@ import type { CustomContextType } from '@admin/shared/types';
 
 import SYMBOLS from '../_services/symbols';
 import type { UsersService } from '../_services/users.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1AdminUserInfo {
@@ -44,35 +43,9 @@ export default openApi(V1AdminUserInfo.httpTrigger as AzureFunction, '/v1/users/
     tags: ['[v1] Admin Users'],
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string', format: 'uuid' },
-                email: { type: 'string' },
-                name: { type: 'string' },
-                phone: { type: 'string' },
-                isActive: { type: 'boolean' },
-                roles: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      id: { type: 'string' },
-                      role: { type: 'string', enum: Object.values(ServiceRoleEnum) },
-                      displayTeam: { type: 'string' },
-                      isActive: { type: 'boolean' }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: { description: 'The request is invalid.' },
       401: { description: 'The user is not authenticated.' },
       403: { description: 'The user is not authorized to access this resource.' },

--- a/apps/admin/v1-admin-user-info/index.ts
+++ b/apps/admin/v1-admin-user-info/index.ts
@@ -5,7 +5,7 @@ import { container } from '../_config';
 
 import { JwtDecoder } from '@admin/shared/decorators';
 import { ServiceRoleEnum } from '@admin/shared/enums';
-import { JoiHelper, ResponseHelper } from '@admin/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@admin/shared/helpers';
 import type { AuthorizationService } from '@admin/shared/services';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import type { CustomContextType } from '@admin/shared/types';
@@ -42,25 +42,7 @@ export default openApi(V1AdminUserInfo.httpTrigger as AzureFunction, '/v1/users/
     operationId: 'v1-admin-user-info',
     description: 'Get user info.',
     tags: ['[v1] Admin Users'],
-    parameters: [
-      {
-        name: 'userIdOrEmail',
-        in: 'path',
-        required: true,
-        schema: {
-          anyOf: [
-            {
-              type: 'string',
-              format: 'uuid'
-            },
-            {
-              type: 'string',
-              format: 'email'
-            }
-          ]
-        }
-      }
-    ],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
       200: {
         description: 'Success',

--- a/apps/admin/v1-admin-user-info/transformation.dtos.ts
+++ b/apps/admin/v1-admin-user-info/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { ServiceRoleEnum } from '@admin/shared/enums';
+import { ServiceRoleEnum } from '@admin/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
@@ -15,3 +16,29 @@ export type ResponseDTO = {
     displayTeam?: string;
   }[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().required(),
+  email: Joi.string().required(),
+  name: Joi.string().required(),
+  phone: Joi.string().optional(),
+  isActive: Joi.boolean().required(),
+  roles: Joi.array().items(
+    Joi.object({
+      id: Joi.string().uuid().required(),
+      role: Joi.string().valid(...Object.values(ServiceRoleEnum)),
+      isActive: Joi.boolean().required(),
+      organisation: Joi.object({
+        id: Joi.string().uuid().required(),
+        name: Joi.string().required(),
+        acronym: Joi.string().allow(null).required()
+      }).optional(),
+      organisationUnit: Joi.object({
+        id: Joi.string().uuid().required(),
+        name: Joi.string().required(),
+        acronym: Joi.string().required()
+      }).optional(),
+      displayTeam: Joi.string().optional()
+    })
+  )
+});

--- a/apps/admin/v1-admin-user-innovations/index.ts
+++ b/apps/admin/v1-admin-user-innovations/index.ts
@@ -7,7 +7,7 @@ import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import type { CustomContextType } from '@admin/shared/types';
 
 import { container } from '../_config';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { JoiHelper, SwaggerHelper } from '@admin/shared/helpers';
 import { ParamsSchema, QueryParamsSchema, QueryParamsType, type ParamsType } from './validation.schemas';
 
@@ -46,30 +46,9 @@ export default openApi(V1MeInnovationsInfo.httpTrigger as AzureFunction, '/v1/us
     tags: ['[v1] Innovations owned by user'],
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string'
-                  },
-                  name: {
-                    type: 'string'
-                  },
-                  isOwner: {
-                    type: 'boolean'
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: { description: 'Bad request' }
     }
   }

--- a/apps/admin/v1-admin-user-innovations/transformation.dtos.ts
+++ b/apps/admin/v1-admin-user-innovations/transformation.dtos.ts
@@ -1,5 +1,15 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
   name: string;
   isOwner: boolean;
 }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required(),
+    isOwner: Joi.boolean().required()
+  })
+);

--- a/apps/admin/v1-admin-user-role-update/index.ts
+++ b/apps/admin/v1-admin-user-role-update/index.ts
@@ -12,6 +12,7 @@ import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import SYMBOLS from '../_services/symbols';
 import type { UsersService } from '../_services/users.service';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
+import { ResponseBodySchema } from './transformation.dtos';
 
 class V1AdminUserRolesCreate {
   @JwtDecoder()
@@ -43,22 +44,9 @@ export default openApi(V1AdminUserRolesCreate.httpTrigger as AzureFunction, '/v1
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
-      204: {
-        description: 'Updated the user role',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  id: { type: 'string', description: 'The role id.' }
-                }
-              }
-            }
-          }
-        }
-      },
+      204: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Updated the user role'
+      }),
       400: { description: 'The request is invalid.' },
       401: { description: 'The user is not authenticated.' },
       403: { description: 'The user is not authorized to access this resource.' },

--- a/apps/admin/v1-admin-user-role-update/transformation.dtos.ts
+++ b/apps/admin/v1-admin-user-role-update/transformation.dtos.ts
@@ -1,1 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = { id: string }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(Joi.object({ id: Joi.string().uuid().required() }));

--- a/apps/admin/v1-admin-user-roles-create/index.ts
+++ b/apps/admin/v1-admin-user-roles-create/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import SYMBOLS from '../_services/symbols';
 import type { UsersService } from '../_services/users.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1AdminUserRolesCreate {
@@ -44,22 +44,9 @@ export default openApi(V1AdminUserRolesCreate.httpTrigger as AzureFunction, '/v1
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
-      201: {
-        description: 'The created roles.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  id: { type: 'string', description: 'The role id.' }
-                }
-              }
-            }
-          }
-        }
-      },
+      201: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The created roles.'
+      }),
       400: { description: 'The request is invalid.' },
       401: { description: 'The user is not authenticated.' },
       403: { description: 'The user is not authorized to access this resource.' },

--- a/apps/admin/v1-admin-user-roles-create/transformation.dtos.ts
+++ b/apps/admin/v1-admin-user-roles-create/transformation.dtos.ts
@@ -1,1 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = { id: string }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({ id: Joi.string().uuid().description('The role id.').required() })
+);

--- a/apps/admin/v1-admin-user-update/index.ts
+++ b/apps/admin/v1-admin-user-update/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import SYMBOLS from '../_services/symbols';
 import type { UsersService } from '../_services/users.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1AdminUserUpdate {
@@ -44,22 +44,9 @@ export default openApi(V1AdminUserUpdate.httpTrigger as AzureFunction, '/v1/user
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
-      '200': {
-        description: 'The user has been updated.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                userId: {
-                  type: 'string',
-                  description: 'Id of the user.'
-                }
-              }
-            }
-          }
-        }
-      },
+      '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The user has been updated.'
+      }),
       '400': { description: 'Bad request.' },
       '401': { description: 'The user is not authorized to lock a user.' },
       '404': { description: 'The user does not exist.' },

--- a/apps/admin/v1-admin-user-update/transformation.dtos.ts
+++ b/apps/admin/v1-admin-user-update/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/admin/v1-admin-validate/index.ts
+++ b/apps/admin/v1-admin-validate/index.ts
@@ -10,7 +10,7 @@ import { container } from '../_config';
 
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
 import { validationsHelper } from '../_config/admin-operations.config';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType, QueryParamsSchema, QueryParamsType } from './validation.schemas';
 import { ValidationHandlersHelper } from '../_handlers/validations/validations.handlers.helper';
 
@@ -48,22 +48,9 @@ export default openApi(V1AdminValidate.httpTrigger as AzureFunction, '/v1/users/
     operationId: 'v1-admin-validate',
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      '200': {
-        description: 'OK',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                validations: {
-                  type: 'object',
-                  description: 'Validation data.'
-                }
-              }
-            }
-          }
-        }
-      },
+      '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'OK'
+      }),
       '400': { description: 'Bad request.' },
       '401': { description: 'The user is not authorized to access validation data.' },
       '500': { description: 'An error occurred while fetching the validation data.' }

--- a/apps/admin/v1-admin-validate/transformation.dtos.ts
+++ b/apps/admin/v1-admin-validate/transformation.dtos.ts
@@ -1,5 +1,19 @@
+import Joi from 'joi';
 import type { ValidationResult } from '../types/validation.types';
+import { ValidationRuleEnum } from '../_config/admin-operations.config';
 
 export type ResponseDTO = {
   validations: ValidationResult[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  validations: Joi.array().items(
+    Joi.object({
+      rule: Joi.string()
+        .valid(...Object.values(ValidationRuleEnum))
+        .required(),
+      valid: Joi.boolean().required(),
+      details: Joi.any().optional()
+    })
+  )
+});

--- a/apps/admin/v1-announcement-create/index.ts
+++ b/apps/admin/v1-announcement-create/index.ts
@@ -11,7 +11,7 @@ import type { AnnouncementsService } from '../_services/announcements.service';
 import SYMBOLS from '../_services/symbols';
 
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType } from './validation.schemas';
 import type { FilterPayload } from '@admin/shared/models/schema-engine/schema.model';
 
@@ -50,19 +50,9 @@ export default openApi(V1AnnouncementsCreate.httpTrigger as AzureFunction, '/v1/
     operationId: 'v1-announcement-create',
     requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
-      '200': {
-        description: 'Announcement created.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string' }
-              }
-            }
-          }
-        }
-      },
+      '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Announcement created.'
+      }),
       '400': { description: 'Bad Request' },
       '401': { description: 'Unauthorized' },
       '403': { description: 'Forbidden' },

--- a/apps/admin/v1-announcement-create/transformation.dtos.ts
+++ b/apps/admin/v1-announcement-create/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/admin/v1-announcement-info/index.ts
+++ b/apps/admin/v1-announcement-info/index.ts
@@ -2,7 +2,6 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@admin/shared/decorators';
-import { AnnouncementTypeEnum, ServiceRoleEnum } from '@admin/shared/enums';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@admin/shared/helpers';
 import type { AuthorizationService } from '@admin/shared/services';
 import type { CustomContextType } from '@admin/shared/types';
@@ -12,7 +11,7 @@ import type { AnnouncementsService } from '../_services/announcements.service';
 import SYMBOLS from '../_services/symbols';
 
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1AnnouncementsInfo {
@@ -54,37 +53,9 @@ export default openApi(V1AnnouncementsInfo.httpTrigger as AzureFunction, '/v1/an
     operationId: 'v1-announcement-info',
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      '200': {
-        description: 'Announcement info retrieved.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string', format: 'uuid' },
-                userRoles: { type: 'array', items: { type: 'string', enum: Object.keys(ServiceRoleEnum) } },
-                params: { type: 'object' },
-                createdAt: { type: 'string', format: 'date-time' },
-                expiresAt: { type: 'string', format: 'date-time' },
-                status: { type: 'string' },
-                filters: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      section: { type: 'string' },
-                      question: { type: 'string' },
-                      answers: { type: 'array', items: { type: 'string' } }
-                    }
-                  }
-                },
-                sendEmail: { type: 'boolean' },
-                type: { type: 'string', enum: Object.keys(AnnouncementTypeEnum) }
-              }
-            }
-          }
-        }
-      },
+      '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Announcement info retrieved.'
+      }),
       '400': { description: 'Bad request' },
       '401': { description: 'Not authorized' },
       '500': { description: 'An error occurred' }

--- a/apps/admin/v1-announcement-info/transformation.dtos.ts
+++ b/apps/admin/v1-announcement-info/transformation.dtos.ts
@@ -1,5 +1,6 @@
-import type { AnnouncementStatusEnum, AnnouncementTypeEnum, ServiceRoleEnum } from '@admin/shared/enums';
+import { AnnouncementStatusEnum, AnnouncementTypeEnum, ServiceRoleEnum } from '@admin/shared/enums';
 import type { FilterPayload } from '@admin/shared/models/schema-engine/schema.model';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
@@ -13,3 +14,24 @@ export type ResponseDTO = {
   sendEmail: boolean;
   type: AnnouncementTypeEnum;
 };
+
+export const ResponseBodySchema = Joi.object({
+  id: Joi.string().uuid().required(),
+  title: Joi.string().required(),
+  userRoles: Joi.array()
+    .items(Joi.string().valid(...Object.values(ServiceRoleEnum)))
+    .required(),
+  params: Joi.object().allow(null).required(),
+  startsAt: Joi.date().required(),
+  expiresAt: Joi.date().allow(null).required(),
+  status: Joi.string().valid(...Object.values(AnnouncementStatusEnum)),
+  filters: Joi.object({
+    section: Joi.string().required(),
+    question: Joi.string().required(),
+    answers: Joi.array().items(Joi.string())
+  })
+    .allow(null)
+    .required(),
+  sendEmail: Joi.boolean().required(),
+  type: Joi.string().valid(...Object.values(AnnouncementTypeEnum))
+});

--- a/apps/admin/v1-announcements-list/index.ts
+++ b/apps/admin/v1-announcements-list/index.ts
@@ -2,8 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@admin/shared/decorators';
-import { ServiceRoleEnum } from '@admin/shared/enums';
-import { JoiHelper, ResponseHelper } from '@admin/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@admin/shared/helpers';
 import type { AuthorizationService } from '@admin/shared/services';
 import type { CustomContextType } from '@admin/shared/types';
 
@@ -12,7 +11,7 @@ import type { AnnouncementsService } from '../_services/announcements.service';
 import SYMBOLS from '../_services/symbols';
 
 import SHARED_SYMBOLS from '@admin/shared/services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { AdminQueryParamsSchema, AdminQueryParamsType } from './validation.schemas';
 
 class V1AnnouncementsList {
@@ -52,26 +51,9 @@ export default openApi(V1AnnouncementsList.httpTrigger as AzureFunction, '/v1/an
     operationId: 'v1-announcements-list',
     tags: ['[v1] Announcements'],
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  id: { type: 'string', format: 'uuid' },
-                  userRoles: { type: 'array', items: { type: 'string', enum: Object.keys(ServiceRoleEnum) } },
-                  params: { type: 'object' },
-                  createdAt: { type: 'string', format: 'date-time' },
-                  expiresAt: { type: 'string', format: 'date-time' }
-                }
-              }
-            }
-          }
-        }
-      }
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      })
     }
   }
 });

--- a/apps/admin/v1-announcements-list/transformation.dtos.ts
+++ b/apps/admin/v1-announcements-list/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { AnnouncementStatusEnum, AnnouncementTypeEnum } from '@admin/shared/enums';
+import { AnnouncementStatusEnum, AnnouncementTypeEnum } from '@admin/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   count: number;
@@ -11,3 +12,17 @@ export type ResponseDTO = {
     type: AnnouncementTypeEnum;
   }[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  count: Joi.number().integer().required(),
+  data: Joi.array().items(
+    Joi.object({
+      id: Joi.string().uuid().required(),
+      title: Joi.string().required(),
+      startsAt: Joi.date().required(),
+      expiresAt: Joi.date().allow(null).required(),
+      status: Joi.string().valid(...Object.values(AnnouncementStatusEnum)),
+      type: Joi.string().valid(...Object.values(AnnouncementTypeEnum))
+    })
+  )
+});

--- a/apps/admin/v1-mfa-info/index.ts
+++ b/apps/admin/v1-mfa-info/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import SYMBOLS from '../_services/symbols';
 import type { UsersService } from '../_services/users.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation';
 
 class V1MfaInfo {
@@ -43,20 +43,9 @@ export default openApi(V1MfaInfo.httpTrigger as AzureFunction, '/v1/{userId}/mfa
     tags: ['[v1] Users'],
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                type: { type: 'string', enum: ['none', 'email', 'phone'] },
-                phoneNumber: { type: 'string' }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: { description: 'Bad Request' },
       401: { description: 'Unauthorized' },
       403: { description: 'Forbidden' },

--- a/apps/admin/v1-mfa-info/transformation.dtos.ts
+++ b/apps/admin/v1-mfa-info/transformation.dtos.ts
@@ -1,1 +1,8 @@
+import Joi from 'joi';
+
 export type ResponseDTO = { type: 'none' } | { type: 'email' } | { type: 'phone'; phoneNumber?: string };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  type: Joi.string().valid('none', 'email', 'phone').required(),
+  phoneNumber: Joi.string().optional()
+});

--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -88,14 +88,19 @@ paths:
                 type: object
                 properties:
                   count:
-                    type: number
+                    type: integer
                   innovation:
                     type: object
                     properties:
                       id:
                         type: string
+                        format: uuid
                       name:
                         type: string
+                    required:
+                      - id
+                      - name
+                    additionalProperties: false
                   data:
                     type: array
                     items:
@@ -103,53 +108,56 @@ paths:
                       properties:
                         type:
                           type: string
+                          enum:
+                            - INNOVATION_MANAGEMENT
+                            - INNOVATION_RECORD
+                            - NEEDS_ASSESSMENT
+                            - SUPPORT
+                            - COMMENTS
+                            - TASKS
+                            - THREADS
                         activity:
                           type: string
+                          enum:
+                            - INNOVATION_CREATION
+                            - OWNERSHIP_TRANSFER
+                            - SHARING_PREFERENCES_UPDATE
+                            - SECTION_DRAFT_UPDATE
+                            - SECTION_SUBMISSION
+                            - INNOVATION_SUBMISSION
+                            - NEEDS_ASSESSMENT_START
+                            - NEEDS_ASSESSMENT_START_EDIT
+                            - NEEDS_ASSESSMENT_COMPLETED
+                            - NEEDS_ASSESSMENT_EDITED
+                            - ORGANISATION_SUGGESTION
+                            - SUPPORT_STATUS_UPDATE
+                            - COMMENT_CREATION
+                            - TASK_CREATION
+                            - TASK_STATUS_DONE_UPDATE
+                            - TASK_STATUS_DECLINED_UPDATE
+                            - TASK_STATUS_OPEN_UPDATE
+                            - TASK_STATUS_CANCELLED_UPDATE
+                            - THREAD_CREATION
+                            - THREAD_MESSAGE_CREATION
+                            - NEEDS_ASSESSMENT_REASSESSMENT_REQUESTED
+                            - INNOVATION_PAUSE
                         date:
-                          type: number
+                          type: string
+                          format: date-time
                         params:
                           type: object
-                          properties:
-                            actionUserId:
-                              type: string
-                            interveningUserId:
-                              type: string
-                            assessmentId:
-                              type: string
-                            sectionId:
-                              type: string
-                            actionId:
-                              type: string
-                            innovationSupportStatus:
-                              type: string
-                            organisations:
-                              type: array
-                              items:
-                                type: string
-                            organisationUnit:
-                              type: string
-                            comment:
-                              type: object
-                              properties:
-                                id:
-                                  type: string
-                                value:
-                                  type: string
-                            totalActions:
-                              type: number
-                            thread:
-                              type: object
-                              properties:
-                                id:
-                                  type: string
-                                subject:
-                                  type: string
-                                messageId:
-                                  type: string
-                            actionUserName:
-                              type: string
-                            interveningUserName:
-                              type: string
+                          properties: {}
+                          additionalProperties: false
+                      required:
+                        - type
+                        - date
+                        - params
+                      additionalProperties: false
+                required:
+                  - count
+                  - innovation
+                  - data
+                additionalProperties: false
         "500":
           description: An error occurred while processing the request.
   /v1/{innovationId}/all-sections:
@@ -172,7 +180,46 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                type: array
+                items:
+                  type: object
+                  properties:
+                    section:
+                      type: object
+                      properties:
+                        section:
+                          type: string
+                        status:
+                          type: string
+                          enum:
+                            - NOT_STARTED
+                            - DRAFT
+                            - SUBMITTED
+                        submittedAt:
+                          type: string
+                          format: date-time
+                        submittedBy:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            displayTag:
+                              type: string
+                          required:
+                            - name
+                            - displayTag
+                          additionalProperties: false
+                        openTasksCount:
+                          type: integer
+                      required:
+                        - section
+                        - openTasksCount
+                      additionalProperties: false
+                    data:
+                      type: object
+                      properties: {}
+                      additionalProperties: false
+                  additionalProperties: false
         "401":
           description: Unauthorized
         "403":
@@ -260,6 +307,10 @@ paths:
                   assessorId:
                     type: string
                     format: uuid
+                required:
+                  - assessmentId
+                  - assessorId
+                additionalProperties: false
         "400":
           description: Bad request. Validation error.
         "401":
@@ -300,13 +351,73 @@ paths:
                   id:
                     type: string
                     format: uuid
+                  majorVersion:
+                    type: integer
+                  minorVersion:
+                    type: integer
+                  editReason:
+                    type: string
+                    nullable: true
+                  previousAssessment:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      majorVersion:
+                        type: integer
+                      minorVersion:
+                        type: integer
+                    required:
+                      - id
+                      - majorVersion
+                      - minorVersion
+                    additionalProperties: false
+                  reassessment:
+                    type: object
+                    properties:
+                      reassessmentReason:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                            - NO_SUPPORT
+                            - PREVIOUSLY_ARCHIVED
+                            - HAS_PROGRESSED_SIGNIFICANTLY
+                            - OTHER
+                        nullable: true
+                      otherReassessmentReason:
+                        type: string
+                      description:
+                        type: string
+                      whatSupportDoYouNeed:
+                        type: string
+                        nullable: true
+                      sectionsUpdatedSinceLastAssessment:
+                        type: array
+                        items:
+                          type: string
+                    required:
+                      - reassessmentReason
+                      - otherReassessmentReason
+                      - description
+                      - whatSupportDoYouNeed
+                      - sectionsUpdatedSinceLastAssessment
+                    additionalProperties: false
                   summary:
                     type: string
+                    nullable: true
                   description:
                     type: string
+                    nullable: true
+                  startedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
                   finishedAt:
                     type: string
                     format: date-time
+                    nullable: true
                   assignTo:
                     type: object
                     properties:
@@ -315,75 +426,96 @@ paths:
                         format: uuid
                       name:
                         type: string
+                    required:
+                      - id
+                      - name
+                    additionalProperties: false
                   maturityLevel:
                     type: string
+                    nullable: true
                   maturityLevelComment:
                     type: string
+                    nullable: true
                   hasRegulatoryApprovals:
-                    type: boolean
+                    type: string
+                    nullable: true
                   hasRegulatoryApprovalsComment:
                     type: string
+                    nullable: true
                   hasEvidence:
-                    type: boolean
+                    type: string
+                    nullable: true
                   hasEvidenceComment:
                     type: string
+                    nullable: true
                   hasValidation:
-                    type: boolean
+                    type: string
+                    nullable: true
                   hasValidationComment:
                     type: string
+                    nullable: true
                   hasProposition:
-                    type: boolean
+                    type: string
+                    nullable: true
                   hasPropositionComment:
                     type: string
+                    nullable: true
                   hasCompetitionKnowledge:
-                    type: boolean
+                    type: string
+                    nullable: true
                   hasCompetitionKnowledgeComment:
                     type: string
+                    nullable: true
                   hasImplementationPlan:
-                    type: boolean
+                    type: string
+                    nullable: true
                   hasImplementationPlanComment:
                     type: string
+                    nullable: true
                   hasScaleResource:
-                    type: boolean
+                    type: string
+                    nullable: true
                   hasScaleResourceComment:
                     type: string
+                    nullable: true
                   suggestedOrganisations:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          format: uuid
-                        name:
-                          type: string
-                        acronym:
-                          type: string
-                        units:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              id:
-                                type: string
-                                format: uuid
-                              name:
-                                type: string
-                              acronym:
-                                type: string
-                              organisation:
-                                type: object
-                                properties:
-                                  id:
-                                    type: string
-                                    format: uuid
-                                  name:
-                                    type: string
-                                  acronym:
-                                    type: string
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type: string
+                      acronym:
+                        type: string
+                        nullable: true
+                      units:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                            name:
+                              type: string
+                            acronym:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - acronym
+                          additionalProperties: false
+                    required:
+                      - id
+                      - name
+                      - acronym
+                      - units
+                    additionalProperties: false
                   updatedAt:
                     type: string
                     format: date-time
+                    nullable: true
                   updatedBy:
                     type: object
                     properties:
@@ -392,6 +524,41 @@ paths:
                         format: uuid
                       name:
                         type: string
+                    required:
+                      - id
+                      - name
+                    additionalProperties: false
+                  isLatest:
+                    type: boolean
+                required:
+                  - id
+                  - majorVersion
+                  - minorVersion
+                  - summary
+                  - description
+                  - startedAt
+                  - finishedAt
+                  - maturityLevel
+                  - maturityLevelComment
+                  - hasRegulatoryApprovals
+                  - hasRegulatoryApprovalsComment
+                  - hasEvidence
+                  - hasEvidenceComment
+                  - hasValidation
+                  - hasValidationComment
+                  - hasProposition
+                  - hasPropositionComment
+                  - hasCompetitionKnowledge
+                  - hasCompetitionKnowledgeComment
+                  - hasImplementationPlan
+                  - hasImplementationPlanComment
+                  - hasScaleResource
+                  - hasScaleResourceComment
+                  - suggestedOrganisations
+                  - updatedAt
+                  - updatedBy
+                  - isLatest
+                additionalProperties: false
         "400":
           description: Bad Request
         "401":
@@ -544,26 +711,9 @@ paths:
                   id:
                     type: string
                     format: uuid
-                  innovationId:
-                    type: string
-                    format: uuid
-                  assessmentId:
-                    type: string
-                    format: uuid
-                  status:
-                    type: string
-                    enum:
-                      - APPROVED
-                      - REJECTED
-                  comment:
-                    type: string
-                    maxLength: 1000
-                  createdAt:
-                    type: string
-                    format: date-time
-                  updatedAt:
-                    type: string
-                    format: date-time
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad request. Validation error.
         "401":
@@ -640,6 +790,33 @@ paths:
       responses:
         "200":
           description: Returns the complete assessments
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    majorVersion:
+                      type: integer
+                    minorVersion:
+                      type: integer
+                    startedAt:
+                      type: string
+                      format: date-time
+                    finishedAt:
+                      type: string
+                      format: date-time
+                  required:
+                    - id
+                    - majorVersion
+                    - minorVersion
+                    - startedAt
+                    - finishedAt
+                  additionalProperties: false
         "400":
           description: Bad Request
         "401":
@@ -688,9 +865,9 @@ paths:
                   id:
                     type: string
                     format: uuid
-                    description: The innovation assessment id.
                 required:
                   - id
+                additionalProperties: false
         "400":
           description: The minor assessment version has not been created.
         "401":
@@ -735,11 +912,23 @@ paths:
                     properties:
                       reason:
                         type: string
+                        enum:
+                          - NO_RESPONSE
+                          - TECHNICAL_DIFFICULTIES
+                          - INCORRECT_DETAILS
+                          - SERVICE_UNAVAILABLE
+                          - CAPACITY
                       message:
                         type: string
                       exemptedAt:
                         type: string
                         format: date-time
+                    required:
+                      - reason
+                    additionalProperties: false
+                required:
+                  - isExempted
+                additionalProperties: false
         "400":
           description: The request is invalid.
         "401":
@@ -821,10 +1010,19 @@ paths:
                 properties:
                   userExists:
                     type: boolean
-                    description: User exists in service
                   collaboratorStatus:
                     type: string
-                    description: Status of the collaborator invite
+                    enum:
+                      - PENDING
+                      - ACTIVE
+                      - DECLINED
+                      - CANCELLED
+                      - REMOVED
+                      - LEFT
+                      - EXPIRED
+                required:
+                  - userExists
+                additionalProperties: false
         "404":
           description: Not Found
   /v1/{innovationId}/collaborators:
@@ -868,10 +1066,10 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: The collaborator id.
-                    example: c0a80121-7ac0-464e-b8f6-27b88b0cda7f
+                    format: uuid
                 required:
                   - id
+                additionalProperties: false
         "400":
           description: The collaborator could not be created.
         "401":
@@ -904,7 +1102,6 @@ paths:
                 properties:
                   count:
                     type: integer
-                    description: The total number of records.
                   data:
                     type: array
                     items:
@@ -912,6 +1109,7 @@ paths:
                       properties:
                         id:
                           type: string
+                          format: uuid
                         name:
                           type: string
                         role:
@@ -920,6 +1118,23 @@ paths:
                           type: string
                         status:
                           type: string
+                          enum:
+                            - PENDING
+                            - ACTIVE
+                            - DECLINED
+                            - CANCELLED
+                            - REMOVED
+                            - LEFT
+                            - EXPIRED
+                        isActive:
+                          type: boolean
+                      required:
+                        - id
+                      additionalProperties: false
+                required:
+                  - count
+                  - data
+                additionalProperties: false
         "400":
           description: The request is invalid.
         "401":
@@ -974,9 +1189,6 @@ paths:
                       - REMOVED
                       - LEFT
                       - EXPIRED
-                  invitedAt:
-                    type: string
-                    format: date-time
                   innovation:
                     type: object
                     properties:
@@ -995,6 +1207,22 @@ paths:
                             format: uuid
                           name:
                             type: string
+                        required:
+                          - id
+                        additionalProperties: false
+                    required:
+                      - id
+                      - name
+                    additionalProperties: false
+                  invitedAt:
+                    type: string
+                    format: date-time
+                required:
+                  - id
+                  - email
+                  - innovation
+                  - invitedAt
+                additionalProperties: false
         "401":
           description: Unauthorized
         "403":
@@ -1054,10 +1282,10 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: The collaborator id.
-                    example: c0a80121-7ac0-464e-b8f6-27b88b0cda7f
+                    format: uuid
                 required:
                   - id
+                additionalProperties: false
         "400":
           description: The collaborator could not be updated.
         "401":
@@ -1104,7 +1332,10 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: Unique identifier for innovation object
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Invalid innovation payload
         "422":
@@ -1499,7 +1730,10 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: Evidence id.
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad Request
         "401":
@@ -1771,8 +2005,10 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
                 required:
                   - id
+                additionalProperties: false
         "400":
           description: The innovation file could not be created.
         "401":
@@ -2031,11 +2267,13 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
                   context:
                     type: object
                     properties:
                       id:
                         type: string
+                        format: uuid
                       type:
                         type: string
                         enum:
@@ -2044,12 +2282,18 @@ paths:
                           - INNOVATION_MESSAGE
                           - INNOVATION_PROGRESS_UPDATE
                           - INNOVATION_SECTION
+                      name:
+                        type: string
+                    required:
+                      - id
+                    additionalProperties: false
                   name:
                     type: string
                   description:
                     type: string
                   createdAt:
                     type: string
+                    format: date-time
                   createdBy:
                     type: object
                     properties:
@@ -2067,20 +2311,40 @@ paths:
                         type: boolean
                       orgUnitName:
                         type: string
+                    required:
+                      - name
+                      - role
+                    additionalProperties: false
                   file:
                     type: object
                     properties:
                       id:
                         type: string
-                        description: Storage Id
+                        format: uuid
                       name:
                         type: string
                       size:
                         type: number
+                        format: float
                       extension:
                         type: string
                       url:
                         type: string
+                    required:
+                      - id
+                      - name
+                      - extension
+                      - url
+                    additionalProperties: false
+                  canDelete:
+                    type: boolean
+                required:
+                  - id
+                  - name
+                  - createdAt
+                  - file
+                  - canDelete
+                additionalProperties: false
         "400":
           description: The request is invalid.
         "401":
@@ -2124,11 +2388,16 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
                   name:
                     type: string
                   url:
                     type: string
-                    description: url for file upload
+                required:
+                  - id
+                  - name
+                  - url
+                additionalProperties: false
         "400":
           description: Invalid payload
         "404":
@@ -2149,6 +2418,222 @@ paths:
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  version:
+                    type: string
+                  status:
+                    type: string
+                    enum:
+                      - CREATED
+                      - WAITING_NEEDS_ASSESSMENT
+                      - NEEDS_ASSESSMENT
+                      - IN_PROGRESS
+                      - WITHDRAWN
+                      - ARCHIVED
+                  archivedStatus:
+                    type: string
+                    enum:
+                      - CREATED
+                      - WAITING_NEEDS_ASSESSMENT
+                      - NEEDS_ASSESSMENT
+                      - IN_PROGRESS
+                      - WITHDRAWN
+                      - ARCHIVED
+                  groupedStatus:
+                    type: string
+                    enum:
+                      - RECORD_NOT_SHARED
+                      - AWAITING_NEEDS_ASSESSMENT
+                      - NEEDS_ASSESSMENT
+                      - AWAITING_SUPPORT
+                      - RECEIVING_SUPPORT
+                      - NO_ACTIVE_SUPPORT
+                      - AWAITING_NEEDS_REASSESSMENT
+                      - WITHDRAWN
+                      - ARCHIVED
+                  hasBeenAssessed:
+                    type: boolean
+                  statusUpdatedAt:
+                    type: string
+                    format: date-time
+                  submittedAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  countryName:
+                    type: string
+                    nullable: true
+                  postCode:
+                    type: string
+                    nullable: true
+                  categories:
+                    type: array
+                    items:
+                      type: string
+                      enum:
+                        - MEDICAL_DEVICE
+                        - IN_VITRO_DIAGNOSTIC
+                        - PHARMACEUTICAL
+                        - DIGITAL
+                        - AI
+                        - EDUCATION
+                        - PPE
+                        - MODELS_CARE
+                        - ESTATES_FACILITIES
+                        - TRAVEL_TRANSPORT
+                        - FOOD_NUTRITION
+                        - DATA_MONITORING
+                        - OTHER
+                  otherCategoryDescription:
+                    type: string
+                    nullable: true
+                  owner:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type: string
+                      isActive:
+                        type: boolean
+                      email:
+                        type: string
+                      contactByEmail:
+                        type: boolean
+                      contactByPhone:
+                        type: boolean
+                      contactByPhoneTimeFrame:
+                        type: string
+                        enum:
+                          - MORNING
+                          - AFTERNOON
+                          - DAILY
+                        nullable: true
+                      mobilePhone:
+                        type: string
+                        nullable: true
+                      lastLoginAt:
+                        type: string
+                        format: date-time
+                        nullable: true
+                      organisation:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          size:
+                            type: string
+                            nullable: true
+                          registrationNumber:
+                            type: string
+                            nullable: true
+                        required:
+                          - name
+                          - size
+                          - registrationNumber
+                        additionalProperties: false
+                    required:
+                      - id
+                      - name
+                      - isActive
+                      - contactByPhoneTimeFrame
+                    additionalProperties: false
+                  lastEndSupportAt:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  assessment:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      createdAt:
+                        type: string
+                        format: date-time
+                      finishedAt:
+                        type: string
+                        format: date-time
+                        nullable: true
+                      assignedTo:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                          name:
+                            type: string
+                          userRoleId:
+                            type: string
+                        required:
+                          - id
+                          - name
+                          - userRoleId
+                        additionalProperties: false
+                    required:
+                      - id
+                      - createdAt
+                      - finishedAt
+                    additionalProperties: false
+                  supports:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        status:
+                          type: string
+                          enum:
+                            - SUGGESTED
+                            - ENGAGING
+                            - WAITING
+                            - UNSUITABLE
+                            - CLOSED
+                        organisationUnitId:
+                          type: string
+                      required:
+                        - id
+                        - organisationUnitId
+                      additionalProperties: false
+                    nullable: true
+                  collaboratorId:
+                    type: string
+                  createdAt:
+                    type: string
+                    format: date-time
+                required:
+                  - id
+                  - name
+                  - description
+                  - version
+                  - status
+                  - groupedStatus
+                  - hasBeenAssessed
+                  - statusUpdatedAt
+                  - submittedAt
+                  - countryName
+                  - postCode
+                  - categories
+                  - otherCategoryDescription
+                  - lastEndSupportAt
+                  - collaboratorId
+                  - createdAt
+                additionalProperties: false
         "400":
           description: Invalid innovation payload
   /v1/{innovationId}/notifications/dismiss:
@@ -2434,6 +2919,17 @@ paths:
       responses:
         "200":
           description: Returns the reassessment request and the cloned assessment id
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad request
         "401":
@@ -2487,51 +2983,61 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: Innovation section id.
-                    example: "1"
+                    format: uuid
+                    nullable: true
                   section:
                     type: string
-                    description: Innovation section key.
-                    example: access
+                    enum:
+                      - INNOVATION_DESCRIPTION
+                      - UNDERSTANDING_OF_NEEDS
+                      - EVIDENCE_OF_EFFECTIVENESS
+                      - MARKET_RESEARCH
+                      - CURRENT_CARE_PATHWAY
+                      - TESTING_WITH_USERS
+                      - REGULATIONS_AND_STANDARDS
+                      - INTELLECTUAL_PROPERTY
+                      - REVENUE_MODEL
+                      - COST_OF_INNOVATION
+                      - DEPLOYMENT
                   status:
                     type: string
-                    description: Innovation section status.
-                    example: COMPLETED
+                    enum:
+                      - NOT_STARTED
+                      - DRAFT
+                      - SUBMITTED
                   submittedAt:
                     type: string
-                    description: Innovation section submission date.
-                    example: 2021-01-01T00:00:00.000Z
-                  data:
+                    format: date-time
+                    nullable: true
+                  submittedBy:
                     type: object
-                    description: Innovation section data.
                     properties:
                       name:
                         type: string
-                        description: Innovation section name.
-                        example: Access
-                      description:
+                      displayTag:
                         type: string
-                        description: Innovation section description.
-                        example: Access description
-                      questions:
-                        type: array
-                        description: Innovation section questions.
-                        items:
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                              description: Innovation section question id.
-                              example: "1"
-                            text:
-                              type: string
-                              description: Innovation section question text.
-                              example: Question text
-                  actionsIds:
+                    required:
+                      - name
+                      - displayTag
+                    additionalProperties: false
+                    nullable: true
+                  data:
+                    type: object
+                    properties: {}
+                    additionalProperties: false
+                    nullable: true
+                  tasksIds:
                     type: array
                     items:
                       type: string
-                      description: The id of the action.
+                required:
+                  - id
+                  - section
+                  - status
+                  - submittedAt
+                  - submittedBy
+                  - data
+                additionalProperties: false
         "401":
           description: Unauthorized
         "403":
@@ -2593,6 +3099,8 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -2637,6 +3145,17 @@ paths:
       responses:
         "200":
           description: Innovation section submit response.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
   /v1/{innovationId}/sections:
     get:
       description: Get an innovation sections list.
@@ -2657,35 +3176,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                    description: Innovation id.
-                  name:
-                    type: string
-                    description: Innovation name.
-                  status:
-                    type: string
-                    description: Innovation status.
-                  sections:
-                    type: array
-                    description: Innovation sections.
-                    items:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                      nullable: true
+                    section:
+                      type: string
+                      enum:
+                        - INNOVATION_DESCRIPTION
+                        - UNDERSTANDING_OF_NEEDS
+                        - EVIDENCE_OF_EFFECTIVENESS
+                        - MARKET_RESEARCH
+                        - CURRENT_CARE_PATHWAY
+                        - TESTING_WITH_USERS
+                        - REGULATIONS_AND_STANDARDS
+                        - INTELLECTUAL_PROPERTY
+                        - REVENUE_MODEL
+                        - COST_OF_INNOVATION
+                        - DEPLOYMENT
+                    status:
+                      type: string
+                      enum:
+                        - NOT_STARTED
+                        - DRAFT
+                        - SUBMITTED
+                    submittedAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    submittedBy:
                       type: object
                       properties:
-                        id:
+                        name:
                           type: string
-                          description: Innovation section id.
-                        section:
-                          type: string
-                          description: Innovation section name.
-                        status:
-                          type: string
-                          description: Innovation section status.
-                        submittedAt:
-                          type: string
-                          description: Innovation section submitted date.
+                        isOwner:
+                          type: boolean
+                      required:
+                        - name
+                      additionalProperties: false
+                      nullable: true
+                    openTasksCount:
+                      type: integer
+                  required:
+                    - id
+                    - submittedAt
+                    - submittedBy
+                    - openTasksCount
+                  additionalProperties: false
         "401":
           description: Unauthorized
         "403":
@@ -2718,33 +3259,23 @@ paths:
                 items:
                   type: object
                   properties:
-                    id:
-                      type: string
-                      description: The unique identifier of the share.
-                    innovationId:
-                      type: string
-                      description: The unique identifier of the innovation.
-                    organisationId:
-                      type: string
-                      description: The unique identifier of the organisation.
-                    organisationName:
-                      type: string
-                      description: The name of the organisation.
-                    organisationUnitId:
-                      type: string
-                      description: The unique identifier of the organisation unit.
-                    organisationUnitName:
-                      type: string
-                      description: The name of the organisation unit.
-                    status:
-                      type: string
-                      description: The status of the share.
-                    createdAt:
-                      type: string
-                      description: The date and time when the share was created.
-                    updatedAt:
-                      type: string
-                      description: The date and time when the share was last updated.
+                    organisation:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        name:
+                          type: string
+                        acronym:
+                          type: string
+                          nullable: true
+                      required:
+                        - id
+                        - name
+                        - acronym
+                      additionalProperties: false
+                  additionalProperties: false
         "401":
           description: Unauthorized
         "403":
@@ -2792,7 +3323,11 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
                     description: The unique identifier of the innovation.
+                required:
+                  - id
+                additionalProperties: false
         "401":
           description: Unauthorized
         "403":
@@ -2850,6 +3385,19 @@ paths:
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  submittedAllSections:
+                    type: boolean
+                  submittedForNeedsAssessment:
+                    type: boolean
+                required:
+                  - submittedAllSections
+                  - submittedForNeedsAssessment
+                additionalProperties: false
         "400":
           description: Invalid innovation payload
   /v1/{innovationId}/submit:
@@ -2876,10 +3424,20 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: Innovation ID
+                    format: uuid
                   status:
                     type: string
-                    description: Innovation status
+                    enum:
+                      - CREATED
+                      - WAITING_NEEDS_ASSESSMENT
+                      - NEEDS_ASSESSMENT
+                      - IN_PROGRESS
+                      - WITHDRAWN
+                      - ARCHIVED
+                required:
+                  - id
+                  - status
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -2979,6 +3537,7 @@ paths:
                         - WAITING
                         - UNSUITABLE
                         - CLOSED
+                additionalProperties: false
         "400":
           description: Bad Request
         "401":
@@ -3104,11 +3663,11 @@ paths:
               schema:
                 type: object
                 properties:
-                  id:
-                    type: string
-                    format: uuid
+                  success:
+                    type: boolean
                 required:
-                  - id
+                  - success
+                additionalProperties: false
   /v1/{innovationId}/supports/{supportId}:
     get:
       description: Get supporting information for an Innovation
@@ -3131,6 +3690,43 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  status:
+                    type: string
+                    enum:
+                      - SUGGESTED
+                      - ENGAGING
+                      - WAITING
+                      - UNSUITABLE
+                      - CLOSED
+                  engagingAccessors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        userRoleId:
+                          type: string
+                          format: uuid
+                        name:
+                          type: string
+                      required:
+                        - id
+                        - userRoleId
+                        - name
+                      additionalProperties: false
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad Request
         "404":
@@ -3204,6 +3800,7 @@ paths:
                     format: uuid
                 required:
                   - id
+                additionalProperties: false
   /v1/{innovationId}/supports:
     post:
       description: Starts support in innovation.
@@ -3292,6 +3889,17 @@ paths:
         "201":
           description: Creates a new innovation support request for the innovation
             identified by the supplied Innovation ID.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "401":
           description: Unauthorised.
     get:
@@ -3309,6 +3917,78 @@ paths:
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    status:
+                      type: string
+                      enum:
+                        - SUGGESTED
+                        - ENGAGING
+                        - WAITING
+                        - UNSUITABLE
+                        - CLOSED
+                    organisation:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        name:
+                          type: string
+                        acronym:
+                          type: string
+                        unit:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                            name:
+                              type: string
+                            acronym:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - acronym
+                          additionalProperties: false
+                      required:
+                        - id
+                        - name
+                        - acronym
+                      additionalProperties: false
+                    engagingAccessors:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                          userRoleId:
+                            type: string
+                          name:
+                            type: string
+                          isActive:
+                            type: boolean
+                        required:
+                          - id
+                          - userRoleId
+                          - name
+                          - isActive
+                        additionalProperties: false
+                  required:
+                    - id
+                    - status
+                  additionalProperties: false
         "404":
           description: Not found
   /v1/{innovationId}/support-summary:
@@ -3708,10 +4388,12 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
                     description: The innovation task id.
                     example: c0a80121-7ac0-464e-b8f6-27b88b0cda7f
                 required:
                   - id
+                additionalProperties: false
         "400":
           description: The innovation task could not be created.
         "401":
@@ -3759,22 +4441,88 @@ paths:
                     enum:
                       - OPEN
                       - DONE
-                      - CANCELED
                       - DECLINED
-                  description:
-                    type: string
+                      - CANCELLED
                   section:
                     type: string
+                    enum:
+                      - INNOVATION_DESCRIPTION
+                      - UNDERSTANDING_OF_NEEDS
+                      - EVIDENCE_OF_EFFECTIVENESS
+                      - MARKET_RESEARCH
+                      - CURRENT_CARE_PATHWAY
+                      - TESTING_WITH_USERS
+                      - REGULATIONS_AND_STANDARDS
+                      - INTELLECTUAL_PROPERTY
+                      - REVENUE_MODEL
+                      - COST_OF_INNOVATION
+                      - DEPLOYMENT
+                  descriptions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        description:
+                          type: string
+                        createdAt:
+                          type: string
+                          format: date-time
+                        name:
+                          type: string
+                        displayTag:
+                          type: string
+                      required:
+                        - description
+                        - createdAt
+                        - name
+                        - displayTag
+                      additionalProperties: false
+                  sameOrganisation:
+                    type: boolean
+                  threadId:
+                    type: string
+                    format: uuid
                   createdAt:
                     type: string
                     format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                  updatedBy:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      displayTag:
+                        type: string
+                    required:
+                      - name
+                      - displayTag
+                    additionalProperties: false
                   createdBy:
                     type: object
                     properties:
                       name:
                         type: string
-                      organisationUnit:
+                      displayTag:
                         type: string
+                    required:
+                      - name
+                      - displayTag
+                    additionalProperties: false
+                required:
+                  - id
+                  - displayId
+                  - status
+                  - section
+                  - descriptions
+                  - sameOrganisation
+                  - threadId
+                  - createdAt
+                  - updatedAt
+                  - updatedBy
+                  - createdBy
+                additionalProperties: false
         "401":
           description: Unauthorized
         "403":
@@ -3835,31 +4583,10 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: The innovation task id.
-                  name:
-                    type: string
-                    description: The name of the task.
-                  description:
-                    type: string
-                    description: The description of the task.
-                  status:
-                    type: string
-                    description: The status of the task.
-                  assignee:
-                    type: string
-                    description: The assignee of the task.
-                  dueDate:
-                    type: string
-                    description: The due date of the task.
-                  comment:
-                    type: string
-                    description: The comment of the task.
-                  createdAt:
-                    type: string
-                    description: The date when the task was created.
-                  updatedAt:
-                    type: string
-                    description: The date when the task was updated.
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: The innovation task data is invalid.
         "401":
@@ -3986,48 +4713,95 @@ paths:
                 properties:
                   count:
                     type: integer
-                    description: The total number of records.
                   data:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          description: The id of the task.
-                        displayId:
-                          type: string
-                          description: The display id of the task.
-                        status:
-                          type: string
-                          description: The status of the task.
-                        description:
-                          type: string
-                          description: The description of the task.
-                        section:
-                          type: string
-                          description: The section of the task.
-                        createdAt:
-                          type: string
-                          description: The date the task was created.
-                        updatedAt:
-                          type: string
-                          description: The date the task was last updated.
-                        innovation:
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                              description: The id of the innovation.
-                            name:
-                              type: string
-                              description: The name of the innovation.
-                        notifications:
-                          type: object
-                          properties:
-                            count:
-                              type: integer
-                              description: The number of notifications for the task.
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      displayId:
+                        type: string
+                      innovation:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                          name:
+                            type: string
+                        required:
+                          - id
+                          - name
+                        additionalProperties: false
+                      status:
+                        type: string
+                        enum:
+                          - OPEN
+                          - DONE
+                          - DECLINED
+                          - CANCELLED
+                      section:
+                        type: string
+                        enum:
+                          - INNOVATION_DESCRIPTION
+                          - UNDERSTANDING_OF_NEEDS
+                          - EVIDENCE_OF_EFFECTIVENESS
+                          - MARKET_RESEARCH
+                          - CURRENT_CARE_PATHWAY
+                          - TESTING_WITH_USERS
+                          - REGULATIONS_AND_STANDARDS
+                          - INTELLECTUAL_PROPERTY
+                          - REVENUE_MODEL
+                          - COST_OF_INNOVATION
+                          - DEPLOYMENT
+                      sameOrganisation:
+                        type: boolean
+                      notifications:
+                        type: integer
+                      createdAt:
+                        type: string
+                        format: date-time
+                      createdBy:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          displayTag:
+                            type: string
+                        required:
+                          - name
+                          - displayTag
+                        additionalProperties: false
+                      updatedAt:
+                        type: string
+                        format: date-time
+                      updatedBy:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          displayTag:
+                            type: string
+                        required:
+                          - name
+                          - displayTag
+                        additionalProperties: false
+                    required:
+                      - id
+                      - displayId
+                      - innovation
+                      - status
+                      - section
+                      - sameOrganisation
+                      - notifications
+                      - createdAt
+                      - createdBy
+                      - updatedAt
+                      - updatedBy
+                    additionalProperties: false
+                required:
+                  - count
+                additionalProperties: false
         "400":
           description: The request is invalid.
         "401":
@@ -4052,6 +4826,69 @@ paths:
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    status:
+                      type: string
+                      enum:
+                        - ENGAGING
+                        - WAITING
+                        - SUGGESTED
+                        - PREVIOUS_ENGAGED
+                    organisation:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        name:
+                          type: string
+                        acronym:
+                          type: string
+                        unit:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                            name:
+                              type: string
+                            acronym:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - acronym
+                          additionalProperties: false
+                      required:
+                        - id
+                        - name
+                        - acronym
+                      additionalProperties: false
+                    recipients:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        name:
+                          type: string
+                      required:
+                        - id
+                        - name
+                      additionalProperties: false
+                  required:
+                    - id
+                    - organisation
+                  additionalProperties: false
         "404":
           description: Not found
   /v1/{innovationId}/threads:
@@ -4134,28 +4971,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  thread:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        description: The thread id.
-                        example: 00000000-0000-0000-0000-000000000000
-                      subject:
-                        type: string
-                        description: The thread subject.
-                        example: Subject
-                      createdBy:
-                        type: object
-                        properties:
-                          id:
-                            type: string
-                            description: The user id.
-                            example: 00000000-0000-0000-0000-000000000000
-                      createdAt:
-                        type: string
-                        description: The thread creation date.
-                        example: 2021-01-01T00:00:00.000Z
+                  id:
+                    type: string
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: The request was invalid.
         "401":
@@ -4219,7 +5040,7 @@ paths:
                 type: object
                 properties:
                   count:
-                    type: number
+                    type: integer
                   data:
                     type: array
                     items:
@@ -4227,33 +5048,57 @@ paths:
                       properties:
                         id:
                           type: string
+                          format: uuid
                         subject:
                           type: string
-                        messageCount:
-                          type: number
-                        hasUnreadNotifications:
-                          type: boolean
                         createdBy:
                           type: object
                           properties:
                             id:
                               type: string
+                              format: uuid
                             displayTeam:
                               type: string
+                          required:
+                            - id
+                          additionalProperties: false
                         lastMessage:
                           type: object
                           properties:
                             id:
                               type: string
+                              format: uuid
                             createdAt:
                               type: string
+                              format: date-time
                             createdBy:
                               type: object
                               properties:
                                 id:
                                   type: string
+                                  format: uuid
                                 displayTeam:
                                   type: string
+                              required:
+                                - id
+                              additionalProperties: false
+                          required:
+                            - id
+                            - createdAt
+                          additionalProperties: false
+                        messageCount:
+                          type: integer
+                        hasUnreadNotifications:
+                          type: boolean
+                      required:
+                        - id
+                        - subject
+                        - messageCount
+                        - hasUnreadNotifications
+                      additionalProperties: false
+                required:
+                  - count
+                additionalProperties: false
         "401":
           description: Unauthorized
         "403":
@@ -4288,26 +5133,63 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  participants:
-                    type: array
-                    items:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    followers:
                       type: object
                       properties:
                         id:
                           type: string
+                          format: uuid
                         name:
                           type: string
-                        type:
-                          type: string
+                        isLocked:
+                          type: boolean
+                        isOwner:
+                          type: boolean
+                        role:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                            role:
+                              type: string
+                              enum:
+                                - ADMIN
+                                - INNOVATOR
+                                - ACCESSOR
+                                - ASSESSMENT
+                                - QUALIFYING_ACCESSOR
+                          required:
+                            - id
+                            - role
+                          additionalProperties: false
                         organisationUnit:
                           type: object
                           properties:
                             id:
                               type: string
+                              format: uuid
+                            name:
+                              type: string
                             acronym:
                               type: string
+                          required:
+                            - id
+                            - name
+                            - acronym
+                          additionalProperties: false
+                          nullable: true
+                      required:
+                        - id
+                        - name
+                        - isLocked
+                        - organisationUnit
+                      additionalProperties: false
+                  additionalProperties: false
         "401":
           description: Unauthorized
         "403":
@@ -4427,19 +5309,46 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
                   subject:
                     type: string
+                  context:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - NEEDS_ASSESSMENT
+                          - SUPPORT
+                          - TASK
+                          - ORGANISATION_SUGGESTION
+                      id:
+                        type: string
+                        format: uuid
+                    required:
+                      - type
+                      - id
+                    additionalProperties: false
                   createdAt:
                     type: string
+                    format: date-time
                   createdBy:
                     type: object
                     properties:
                       id:
                         type: string
+                        format: uuid
                       name:
                         type: string
-                      type:
-                        type: string
+                    required:
+                      - id
+                      - name
+                    additionalProperties: false
+                required:
+                  - id
+                  - subject
+                  - createdAt
+                additionalProperties: false
         "401":
           description: Unauthorized
         "403":
@@ -4526,27 +5435,37 @@ paths:
                   threadMessage:
                     type: object
                     properties:
-                      id:
-                        type: string
-                        description: Message ID.
-                      message:
-                        type: string
-                        description: Message.
                       createdBy:
                         type: object
                         properties:
                           id:
                             type: string
-                            description: User ID.
+                            format: uuid
                           identityId:
                             type: string
-                            description: User identity ID.
-                      createdAt:
+                        required:
+                          - id
+                          - identityId
+                        additionalProperties: false
+                      id:
                         type: string
-                        description: Date when the message was created.
+                        format: uuid
+                      message:
+                        type: string
                       isEditable:
                         type: boolean
-                        description: Flag to indicate if the message can be edited.
+                      createdAt:
+                        type: string
+                        format: date-time
+                    required:
+                      - id
+                      - message
+                      - isEditable
+                      - createdAt
+                    additionalProperties: false
+                required:
+                  - threadMessage
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -4585,7 +5504,7 @@ paths:
                 type: object
                 properties:
                   count:
-                    type: number
+                    type: integer
                   messages:
                     type: array
                     items:
@@ -4593,43 +5512,7 @@ paths:
                       properties:
                         id:
                           type: string
-                        createdAt:
-                          type: string
-                        createdBy:
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                            name:
-                              type: string
-                            type:
-                              type: string
-                              enum:
-                                - INNOVATOR
-                                - ASSESSOR
-                                - ACCESSOR
-                            organisationUnit:
-                              type: object
-                              properties:
-                                id:
-                                  type: string
-                                name:
-                                  type: string
-                                acronym:
-                                  type: string
-                            organisation:
-                              type: object
-                              properties:
-                                id:
-                                  type: string
-                                name:
-                                  type: string
-                                acronym:
-                                  type: string
-                        isEditable:
-                          type: boolean
-                        isNew:
-                          type: boolean
+                          format: uuid
                         message:
                           type: string
                         file:
@@ -4637,12 +5520,87 @@ paths:
                           properties:
                             id:
                               type: string
+                              format: uuid
                             name:
                               type: string
                             url:
                               type: string
+                          required:
+                            - id
+                            - name
+                            - url
+                          additionalProperties: false
+                        createdAt:
+                          type: string
+                          format: date-time
+                        isNew:
+                          type: boolean
+                        isEditable:
+                          type: boolean
+                        createdBy:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                            name:
+                              type: string
+                            role:
+                              type: string
+                            isOwner:
+                              type: boolean
+                            organisation:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                  format: uuid
+                                name:
+                                  type: string
+                                acronym:
+                                  type: string
+                                  nullable: true
+                              required:
+                                - id
+                                - name
+                                - acronym
+                              additionalProperties: false
+                            organisationUnit:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                  format: uuid
+                                name:
+                                  type: string
+                                acronym:
+                                  type: string
+                                  nullable: true
+                              required:
+                                - id
+                                - name
+                                - acronym
+                              additionalProperties: false
+                          required:
+                            - id
+                            - name
+                            - role
+                            - isOwner
+                          additionalProperties: false
                         updatedAt:
                           type: string
+                          format: date-time
+                      required:
+                        - id
+                        - message
+                        - createdAt
+                        - isNew
+                        - isEditable
+                        - updatedAt
+                      additionalProperties: false
+                required:
+                  - count
+                additionalProperties: false
         "400":
           description: Bad request
         "401":
@@ -4688,13 +5646,17 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: Message ID
+                    format: uuid
                   message:
                     type: string
-                    description: Message
                   createdAt:
                     type: string
-                    description: Message creation date
+                    format: date-time
+                required:
+                  - id
+                  - message
+                  - createdAt
+                additionalProperties: false
         "401":
           description: Unauthorized
         "403":
@@ -4751,7 +5713,11 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
                     description: Message Id
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad Request
         "401":
@@ -4783,7 +5749,9 @@ paths:
                 properties:
                   userExists:
                     type: boolean
-                    description: User exists in service
+                required:
+                  - userExists
+                additionalProperties: false
         "404":
           description: The innovation transfer does not exist
   /v1/transfers:
@@ -4818,6 +5786,13 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad Request
           content:
@@ -4832,13 +5807,38 @@ paths:
       parameters: []
       responses:
         "200":
-          description: Success
+          description: The innovation assessment has been created.
           content:
             application/json:
               schema:
                 type: array
                 items:
                   type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    email:
+                      type: string
+                    innovation:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        name:
+                          type: string
+                        owner:
+                          type: string
+                      required:
+                        - id
+                        - name
+                      additionalProperties: false
+                  required:
+                    - id
+                    - email
+                    - innovation
+                  additionalProperties: false
   /v1/transfers/{transferId}:
     get:
       description: Get an innovation transfer
@@ -4857,6 +5857,38 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  email:
+                    type: string
+                  innovation:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type: string
+                      owner:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                        required:
+                          - name
+                        additionalProperties: false
+                    required:
+                      - id
+                      - name
+                      - owner
+                    additionalProperties: false
+                required:
+                  - id
+                  - email
+                  - innovation
+                additionalProperties: false
         "404":
           description: Not Found
           content:
@@ -4893,6 +5925,17 @@ paths:
       responses:
         "204":
           description: The innovation transfer status has been updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: The innovation transfer status is invalid
         "401":
@@ -4958,6 +6001,10 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: The request is invalid.
         "401":
@@ -5021,13 +6068,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  count:
-                    type: number
-                  data:
-                    type: array
-                    items:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    count:
+                      type: integer
+                    data:
                       type: object
                       properties:
                         id:
@@ -5049,9 +6096,19 @@ paths:
                               type: string
                             displayTeam:
                               type: string
+                          required:
+                            - name
+                          additionalProperties: false
                         createdAt:
                           type: string
                           format: date-time
+                      required:
+                        - id
+                        - createdAt
+                      additionalProperties: false
+                  required:
+                    - count
+                  additionalProperties: false
         "400":
           description: The request is invalid.
         "401":
@@ -5104,12 +6161,12 @@ paths:
                   createdBy:
                     type: object
                     properties:
-                      name:
-                        type: string
+                      name: {}
                       displayRole:
                         type: string
-                      displayTeam:
+                      displayType:
                         type: string
+                    additionalProperties: false
                   createdAt:
                     type: string
                     format: date-time
@@ -5118,9 +6175,18 @@ paths:
                     properties:
                       name:
                         type: string
+                    required:
+                      - name
+                    additionalProperties: false
                   updatedAt:
                     type: string
                     format: date-time
+                required:
+                  - id
+                  - requestReason
+                  - createdAt
+                  - updatedAt
+                additionalProperties: false
         "400":
           description: The request is invalid.
         "401":
@@ -5195,9 +6261,11 @@ paths:
               schema:
                 type: object
                 properties:
-                  id:
-                    type: string
-                    description: Unique identifier for innovation object
+                  overdue:
+                    type: integer
+                required:
+                  - overdue
+                additionalProperties: false
         "400":
           description: Invalid innovation payload
   /v1/search:
@@ -5469,15 +6537,27 @@ paths:
             description: Id of the innovation.
       responses:
         "200":
-          description: OK
+          description: The innovation assessment has been created.
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   validations:
-                    type: object
-                    description: Validation data.
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        rule:
+                          type: string
+                        valid:
+                          type: boolean
+                        details: {}
+                      required:
+                        - rule
+                        - valid
+                      additionalProperties: false
+                additionalProperties: false
         "400":
           description: Bad request.
         "401":
@@ -5497,7 +6577,17 @@ paths:
             application/json:
               schema:
                 type: object
-                properties: {}
+                properties:
+                  version:
+                    type: integer
+                  schema:
+                    type: object
+                    properties: {}
+                    additionalProperties: false
+                required:
+                  - version
+                  - schema
+                additionalProperties: false
         "400":
           description: Bad request
         "401":

--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -160,11 +160,12 @@ paths:
       summary: Get an innovation sections list details.
       operationId: v1-innovation-all-sections-list
       parameters:
-        - in: path
-          name: innovationId
+        - name: innovationId
+          in: path
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: Success
@@ -278,14 +279,12 @@ paths:
       parameters:
         - name: innovationId
           in: path
-          description: Innovation Id
           required: true
           schema:
             type: string
             format: uuid
         - name: assessmentId
           in: path
-          description: Assessment Id
           required: true
           schema:
             type: string
@@ -410,14 +409,12 @@ paths:
       parameters:
         - name: innovationId
           in: path
-          description: Innovation ID
           required: true
           schema:
             type: string
             format: uuid
         - name: assessmentId
           in: path
-          description: Assessment ID
           required: true
           schema:
             type: string
@@ -430,16 +427,112 @@ paths:
             schema:
               type: object
               properties:
-                status:
+                summary:
+                  type: string
+                  maxLength: 2000
+                  nullable: true
+                description:
+                  type: string
+                  maxLength: 2000
+                  nullable: true
+                maturityLevel:
                   type: string
                   enum:
-                    - APPROVED
-                    - REJECTED
-                comment:
+                    - DISCOVERY
+                    - ADVANCED
+                    - READY
+                  nullable: true
+                maturityLevelComment:
                   type: string
-                  maxLength: 1000
-              required:
-                - status
+                  maxLength: 200
+                  nullable: true
+                hasRegulatoryApprovals:
+                  type: string
+                  enum:
+                    - YES
+                    - PARTIALLY
+                    - NO
+                  nullable: true
+                hasRegulatoryApprovalsComment:
+                  type: string
+                  maxLength: 200
+                  nullable: true
+                hasEvidence:
+                  type: string
+                  enum:
+                    - YES
+                    - PARTIALLY
+                    - NO
+                  nullable: true
+                hasEvidenceComment:
+                  type: string
+                  maxLength: 200
+                  nullable: true
+                hasValidation:
+                  type: string
+                  enum:
+                    - YES
+                    - PARTIALLY
+                    - NO
+                  nullable: true
+                hasValidationComment:
+                  type: string
+                  maxLength: 200
+                  nullable: true
+                hasProposition:
+                  type: string
+                  enum:
+                    - YES
+                    - PARTIALLY
+                    - NO
+                  nullable: true
+                hasPropositionComment:
+                  type: string
+                  maxLength: 200
+                  nullable: true
+                hasCompetitionKnowledge:
+                  type: string
+                  enum:
+                    - YES
+                    - PARTIALLY
+                    - NO
+                  nullable: true
+                hasCompetitionKnowledgeComment:
+                  type: string
+                  maxLength: 200
+                  nullable: true
+                hasImplementationPlan:
+                  type: string
+                  enum:
+                    - YES
+                    - PARTIALLY
+                    - NO
+                  nullable: true
+                hasImplementationPlanComment:
+                  type: string
+                  maxLength: 200
+                  nullable: true
+                hasScaleResource:
+                  type: string
+                  enum:
+                    - YES
+                    - PARTIALLY
+                    - NO
+                  nullable: true
+                hasScaleResourceComment:
+                  type: string
+                  maxLength: 200
+                  nullable: true
+                suggestedOrganisationUnitsIds:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  nullable: true
+                isSubmission:
+                  type: boolean
+                  default: false
+              additionalProperties: false
       responses:
         "200":
           description: Returns the updated innovation assessment.
@@ -492,7 +585,6 @@ paths:
       parameters:
         - name: innovationId
           in: path
-          description: The innovation id.
           required: true
           schema:
             type: string
@@ -505,11 +597,12 @@ paths:
             schema:
               type: object
               properties:
-                comment:
+                message:
                   type: string
-                  description: The comment for the assessment.
+                  maxLength: 4000
               required:
-                - comment
+                - message
+              additionalProperties: false
       responses:
         "200":
           description: The innovation assessment has been created.
@@ -2050,7 +2143,6 @@ paths:
         - name: innovationId
           in: path
           required: true
-          description: Innovation ID
           schema:
             type: string
             format: uuid
@@ -2067,7 +2159,6 @@ paths:
         - name: innovationId
           in: path
           required: true
-          description: Innovation ID
           schema:
             type: string
             format: uuid
@@ -2084,27 +2175,117 @@ paths:
                   items:
                     type: string
                     format: uuid
-                notificationContext:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                      format: uuid
-                    type:
-                      type: string
-                      enum:
-                        - TASK
-                        - DOCUMENTS
-                        - MESSAGES
-                        - SUPPORT
-                        - NEEDS_ASSESSMENT
-                        - ORGANISATION_SUGGESTIONS
-                        - INNOVATION_MANAGEMENT
-                        - ADMIN
-                        - ACCOUNT
-                        - AUTOMATIC
-                        - NOTIFY_ME
-                        - ANNOUNCEMENTS
+                  default: []
+                contextTypes:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - TASK
+                      - DOCUMENTS
+                      - MESSAGES
+                      - SUPPORT
+                      - NEEDS_ASSESSMENT
+                      - ORGANISATION_SUGGESTIONS
+                      - INNOVATION_MANAGEMENT
+                      - ADMIN
+                      - ACCOUNT
+                      - AUTOMATIC
+                      - NOTIFY_ME
+                      - ANNOUNCEMENTS
+                  default: []
+                contextDetails:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - TA01_TASK_CREATION_TO_INNOVATOR
+                      - TA02_TASK_RESPONDED_TO_OTHER_INNOVATORS
+                      - TA03_TASK_DONE_TO_ACCESSOR_OR_ASSESSMENT
+                      - TA04_TASK_DECLINED_TO_ACCESSOR_OR_ASSESSMENT
+                      - TA05_TASK_CANCELLED_TO_INNOVATOR
+                      - TA06_TASK_REOPEN_TO_INNOVATOR
+                      - DC01_UPLOADED_DOCUMENT_TO_INNOVATOR
+                      - ME01_THREAD_CREATION
+                      - ME02_THREAD_ADD_FOLLOWERS
+                      - ME03_THREAD_MESSAGE_CREATION
+                      - ST01_SUPPORT_STATUS_TO_ENGAGING
+                      - ST02_SUPPORT_STATUS_TO_OTHER
+                      - ST03_SUPPORT_STATUS_TO_WAITING
+                      - ST04_SUPPORT_NEW_ASSIGNED_ACCESSORS_TO_INNOVATOR
+                      - ST05_SUPPORT_NEW_ASSIGNED_ACCESSOR_TO_NEW_QA
+                      - ST06_SUPPORT_NEW_ASSIGNED_ACCESSOR_TO_OLD_QA
+                      - ST07_SUPPORT_STATUS_CHANGE_REQUEST
+                      - ST08_SUPPORT_NEW_ASSIGNED_WAITING_INNOVATION_TO_QA
+                      - SS01_SUPPORT_SUMMARY_UPDATE_TO_INNOVATORS
+                      - SS02_SUPPORT_SUMMARY_UPDATE_TO_OTHER_ENGAGING_ACCESSORS
+                      - NA01_INNOVATOR_SUBMITS_FOR_NEEDS_ASSESSMENT_TO_INNOVATOR
+                      - NA02_INNOVATOR_SUBMITS_FOR_NEEDS_ASSESSMENT_TO_ASSESSMENT
+                      - NA03_NEEDS_ASSESSMENT_STARTED_TO_INNOVATOR
+                      - NA04_NEEDS_ASSESSMENT_COMPLETE_TO_INNOVATOR
+                      - NA06_NEEDS_ASSESSOR_REMOVED
+                      - NA07_NEEDS_ASSESSOR_ASSIGNED
+                      - OS01_UNITS_SUGGESTION_TO_SUGGESTED_UNITS_QA
+                      - OS02_UNITS_SUGGESTION_NOT_SHARED_TO_INNOVATOR
+                      - OS03_INNOVATION_DELAYED_SHARED_SUGGESTION
+                      - RE01_EXPORT_REQUEST_SUBMITTED
+                      - RE02_EXPORT_REQUEST_APPROVED
+                      - RE03_EXPORT_REQUEST_REJECTED
+                      - AI01_INNOVATION_ARCHIVED_TO_SELF
+                      - AI02_INNOVATION_ARCHIVED_TO_COLLABORATORS
+                      - AI03_INNOVATION_ARCHIVED_TO_ENGAGING_QA_A
+                      - AI04_INNOVATION_ARCHIVED_TO_NA_DURING_NEEDS_ASSESSMENT
+                      - SH04_INNOVATION_STOPPED_SHARING_WITH_INDIVIDUAL_ORG_TO_OWNER
+                      - SH05_INNOVATION_STOPPED_SHARING_WITH_INDIVIDUAL_ORG_TO_QA_A
+                      - DA01_OWNER_DELETED_ACCOUNT_WITH_PENDING_TRANSFER_TO_COLLABORATOR
+                      - DA02_OWNER_DELETED_ACCOUNT_WITHOUT_PENDING_TRANSFER_TO_COLLABORATOR
+                      - MC01_COLLABORATOR_INVITE_EXISTING_USER
+                      - MC02_COLLABORATOR_INVITE_NEW_USER
+                      - MC03_COLLABORATOR_UPDATE_CANCEL_INVITE
+                      - MC04_COLLABORATOR_UPDATE_ACCEPTS_INVITE
+                      - MC05_COLLABORATOR_UPDATE_DECLINES_INVITE
+                      - MC06_COLLABORATOR_UPDATE_REMOVED_COLLABORATOR
+                      - MC07_COLLABORATOR_UPDATE_COLLABORATOR_LEFT_TO_INNOVATORS
+                      - MC08_COLLABORATOR_UPDATE_COLLABORATOR_LEFT_TO_SELF
+                      - TO01_TRANSFER_OWNERSHIP_NEW_USER
+                      - TO02_TRANSFER_OWNERSHIP_EXISTING_USER
+                      - TO06_TRANSFER_OWNERSHIP_ACCEPTS_PREVIOUS_OWNER
+                      - TO07_TRANSFER_OWNERSHIP_ACCEPTS_ASSIGNED_ACCESSORS
+                      - TO08_TRANSFER_OWNERSHIP_DECLINES_PREVIOUS_OWNER
+                      - TO09_TRANSFER_OWNERSHIP_CANCELED_NEW_OWNER
+                      - AP02_INNOVATOR_LOCKED_TO_ASSIGNED_USERS
+                      - AP03_USER_LOCKED_TO_LOCKED_USER
+                      - AP07_UNIT_INACTIVATED_TO_ENGAGING_INNOVATIONS
+                      - AP08_USER_EMAIL_ADDRESS_UPDATED
+                      - AP09_NEW_SUPPORTING_ACCOUNT
+                      - CA01_ACCOUNT_CREATION_OF_INNOVATOR
+                      - CA02_ACCOUNT_CREATION_OF_COLLABORATOR
+                      - AU01_INNOVATOR_INCOMPLETE_RECORD
+                      - AU02_ACCESSOR_IDLE_ENGAGING_SUPPORT
+                      - AU03_INNOVATOR_IDLE_SUPPORT
+                      - AU04_SUPPORT_KPI_REMINDER
+                      - AU05_SUPPORT_KPI_OVERDUE
+                      - AU06_ACCESSOR_IDLE_WAITING
+                      - AU07_TRANSFER_ONE_WEEK_REMINDER_NEW_USER
+                      - AU08_TRANSFER_ONE_WEEK_REMINDER_EXISTING_USER
+                      - AU09_TRANSFER_EXPIRED
+                      - AU10_ACCESSOR_IDLE_ENGAGING_SUPPORT_FOR_SIX_WEEKS
+                      - AU11_ACCESSOR_IDLE_WAITING_SUPPORT_FOR_SIX_WEEKS
+                      - SUPPORT_UPDATED
+                      - PROGRESS_UPDATE_CREATED
+                      - INNOVATION_RECORD_UPDATED
+                      - REMINDER
+                      - SUGGESTED_SUPPORT_UPDATED
+                      - AP10_NEW_ANNOUNCEMENT
+                      - AP11_NEW_ANNOUNCEMENT_WITH_INNOVATIONS_NAME
+                  default: []
+                contextIds:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  default: []
+              additionalProperties: false
       responses:
         "204":
           description: Success
@@ -2453,17 +2634,6 @@ paths:
               - REVENUE_MODEL
               - COST_OF_INNOVATION
               - DEPLOYMENT
-      requestBody:
-        description: Innovation section submit request body.
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  description: Innovation section id.
-                  example: "1"
       responses:
         "200":
           description: Innovation section submit response.
@@ -2475,11 +2645,12 @@ paths:
       summary: Get an innovation sections list.
       operationId: v1-innovation-sections-list
       parameters:
-        - in: path
-          name: innovationId
+        - name: innovationId
+          in: path
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: Success
@@ -2531,11 +2702,12 @@ paths:
       summary: Get all the shares for an innovation.
       operationId: v1-innovation-shares
       parameters:
-        - in: path
-          name: innovationId
+        - name: innovationId
+          in: path
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: OK
@@ -2672,7 +2844,6 @@ paths:
         - name: innovationId
           in: path
           required: true
-          description: Innovation ID
           schema:
             type: string
             format: uuid
@@ -2726,11 +2897,12 @@ paths:
       tags:
         - Innovation Suggestions
       parameters:
-        - in: path
-          name: innovationId
+        - name: innovationId
+          in: path
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: OK
@@ -2744,11 +2916,31 @@ paths:
       tags:
         - Create Innovation Suggestion
       parameters:
-        - in: path
-          name: innovationId
+        - name: innovationId
+          in: path
           required: true
           schema:
             type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                  maxLength: 2000
+                organisationUnits:
+                  type: array
+                  items:
+                    type: string
+                  minItems: 1
+              required:
+                - description
+                - organisationUnits
+              additionalProperties: false
       responses:
         "201":
           description: Creates a suggestion.
@@ -2868,15 +3060,19 @@ paths:
       tags:
         - Innovation Support
       parameters:
-        - in: path
-          name: innovationId
-          description: Unique innovation ID
+        - name: innovationId
+          in: path
           required: true
-        - in: path
-          name: supportId
+          schema:
+            type: string
+            format: uuid
+        - name: supportId
+          in: path
           required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
-        description: ""
         required: true
         content:
           application/json:
@@ -2886,17 +3082,20 @@ paths:
                 status:
                   type: string
                   enum:
-                    - SUGGESTED
                     - ENGAGING
                     - WAITING
                     - UNSUITABLE
                     - CLOSED
+                  not:
+                    enum:
+                      - SUGGESTED
                 message:
                   type: string
-                  maxLength: 400
+                  maxLength: 2000
               required:
                 - status
                 - message
+              additionalProperties: false
       responses:
         "200":
           description: Innovation ID
@@ -2917,16 +3116,18 @@ paths:
       tags:
         - "[v1] Innovation Support"
       parameters:
-        - in: path
-          name: innovationId
+        - name: innovationId
+          in: path
           required: true
           schema:
             type: string
-        - in: path
-          name: supportId
+            format: uuid
+        - name: supportId
+          in: path
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: OK
@@ -2940,19 +3141,19 @@ paths:
       tags:
         - "[v1] Innovation Support"
       parameters:
-        - in: path
-          name: innovationId
-          description: Unique innovation ID
+        - name: innovationId
+          in: path
           required: true
           schema:
             type: string
-        - in: path
-          name: supportId
+            format: uuid
+        - name: supportId
+          in: path
           required: true
           schema:
             type: string
+            format: uuid
       requestBody:
-        description: ""
         required: true
         content:
           application/json:
@@ -2962,25 +3163,30 @@ paths:
                 status:
                   type: string
                   enum:
-                    - SUGGESTED
                     - ENGAGING
                     - WAITING
                     - UNSUITABLE
                     - CLOSED
                 message:
                   type: string
-                  maxLength: 400
+                  maxLength: 4000
                 accessors:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      accessorId:
-                        type: string
-                        format: uuid
-                      organisationalUnitId:
-                        type: string
-                        format: uuid
+                  oneOf:
+                    - type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                          userRoleId:
+                            type: string
+                            format: uuid
+                        required:
+                          - id
+                          - userRoleId
+                        additionalProperties: false
+                      x-required: true
               required:
                 - status
                 - message
@@ -3005,11 +3211,83 @@ paths:
       tags:
         - "[v1] Innovation Support"
       parameters:
-        - in: path
-          name: innovationId
+        - name: innovationId
+          in: path
           required: true
           schema:
             type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - ENGAGING
+                    - WAITING
+                    - UNSUITABLE
+                message:
+                  type: string
+                  maxLength: 4000
+                file:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      maxLength: 100
+                    description:
+                      type: string
+                      maxLength: 500
+                    file:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          maxLength: 100
+                        name:
+                          type: string
+                          maxLength: 100
+                        size:
+                          type: number
+                          format: float
+                        extension:
+                          type: string
+                          maxLength: 4
+                      required:
+                        - id
+                        - name
+                        - size
+                        - extension
+                      additionalProperties: false
+                  required:
+                    - name
+                    - file
+                  additionalProperties: false
+                accessors:
+                  oneOf:
+                    - type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                          userRoleId:
+                            type: string
+                            format: uuid
+                        required:
+                          - id
+                          - userRoleId
+                        additionalProperties: false
+                      x-required: true
+              required:
+                - status
+                - message
+              additionalProperties: false
       responses:
         "201":
           description: Creates a new innovation support request for the innovation
@@ -3022,16 +3300,12 @@ paths:
       tags:
         - "[v1] Innovation Support"
       parameters:
-        - in: path
-          name: innovationId
+        - name: innovationId
+          in: path
           required: true
           schema:
             type: string
-        - in: query
-          name: status
-          required: false
-          schema:
-            type: string
+            format: uuid
       responses:
         "200":
           description: Success
@@ -3515,16 +3789,16 @@ paths:
       parameters:
         - name: innovationId
           in: path
-          description: The innovation id.
           required: true
           schema:
             type: string
+            format: uuid
         - name: taskId
           in: path
-          description: The innovation task id.
           required: true
           schema:
             type: string
+            format: uuid
       requestBody:
         description: The innovation task data.
         required: true
@@ -3533,24 +3807,24 @@ paths:
             schema:
               type: object
               properties:
-                name:
-                  type: string
-                  description: The name of the task.
-                description:
-                  type: string
-                  description: The description of the task.
                 status:
+                  oneOf:
+                    - type: string
+                      enum:
+                        - OPEN
+                        - CANCELLED
+                      x-required: true
+                    - type: string
+                      enum:
+                        - DONE
+                        - DECLINED
+                      x-required: true
+                message:
                   type: string
-                  description: The status of the task.
-                assignee:
-                  type: string
-                  description: The assignee of the task.
-                dueDate:
-                  type: string
-                  description: The due date of the task.
-                comment:
-                  type: string
-                  description: The comment of the task.
+                  maxLength: 500
+              required:
+                - message
+              additionalProperties: false
       responses:
         "200":
           description: The innovation task has been updated.
@@ -3604,48 +3878,104 @@ paths:
         - name: skip
           in: query
           required: false
-          description: The number of records to skip.
           schema:
             type: integer
-            minimum: 0
         - name: take
           in: query
           required: false
-          description: The number of records to take.
           schema:
             type: integer
-            minimum: 1
             maximum: 100
+            default: 20
         - name: order
           in: query
           required: false
-          description: The order of the records.
           schema:
-            type: string
-        - name: status
-          in: query
-          required: false
-          description: The status of the task.
-          schema:
-            type: string
-        - name: section
-          in: query
-          required: false
-          description: The section of the task.
-          schema:
-            type: string
+            type: object
+            properties: {}
+            additionalProperties:
+              type: string
+              enum:
+                - ASC
+                - DESC
+            default:
+              default: DESC
         - name: innovationId
           in: query
           required: false
-          description: The innovation id of the task.
           schema:
             type: string
+            format: uuid
         - name: innovationName
           in: query
           required: false
-          description: The innovation name of the task.
           schema:
             type: string
+            nullable: true
+        - name: sections
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - INNOVATION_DESCRIPTION
+                - UNDERSTANDING_OF_NEEDS
+                - EVIDENCE_OF_EFFECTIVENESS
+                - MARKET_RESEARCH
+                - CURRENT_CARE_PATHWAY
+                - TESTING_WITH_USERS
+                - REGULATIONS_AND_STANDARDS
+                - INTELLECTUAL_PROPERTY
+                - REVENUE_MODEL
+                - COST_OF_INNOVATION
+                - DEPLOYMENT
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - OPEN
+                - DONE
+                - DECLINED
+                - CANCELLED
+        - name: innovationStatus
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - CREATED
+                - WAITING_NEEDS_ASSESSMENT
+                - NEEDS_ASSESSMENT
+                - IN_PROGRESS
+                - WITHDRAWN
+                - ARCHIVED
+        - name: createdByMe
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: allTasks
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: fields
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - notifications
       responses:
         "200":
           description: The list of innovation tasks.
@@ -3713,11 +4043,12 @@ paths:
       tags:
         - "[v1] Innovation Threads Available Recipients"
       parameters:
-        - in: path
-          name: innovationId
+        - name: innovationId
+          in: path
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: Success
@@ -3733,10 +4064,10 @@ paths:
       parameters:
         - name: innovationId
           in: path
-          description: The innovation id.
           required: true
           schema:
             type: string
+            format: uuid
       requestBody:
         description: The thread details.
         required: true
@@ -3747,15 +4078,54 @@ paths:
               properties:
                 subject:
                   type: string
-                  description: The thread subject.
-                  example: Subject
+                  maxLength: 200
                 message:
                   type: string
-                  description: The thread message.
-                  example: Message
+                  maxLength: 4000
+                file:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      maxLength: 100
+                    description:
+                      type: string
+                      maxLength: 500
+                    file:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          maxLength: 100
+                        name:
+                          type: string
+                          maxLength: 100
+                        size:
+                          type: number
+                          format: float
+                        extension:
+                          type: string
+                          maxLength: 4
+                      required:
+                        - id
+                        - name
+                        - size
+                        - extension
+                      additionalProperties: false
+                  required:
+                    - name
+                    - file
+                  additionalProperties: false
+                followerUserRoleIds:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
               required:
                 - subject
                 - message
+                - followerUserRoleIds
+              additionalProperties: false
       responses:
         "200":
           description: The thread was created successfully.
@@ -4037,16 +4407,16 @@ paths:
       parameters:
         - name: innovationId
           in: path
-          description: Innovation Id
           required: true
           schema:
             type: string
+            format: uuid
         - name: threadId
           in: path
-          description: Thread Id
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: Success
@@ -4087,16 +4457,16 @@ paths:
       parameters:
         - name: innovationId
           in: path
-          description: Innovation ID
           required: true
           schema:
             type: string
+            format: uuid
         - name: threadId
           in: path
-          description: Thread ID
           required: true
           schema:
             type: string
+            format: uuid
       requestBody:
         description: Message to be created.
         required: true
@@ -4107,7 +4477,44 @@ paths:
               properties:
                 message:
                   type: string
-                  description: Message to be created.
+                  maxLength: 4000
+                file:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      maxLength: 100
+                    description:
+                      type: string
+                      maxLength: 500
+                    file:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          maxLength: 100
+                        name:
+                          type: string
+                          maxLength: 100
+                        size:
+                          type: number
+                          format: float
+                        extension:
+                          type: string
+                          maxLength: 4
+                      required:
+                        - id
+                        - name
+                        - size
+                        - extension
+                      additionalProperties: false
+                  required:
+                    - name
+                    - file
+                  additionalProperties: false
+              required:
+                - message
+              additionalProperties: false
       responses:
         "200":
           description: Message created.
@@ -4255,22 +4662,22 @@ paths:
       parameters:
         - name: innovationId
           in: path
-          description: Innovation ID
           required: true
           schema:
             type: string
+            format: uuid
         - name: threadId
           in: path
-          description: Thread ID
           required: true
           schema:
             type: string
+            format: uuid
         - name: messageId
           in: path
-          description: Message ID
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: Success
@@ -4305,24 +4712,23 @@ paths:
       parameters:
         - name: innovationId
           in: path
-          description: Innovation Id
           required: true
           schema:
             type: string
+            format: uuid
         - name: threadId
           in: path
-          description: Thread Id
           required: true
           schema:
             type: string
+            format: uuid
         - name: messageId
           in: path
-          description: Message Id
           required: true
           schema:
             type: string
+            format: uuid
       requestBody:
-        description: Message
         required: true
         content:
           application/json:
@@ -4331,7 +4737,10 @@ paths:
               properties:
                 message:
                   type: string
-                  description: Message
+                  maxLength: 4000
+              required:
+                - message
+              additionalProperties: false
       responses:
         "200":
           description: Success
@@ -4358,11 +4767,12 @@ paths:
       description: Get details of pending innovations transfers
       operationId: v1-innovation-transfer-check
       parameters:
-        - in: path
-          name: transferId
+        - name: transferId
+          in: path
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: Ok
@@ -4382,10 +4792,25 @@ paths:
       operationId: createInnovationTransfer
       parameters: []
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                innovationId:
+                  type: string
+                  format: uuid
+                ownerToCollaborator:
+                  type: boolean
+              required:
+                - email
+                - innovationId
+                - ownerToCollaborator
+              additionalProperties: false
       responses:
         "200":
           description: Success
@@ -4424,6 +4849,7 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
       responses:
         "200":
           description: Success
@@ -4444,9 +4870,9 @@ paths:
         - name: transferId
           in: path
           required: true
-          description: The innovation transfer id
           schema:
             type: string
+            format: uuid
       requestBody:
         description: The innovation transfer status
         required: true
@@ -4454,6 +4880,16 @@ paths:
           application/json:
             schema:
               type: object
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - CANCELED
+                    - DECLINED
+                    - COMPLETED
+              required:
+                - status
+              additionalProperties: false
       responses:
         "204":
           description: The innovation transfer status has been updated

--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -614,9 +614,9 @@ paths:
                   id:
                     type: string
                     format: uuid
-                    description: The innovation assessment id.
                 required:
                   - id
+                additionalProperties: false
         "400":
           description: The innovation assessment has not been created.
         "401":

--- a/apps/innovations/v1-innovation-activities-log-list/index.ts
+++ b/apps/innovations/v1-innovation-activities-log-list/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationsService } from '../_services/innovations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType, QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1InnovationsActivitiesLogList {
@@ -67,117 +67,11 @@ export default openApi(V1InnovationsActivitiesLogList.httpTrigger as AzureFuncti
     operationId: 'v1-innovation-activities-log-list',
     description: 'Get activities log list of an Innovation',
     tags: ['[v1] Innovation Activities Log'],
-    parameters: SwaggerHelper.paramJ2S( { query: QueryParamsSchema, path: ParamsSchema }),
+    parameters: SwaggerHelper.paramJ2S({ query: QueryParamsSchema, path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                count: {
-                  type: 'number'
-                },
-                innovation: {
-                  type: 'object',
-                  properties: {
-                    id: {
-                      type: 'string'
-                    },
-                    name: {
-                      type: 'string'
-                    }
-                  }
-                },
-                data: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      type: {
-                        type: 'string'
-                      },
-                      activity: {
-                        type: 'string'
-                      },
-                      date: {
-                        type: 'number'
-                      },
-                      params: {
-                        type: 'object',
-                        properties: {
-                          actionUserId: {
-                            type: 'string'
-                          },
-                          interveningUserId: {
-                            type: 'string'
-                          },
-                          assessmentId: {
-                            type: 'string'
-                          },
-                          sectionId: {
-                            type: 'string'
-                          },
-                          actionId: {
-                            type: 'string'
-                          },
-                          innovationSupportStatus: {
-                            type: 'string'
-                          },
-                          organisations: {
-                            type: 'array',
-                            items: {
-                              type: 'string'
-                            }
-                          },
-                          organisationUnit: {
-                            type: 'string'
-                          },
-                          comment: {
-                            type: 'object',
-                            properties: {
-                              id: {
-                                type: 'string'
-                              },
-                              value: {
-                                type: 'string'
-                              }
-                            }
-                          },
-                          totalActions: {
-                            type: 'number'
-                          },
-                          thread: {
-                            type: 'object',
-                            properties: {
-                              id: {
-                                type: 'string'
-                              },
-                              subject: {
-                                type: 'string'
-                              },
-                              messageId: {
-                                type: 'string'
-                              }
-                            }
-                          },
-                          actionUserName: {
-                            type: 'string'
-                          },
-                          interveningUserName: {
-                            type: 'string'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       500: {
         description: 'An error occurred while processing the request.'
       }

--- a/apps/innovations/v1-innovation-activities-log-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-activities-log-list/transformation.dtos.ts
@@ -1,5 +1,6 @@
-import type { ActivityEnum, ActivityTypeEnum } from '@innovations/shared/enums';
+import { ActivityEnum, ActivityTypeEnum } from '@innovations/shared/enums';
 import type { ActivityLogListParamsType } from '@innovations/shared/types';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   count: number;
@@ -11,3 +12,23 @@ export type ResponseDTO = {
     params: ActivityLogListParamsType;
   }[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  count: Joi.number().integer().required(),
+  innovation: Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required()
+  }).required(),
+  data: Joi.array()
+    .items(
+      Joi.object({
+        type: Joi.string()
+          .valid(...Object.values(ActivityTypeEnum))
+          .required(),
+        activity: Joi.string().valid(...Object.values(ActivityEnum)),
+        date: Joi.date().required(),
+        params: Joi.object<ActivityLogListParamsType>().required()
+      })
+    )
+    .required()
+});

--- a/apps/innovations/v1-innovation-all-sections-list/index.ts
+++ b/apps/innovations/v1-innovation-all-sections-list/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -55,7 +55,7 @@ export default openApi(GetInnovationAllSectionsList.httpTrigger as AzureFunction
     tags: ['Innovation'],
     summary: 'Get an innovation sections list details.',
     operationId: 'v1-innovation-all-sections-list',
-    parameters: [{ in: 'path', name: 'innovationId', required: true, schema: { type: 'string' } }],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
       200: {
         description: 'Success',

--- a/apps/innovations/v1-innovation-all-sections-list/index.ts
+++ b/apps/innovations/v1-innovation-all-sections-list/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 
 import type { InnovationSectionsService } from '../_services/innovation-sections.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType, QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class GetInnovationAllSectionsList {
@@ -57,16 +57,9 @@ export default openApi(GetInnovationAllSectionsList.httpTrigger as AzureFunction
     operationId: 'v1-innovation-all-sections-list',
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object'
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       401: {
         description: 'Unauthorized'
       },

--- a/apps/innovations/v1-innovation-all-sections-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-all-sections-list/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { InnovationSectionStatusEnum } from '@innovations/shared/enums';
+import { InnovationSectionStatusEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   section: {
@@ -10,3 +11,19 @@ export type ResponseDTO = {
   };
   data: Record<string, any>;
 }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    section: Joi.object({
+      section: Joi.string().required(),
+      status: Joi.string().valid(...Object.values(InnovationSectionStatusEnum)),
+      submittedAt: Joi.date().optional(),
+      submittedBy: Joi.object({
+        name: Joi.string().required(),
+        displayTag: Joi.string().required()
+      }).optional(),
+      openTasksCount: Joi.number().integer().required()
+    }),
+    data: Joi.object().pattern(Joi.string(), Joi.any)
+  })
+);

--- a/apps/innovations/v1-innovation-assessment-assessor-update/index.ts
+++ b/apps/innovations/v1-innovation-assessment-assessor-update/index.ts
@@ -13,7 +13,7 @@ import { container } from '../_config';
 
 import type { InnovationAssessmentsService } from '../_services/innovation-assessments.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationAssessmentAssessorUpdate {
@@ -67,26 +67,9 @@ export default openApi(
         description: 'The new assessor to be assigned.'
       }),
       responses: {
-        200: {
-          description: 'The assigned assessor has been successfully updated.',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  assessmentId: {
-                    type: 'string',
-                    format: 'uuid'
-                  },
-                  assessorId: {
-                    type: 'string',
-                    format: 'uuid'
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'The assigned assessor has been successfully updated.'
+        }),
         400: {
           description: 'Bad request. Validation error.'
         },

--- a/apps/innovations/v1-innovation-assessment-assessor-update/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-assessment-assessor-update/transformation.dtos.ts
@@ -1,4 +1,11 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   assessmentId: string;
   assessorId: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  assessmentId: Joi.string().uuid().required(),
+  assessorId: Joi.string().uuid().required()
+});

--- a/apps/innovations/v1-innovation-assessment-create/index.ts
+++ b/apps/innovations/v1-innovation-assessment-create/index.ts
@@ -13,7 +13,7 @@ import { container } from '../_config';
 
 import type { InnovationAssessmentsService } from '../_services/innovation-assessments.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class CreateInnovationAssessment {
@@ -64,24 +64,9 @@ export default openApi(CreateInnovationAssessment.httpTrigger as AzureFunction, 
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'The innovation assessment data.', required: true }),
     responses: {
-      200: {
-        description: 'The innovation assessment has been created.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string',
-                  format: 'uuid',
-                  description: 'The innovation assessment id.'
-                }
-              },
-              required: ['id']
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The innovation assessment has been created.'
+      }),
       400: {
         description: 'The innovation assessment has not been created.'
       },

--- a/apps/innovations/v1-innovation-assessment-create/index.ts
+++ b/apps/innovations/v1-innovation-assessment-create/index.ts
@@ -3,7 +3,7 @@ import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { Audit, ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationStatusEnum } from '@innovations/shared/enums';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import { ActionEnum, TargetEnum } from '@innovations/shared/services/integrations/audit.service';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -61,36 +61,8 @@ export default openApi(CreateInnovationAssessment.httpTrigger as AzureFunction, 
     description: 'Create an innovation assessment.',
     operationId: 'v1-innovation-assessment-create',
     tags: ['Innovation Assessment'],
-    parameters: [
-      {
-        name: 'innovationId',
-        in: 'path',
-        description: 'The innovation id.',
-        required: true,
-        schema: {
-          type: 'string',
-          format: 'uuid'
-        }
-      }
-    ],
-    requestBody: {
-      description: 'The innovation assessment data.',
-      required: true,
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              comment: {
-                type: 'string',
-                description: 'The comment for the assessment.'
-              }
-            },
-            required: ['comment']
-          }
-        }
-      }
-    },
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+    requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'The innovation assessment data.', required: true }),
     responses: {
       200: {
         description: 'The innovation assessment has been created.',

--- a/apps/innovations/v1-innovation-assessment-create/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-assessment-create/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-assessment-edit/index.ts
+++ b/apps/innovations/v1-innovation-assessment-edit/index.ts
@@ -13,7 +13,7 @@ import { container } from '../_config';
 
 import type { InnovationAssessmentsService } from '../_services/innovation-assessments.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class EditInnovationAssessment {
@@ -64,24 +64,9 @@ export default openApi(EditInnovationAssessment.httpTrigger as AzureFunction, '/
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
-      200: {
-        description: 'The minor assessment version has been created.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string',
-                  format: 'uuid',
-                  description: 'The innovation assessment id.'
-                }
-              },
-              required: ['id']
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The minor assessment version has been created.'
+      }),
       400: {
         description: 'The minor assessment version has not been created.'
       },

--- a/apps/innovations/v1-innovation-assessment-edit/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-assessment-edit/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-assessment-info/index.ts
+++ b/apps/innovations/v1-innovation-assessment-info/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 
 import type { InnovationAssessmentsService } from '../_services/innovation-assessments.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationAssessmentInfo {
@@ -100,83 +100,9 @@ export default openApi(
       operationId: 'v1-innovation-assessment-info',
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
-          description: 'Success',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  id: { type: 'string', format: 'uuid' },
-                  summary: { type: 'string' },
-                  description: { type: 'string' },
-                  finishedAt: { type: 'string', format: 'date-time' },
-                  assignTo: {
-                    type: 'object',
-                    properties: {
-                      id: { type: 'string', format: 'uuid' },
-                      name: { type: 'string' }
-                    }
-                  },
-                  maturityLevel: { type: 'string' },
-                  maturityLevelComment: { type: 'string' },
-                  hasRegulatoryApprovals: { type: 'boolean' },
-                  hasRegulatoryApprovalsComment: { type: 'string' },
-                  hasEvidence: { type: 'boolean' },
-                  hasEvidenceComment: { type: 'string' },
-                  hasValidation: { type: 'boolean' },
-                  hasValidationComment: { type: 'string' },
-                  hasProposition: { type: 'boolean' },
-                  hasPropositionComment: { type: 'string' },
-                  hasCompetitionKnowledge: { type: 'boolean' },
-                  hasCompetitionKnowledgeComment: { type: 'string' },
-                  hasImplementationPlan: { type: 'boolean' },
-                  hasImplementationPlanComment: { type: 'string' },
-                  hasScaleResource: { type: 'boolean' },
-                  hasScaleResourceComment: { type: 'string' },
-                  suggestedOrganisations: {
-                    type: 'array',
-                    items: {
-                      type: 'object',
-                      properties: {
-                        id: { type: 'string', format: 'uuid' },
-                        name: { type: 'string' },
-                        acronym: { type: 'string' },
-                        units: {
-                          type: 'array',
-                          items: {
-                            type: 'object',
-                            properties: {
-                              id: { type: 'string', format: 'uuid' },
-                              name: { type: 'string' },
-                              acronym: { type: 'string' },
-                              organisation: {
-                                type: 'object',
-                                properties: {
-                                  id: { type: 'string', format: 'uuid' },
-                                  name: { type: 'string' },
-                                  acronym: { type: 'string' }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  updatedAt: { type: 'string', format: 'date-time' },
-                  updatedBy: {
-                    type: 'object',
-                    properties: {
-                      id: { type: 'string', format: 'uuid' },
-                      name: { type: 'string' }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Success'
+        }),
         400: {
           description: 'Bad Request'
         },

--- a/apps/innovations/v1-innovation-assessment-info/index.ts
+++ b/apps/innovations/v1-innovation-assessment-info/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { Audit, JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import { ActionEnum, TargetEnum } from '@innovations/shared/services/integrations/audit.service';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -98,28 +98,7 @@ export default openApi(
       description: 'Get Innovation Assessment Info',
       tags: ['Innovation Assessment Info'],
       operationId: 'v1-innovation-assessment-info',
-      parameters: [
-        {
-          name: 'innovationId',
-          in: 'path',
-          description: 'Innovation Id',
-          required: true,
-          schema: {
-            type: 'string',
-            format: 'uuid'
-          }
-        },
-        {
-          name: 'assessmentId',
-          in: 'path',
-          description: 'Assessment Id',
-          required: true,
-          schema: {
-            type: 'string',
-            format: 'uuid'
-          }
-        }
-      ],
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
         200: {
           description: 'Success',

--- a/apps/innovations/v1-innovation-assessment-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-assessment-info/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { ReassessmentType } from '../_types/innovation.types';
+import Joi from 'joi';
+import { ReassessmentReasons, type ReassessmentType } from '../_types/innovation.types';
 
 export type ResponseDTO = {
   id: string;
@@ -38,3 +39,69 @@ export type ResponseDTO = {
   updatedBy: { id: string; name: string };
   isLatest: boolean;
 };
+
+export const ResponseBodySchema = Joi.object({
+  id: Joi.string().uuid().required(),
+  majorVersion: Joi.number().integer().required(),
+  minorVersion: Joi.number().integer().required(),
+  editReason: Joi.string().allow(null),
+  previousAssessment: Joi.object({
+    id: Joi.string().uuid().required(),
+    majorVersion: Joi.number().integer().required(),
+    minorVersion: Joi.number().integer().required()
+  }).optional(),
+  reassessment: Joi.object({
+    reassessmentReason: Joi.array()
+      .items(Joi.string().valid(...ReassessmentReasons))
+      .allow(null)
+      .required(),
+    otherReassessmentReason: Joi.string().required(),
+    description: Joi.string().required(),
+    whatSupportDoYouNeed: Joi.string().allow(null).required(),
+    sectionsUpdatedSinceLastAssessment: Joi.array().items(Joi.string()).required()
+  }).optional(),
+  summary: Joi.string().allow(null).required(),
+  description: Joi.string().allow(null).required(),
+  startedAt: Joi.date().allow(null).required(),
+  finishedAt: Joi.date().allow(null).required(),
+  assignTo: Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required()
+  }).optional(),
+  maturityLevel: Joi.string().allow(null).required(),
+  maturityLevelComment: Joi.string().allow(null).required(),
+  hasRegulatoryApprovals: Joi.string().allow(null).required(),
+  hasRegulatoryApprovalsComment: Joi.string().allow(null).required(),
+  hasEvidence: Joi.string().allow(null).required(),
+  hasEvidenceComment: Joi.string().allow(null).required(),
+  hasValidation: Joi.string().allow(null).required(),
+  hasValidationComment: Joi.string().allow(null).required(),
+  hasProposition: Joi.string().allow(null).required(),
+  hasPropositionComment: Joi.string().allow(null).required(),
+  hasCompetitionKnowledge: Joi.string().allow(null).required(),
+  hasCompetitionKnowledgeComment: Joi.string().allow(null).required(),
+  hasImplementationPlan: Joi.string().allow(null).required(),
+  hasImplementationPlanComment: Joi.string().allow(null).required(),
+  hasScaleResource: Joi.string().allow(null).required(),
+  hasScaleResourceComment: Joi.string().allow(null).required(),
+  suggestedOrganisations: Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required(),
+    acronym: Joi.string().allow(null).required(),
+    units: Joi.array()
+      .items(
+        Joi.object({
+          id: Joi.string().uuid().required(),
+          name: Joi.string().required(),
+          acronym: Joi.string().required()
+        })
+      )
+      .required()
+  }).required(),
+  updatedAt: Joi.date().allow(null).required(),
+  updatedBy: Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required()
+  }).required(),
+  isLatest: Joi.boolean().required()
+});

--- a/apps/innovations/v1-innovation-assessment-kpi-exemption-info/index.ts
+++ b/apps/innovations/v1-innovation-assessment-kpi-exemption-info/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationAssessmentsService } from '../_services/innovation-assessments.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationAssessmentKPIExemptionInfo {
@@ -56,27 +56,9 @@ export default openApi(
       tags: ['[v1] Innovation Assessment'],
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
-          description: 'Success',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  isExempted: { type: 'boolean' },
-                  exemption: {
-                    type: 'object',
-                    properties: {
-                      reason: { type: 'string' },
-                      message: { type: 'string' },
-                      exemptedAt: { type: 'string', format: 'date-time' }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Success'
+        }),
         400: { description: 'The request is invalid.' },
         401: { description: 'The user is not authenticated.' },
         403: { description: 'The user is not authorized to access this resource.' },

--- a/apps/innovations/v1-innovation-assessment-kpi-exemption-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-assessment-kpi-exemption-info/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { InnovationAssessmentKPIExemptionType } from '@innovations/shared/types';
+import { InnovationAssessmentKPIExemption, type InnovationAssessmentKPIExemptionType } from '@innovations/shared/types';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   isExempted: boolean;
@@ -8,3 +9,14 @@ export type ResponseDTO = {
     exemptedAt: Date;
   };
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  isExempted: Joi.boolean().required(),
+  exemption: Joi.object({
+    reason: Joi.string()
+      .valid(...InnovationAssessmentKPIExemption)
+      .required(),
+    message: Joi.string().optional(),
+    exemptedAt: Joi.date()
+  }).optional()
+});

--- a/apps/innovations/v1-innovation-assessment-update/index.ts
+++ b/apps/innovations/v1-innovation-assessment-update/index.ts
@@ -3,7 +3,7 @@ import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { Audit, ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationStatusEnum } from '@innovations/shared/enums';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import { ActionEnum, TargetEnum } from '@innovations/shared/services/integrations/audit.service';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -70,50 +70,8 @@ export default openApi(
       summary: 'Update an innovation assessment',
       description: 'Update an innovation assessment.',
       operationId: 'v1-innovation-assessment-update',
-      parameters: [
-        {
-          name: 'innovationId',
-          in: 'path',
-          description: 'Innovation ID',
-          required: true,
-          schema: {
-            type: 'string',
-            format: 'uuid'
-          }
-        },
-        {
-          name: 'assessmentId',
-          in: 'path',
-          description: 'Assessment ID',
-          required: true,
-          schema: {
-            type: 'string',
-            format: 'uuid'
-          }
-        }
-      ],
-      requestBody: {
-        description: 'Innovation assessment update request body.',
-        required: true,
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                status: {
-                  type: 'string',
-                  enum: ['APPROVED', 'REJECTED']
-                },
-                comment: {
-                  type: 'string',
-                  maxLength: 1000
-                }
-              },
-              required: ['status']
-            }
-          }
-        }
-      },
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+      requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'Innovation assessment update request body.' }),
       responses: {
         200: {
           description: 'Returns the updated innovation assessment.',

--- a/apps/innovations/v1-innovation-assessment-update/index.ts
+++ b/apps/innovations/v1-innovation-assessment-update/index.ts
@@ -13,7 +13,7 @@ import { container } from '../_config';
 
 import type { InnovationAssessmentsService } from '../_services/innovation-assessments.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationAssessmentUpdate {
@@ -73,46 +73,9 @@ export default openApi(
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'Innovation assessment update request body.' }),
       responses: {
-        200: {
-          description: 'Returns the updated innovation assessment.',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string',
-                    format: 'uuid'
-                  },
-                  innovationId: {
-                    type: 'string',
-                    format: 'uuid'
-                  },
-                  assessmentId: {
-                    type: 'string',
-                    format: 'uuid'
-                  },
-                  status: {
-                    type: 'string',
-                    enum: ['APPROVED', 'REJECTED']
-                  },
-                  comment: {
-                    type: 'string',
-                    maxLength: 1000
-                  },
-                  createdAt: {
-                    type: 'string',
-                    format: 'date-time'
-                  },
-                  updatedAt: {
-                    type: 'string',
-                    format: 'date-time'
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Returns the updated innovation assessment.'
+        }),
         400: {
           description: 'Bad request. Validation error.'
         },

--- a/apps/innovations/v1-innovation-assessment-update/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-assessment-update/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-assessments-list/index.ts
+++ b/apps/innovations/v1-innovation-assessments-list/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationAssessmentsService } from '../_services/innovation-assessments.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationAssessmentsList {
@@ -50,7 +50,9 @@ export default openApi(V1InnovationAssessmentsList.httpTrigger as AzureFunction,
     operationId: 'v1-innovation-assessments-list',
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: { description: 'Returns the complete assessments' },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Returns the complete assessments'
+      }),
       400: { description: 'Bad Request' },
       401: { description: 'Unauthorized' },
       403: { description: 'Forbidden' },

--- a/apps/innovations/v1-innovation-assessments-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-assessments-list/transformation.dtos.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
   majorVersion: number;
@@ -5,3 +7,13 @@ export type ResponseDTO = {
   startedAt: Date;
   finishedAt: Date;
 }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    id: Joi.string().uuid().required(),
+    majorVersion: Joi.number().integer().required(),
+    minorVersion: Joi.number().integer().required(),
+    startedAt: Joi.date().required(),
+    finishedAt: Joi.date().required()
+  })
+);

--- a/apps/innovations/v1-innovation-collaboration-check/index.ts
+++ b/apps/innovations/v1-innovation-collaboration-check/index.ts
@@ -4,7 +4,7 @@ import type { AzureFunction, Context, HttpRequest } from '@azure/functions';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 
 import { container } from '../_config';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 
 import type { InnovationCollaboratorsService } from '../_services/innovation-collaborators.service';
 import SYMBOLS from '../_services/symbols';
@@ -43,23 +43,9 @@ export default openApi(
       tags: ['[v1] Innovation Collaborators'],
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
-          description: 'Success',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  userExists: { type: 'boolean', description: 'User exists in service' },
-                  collaboratorStatus: {
-                    type: 'string',
-                    description: 'Status of the collaborator invite'
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Success'
+        }),
         404: {
           description: 'Not Found'
         }

--- a/apps/innovations/v1-innovation-collaboration-check/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-collaboration-check/transformation.dtos.ts
@@ -1,6 +1,12 @@
-import type { InnovationCollaboratorStatusEnum } from '@innovations/shared/enums';
+import { InnovationCollaboratorStatusEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   userExists: boolean;
   collaboratorStatus: InnovationCollaboratorStatusEnum;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  userExists: Joi.boolean().required(),
+  collaboratorStatus: Joi.string().valid(...Object.values(InnovationCollaboratorStatusEnum))
+});

--- a/apps/innovations/v1-innovation-collaborator-create/index.ts
+++ b/apps/innovations/v1-innovation-collaborator-create/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationCollaboratorsService } from '../_services/innovation-collaborators.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationCollaboratorCreate {
@@ -59,24 +59,9 @@ export default openApi(
         description: 'The collaborator to be invited.'
       }),
       responses: {
-        200: {
-          description: 'The collaborator has been created.',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string',
-                    description: 'The collaborator id.',
-                    example: 'c0a80121-7ac0-464e-b8f6-27b88b0cda7f'
-                  }
-                },
-                required: ['id']
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'The collaborator has been created.'
+        }),
         400: {
           description: 'The collaborator could not be created.'
         },

--- a/apps/innovations/v1-innovation-collaborator-create/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-collaborator-create/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-collaborator-info/index.ts
+++ b/apps/innovations/v1-innovation-collaborator-info/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationCollaboratorsService } from '../_services/innovation-collaborators.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationCollaboratorInfo {
@@ -70,66 +70,9 @@ export default openApi(
       tags: ['[v1] Innovation Collaborators'],
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
-          description: 'The innovation collaborator information.',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string',
-                    format: 'uuid'
-                  },
-                  name: {
-                    type: 'string'
-                  },
-                  role: {
-                    type: 'string'
-                  },
-                  email: {
-                    type: 'string'
-                  },
-                  status: {
-                    type: 'string',
-                    enum: ['PENDING', 'ACTIVE', 'DECLINED', 'CANCELLED', 'REMOVED', 'LEFT', 'EXPIRED']
-                  },
-                  invitedAt: {
-                    type: 'string',
-                    format: 'date-time'
-                  },
-                  innovation: {
-                    type: 'object',
-                    properties: {
-                      id: {
-                        type: 'string',
-                        format: 'uuid'
-                      },
-                      name: {
-                        type: 'string'
-                      },
-                      description: {
-                        type: 'string'
-                      },
-                      owner: {
-                        type: 'object',
-                        properties: {
-                          id: {
-                            type: 'string',
-                            format: 'uuid'
-                          },
-                          name: {
-                            type: 'string'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'The innovation collaborator information.'
+        }),
         401: {
           description: 'Unauthorized'
         },

--- a/apps/innovations/v1-innovation-collaborator-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-collaborator-info/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { InnovationCollaboratorStatusEnum } from '@innovations/shared/enums';
+import { InnovationCollaboratorStatusEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
@@ -17,3 +18,21 @@ export type ResponseDTO = {
   };
   invitedAt: Date;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().required(),
+  name: Joi.string().optional(),
+  role: Joi.string().optional(),
+  email: Joi.string().required(),
+  status: Joi.string().valid(...Object.values(InnovationCollaboratorStatusEnum)),
+  innovation: Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required(),
+    description: Joi.string().optional(),
+    owner: Joi.object({
+      id: Joi.string().uuid().required(),
+      name: Joi.string().optional()
+    }).optional()
+  }).required(),
+  invitedAt: Joi.date().required()
+});

--- a/apps/innovations/v1-innovation-collaborator-update/index.ts
+++ b/apps/innovations/v1-innovation-collaborator-update/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationCollaboratorsService } from '../_services/innovation-collaborators.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationCollaboratorUpdate {
@@ -67,24 +67,9 @@ export default openApi(
         description: 'The information to update collaborator invite.'
       }),
       responses: {
-        200: {
-          description: 'The collaborator has been updated.',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string',
-                    description: 'The collaborator id.',
-                    example: 'c0a80121-7ac0-464e-b8f6-27b88b0cda7f'
-                  }
-                },
-                required: ['id']
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'The collaborator has been updated.'
+        }),
         400: {
           description: 'The collaborator could not be updated.'
         },

--- a/apps/innovations/v1-innovation-collaborator-update/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-collaborator-update/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-collaborators-list/index.ts
+++ b/apps/innovations/v1-innovation-collaborators-list/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 
 import type { InnovationCollaboratorsService } from '../_services/innovation-collaborators.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType, QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1InnovationCollaboratorsList {
@@ -73,45 +73,9 @@ export default openApi(V1InnovationCollaboratorsList.httpTrigger as AzureFunctio
     tags: ['[v1] Innovation Collaborators'],
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'The list of innovation collaborators.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                count: {
-                  type: 'integer',
-                  description: 'The total number of records.'
-                },
-                data: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      id: {
-                        type: 'string'
-                      },
-                      name: {
-                        type: 'string'
-                      },
-                      role: {
-                        type: 'string'
-                      },
-                      email: {
-                        type: 'string'
-                      },
-                      status: {
-                        type: 'string'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The list of innovation collaborators.'
+      }),
       400: {
         description: 'The request is invalid.'
       },

--- a/apps/innovations/v1-innovation-collaborators-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-collaborators-list/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { InnovationCollaboratorStatusEnum } from '@innovations/shared/enums';
+import { InnovationCollaboratorStatusEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   count: number;
@@ -11,3 +12,19 @@ export type ResponseDTO = {
     isActive?: boolean;
   }[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  count: Joi.number().integer().required(),
+  data: Joi.array()
+    .items(
+      Joi.object({
+        id: Joi.string().uuid().required(),
+        name: Joi.string().optional(),
+        role: Joi.string().optional(),
+        email: Joi.string().optional(),
+        status: Joi.string().valid(...Object.values(InnovationCollaboratorStatusEnum)),
+        isActive: Joi.boolean().optional()
+      })
+    )
+    .required()
+});

--- a/apps/innovations/v1-innovation-create/index.ts
+++ b/apps/innovations/v1-innovation-create/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 
 import type { InnovationsService } from '../_services/innovations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import {
   BodySchema,
   BodySchemaAfterCalculatedFieldsSchema,
@@ -66,19 +66,9 @@ export default openApi(V1InnovationCreate.httpTrigger as AzureFunction, '/v1', {
       description: 'The innovation to be created.'
     }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string', description: 'Unique identifier for innovation object' }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: { description: 'Invalid innovation payload' },
       422: { description: 'Unprocessable entity' }
     }

--- a/apps/innovations/v1-innovation-create/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-create/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-evidence-create/index.ts
+++ b/apps/innovations/v1-innovation-evidence-create/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationSectionsService } from '../_services/innovation-sections.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationEvidenceCreate {
@@ -60,19 +60,9 @@ export default openApi(V1InnovationEvidenceCreate.httpTrigger as AzureFunction, 
       description: 'The evidence data to create.'
     }),
     responses: {
-      200: {
-        description: 'Innovation evidence info.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string', description: 'Evidence id.' }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Innovation evidence info.'
+      }),
       400: {
         description: 'Bad Request'
       },

--- a/apps/innovations/v1-innovation-evidence-create/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-evidence-create/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-file-create/index.ts
+++ b/apps/innovations/v1-innovation-file-create/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 import { ServiceRoleEnum } from '@innovations/shared/enums';
 import type { InnovationFileService } from '../_services/innovation-file.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationFileCreate {
@@ -59,20 +59,9 @@ export default openApi(V1InnovationFileCreate.httpTrigger as AzureFunction, '/v1
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
-      200: {
-        description: 'The innovation file has been created.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string' }
-              },
-              required: ['id']
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The innovation file has been created.'
+      }),
       400: {
         description: 'The innovation file could not be created.'
       },

--- a/apps/innovations/v1-innovation-file-create/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-file-create/transformation.dtos.ts
@@ -1,1 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = { id: string };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().required()
+});

--- a/apps/innovations/v1-innovation-file-info/index.ts
+++ b/apps/innovations/v1-innovation-file-info/index.ts
@@ -9,10 +9,9 @@ import type { CustomContextType } from '@innovations/shared/types';
 
 import { container } from '../_config';
 
-import { InnovationFileContextTypeEnum, ServiceRoleEnum } from '@innovations/shared/enums';
 import type { InnovationFileService } from '../_services/innovation-file.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationFileInfo {
@@ -72,54 +71,9 @@ export default openApi(V1InnovationFileInfo.httpTrigger as AzureFunction, '/v1/{
     tags: ['[v1] Innovation Files'],
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string' },
-                context: {
-                  type: 'object',
-                  properties: {
-                    id: { type: 'string' },
-                    type: {
-                      type: 'string',
-                      enum: Object.values(InnovationFileContextTypeEnum)
-                    }
-                  }
-                },
-                name: { type: 'string' },
-                description: { type: 'string' },
-                createdAt: { type: 'string' },
-                createdBy: {
-                  type: 'object',
-                  properties: {
-                    name: { type: 'string' },
-                    role: {
-                      type: 'string',
-                      enum: Object.values(ServiceRoleEnum)
-                    },
-                    isOwner: { type: 'boolean' },
-                    orgUnitName: { type: 'string' }
-                  }
-                },
-                file: {
-                  type: 'object',
-                  properties: {
-                    id: { type: 'string', description: 'Storage Id' },
-                    name: { type: 'string' },
-                    size: { type: 'number' },
-                    extension: { type: 'string' },
-                    url: { type: 'string' }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: {
         description: 'The request is invalid.'
       },

--- a/apps/innovations/v1-innovation-file-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-file-info/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { InnovationFileContextTypeEnum, ServiceRoleEnum } from '@innovations/shared/enums';
+import { InnovationFileContextTypeEnum, ServiceRoleEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
@@ -10,3 +11,31 @@ export type ResponseDTO = {
   file: { id: string; name: string; size?: number; extension: string; url: string };
   canDelete: boolean;
 };
+
+export const ResponseBodySchema = Joi.object({
+  id: Joi.string().uuid().required(),
+  context: Joi.object({
+    id: Joi.string().uuid().required(),
+    type: Joi.string().valid(...Object.values(InnovationFileContextTypeEnum)),
+    name: Joi.string().optional()
+  }),
+  name: Joi.string().required(),
+  description: Joi.string().optional(),
+  createdAt: Joi.date().required(),
+  createdBy: Joi.object({
+    name: Joi.string().required(),
+    role: Joi.string()
+      .valid(...Object.values(ServiceRoleEnum))
+      .required(),
+    isOwner: Joi.boolean().optional(),
+    orgUnitName: Joi.string().optional()
+  }),
+  file: Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required(),
+    size: Joi.number().optional(),
+    extension: Joi.string().required(),
+    url: Joi.string().required()
+  }).required(),
+  canDelete: Joi.boolean().required()
+});

--- a/apps/innovations/v1-innovation-file-upload-url/index.ts
+++ b/apps/innovations/v1-innovation-file-upload-url/index.ts
@@ -11,7 +11,7 @@ import type { CustomContextType } from '@innovations/shared/types';
 
 import type { InnovationFileService } from '../_services/innovation-file.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationFileUploadUrl {
@@ -57,21 +57,9 @@ export default openApi(V1InnovationFileUploadUrl.httpTrigger as AzureFunction, '
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string' },
-                name: { type: 'string' },
-                url: { type: 'string', description: 'url for file upload' }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: { description: 'Invalid payload' },
       404: { description: 'Innovation not found' }
     }

--- a/apps/innovations/v1-innovation-file-upload-url/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-file-upload-url/transformation.dtos.ts
@@ -1,5 +1,13 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
   name: string;
   url: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().required(),
+  name: Joi.string().required(),
+  url: Joi.string().required()
+});

--- a/apps/innovations/v1-innovation-files-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-files-list/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { InnovationFileContextTypeEnum, ServiceRoleEnum } from '@innovations/shared/enums';
+import { InnovationFileContextTypeEnum, ServiceRoleEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   count: number;
@@ -12,3 +13,33 @@ export type ResponseDTO = {
     file: { id: string; name: string; size?: number; extension: string; url: string };
   }[];
 };
+
+export const ResponseBodySchema = Joi.object({
+  count: Joi.number().integer().required(),
+  data: Joi.array().items(
+    Joi.object({
+      id: Joi.string().uuid().required(),
+      context: Joi.object({
+        id: Joi.string().uuid().optional(),
+        type: Joi.string().valid(...Object.values(InnovationFileContextTypeEnum)),
+        name: Joi.string().optional()
+      }).required(),
+      name: Joi.string().required(),
+      description: Joi.string().optional(),
+      createdAt: Joi.date().required(),
+      createdBy: Joi.object({
+        name: Joi.string().required(),
+        role: Joi.string().valid(...Object.values(ServiceRoleEnum)),
+        isOwner: Joi.boolean().optional(),
+        orgUnitName: Joi.string().optional()
+      }).required(),
+      file: Joi.object({
+        id: Joi.string().uuid().required(),
+        name: Joi.string().required(),
+        size: Joi.number().optional(),
+        extension: Joi.string().required(),
+        url: Joi.string().required()
+      })
+    })
+  )
+});

--- a/apps/innovations/v1-innovation-info/index.ts
+++ b/apps/innovations/v1-innovation-info/index.ts
@@ -3,7 +3,7 @@ import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { Audit, JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationStatusEnum, ServiceRoleEnum } from '@innovations/shared/enums';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import { ActionEnum, TargetEnum } from '@innovations/shared/services/integrations/audit.service';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -107,18 +107,7 @@ export default openApi(V1InnovationInfo.httpTrigger as AzureFunction, '/v1/{inno
     operationId: 'v1-innovation-info',
     description: 'Get innovation information.',
     tags: ['[v1] Innovation'],
-    parameters: [
-      {
-        name: 'innovationId',
-        in: 'path',
-        required: true,
-        description: 'Innovation ID',
-        schema: {
-          type: 'string',
-          format: 'uuid'
-        }
-      }
-    ],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
       200: { description: 'Success' },
       400: { description: 'Invalid innovation payload' }

--- a/apps/innovations/v1-innovation-info/index.ts
+++ b/apps/innovations/v1-innovation-info/index.ts
@@ -13,7 +13,7 @@ import { container } from '../_config';
 
 import type { InnovationsService } from '../_services/innovations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType, QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1InnovationInfo {
@@ -109,7 +109,9 @@ export default openApi(V1InnovationInfo.httpTrigger as AzureFunction, '/v1/{inno
     tags: ['[v1] Innovation'],
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: { description: 'Success' },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: { description: 'Invalid innovation payload' }
     }
   }

--- a/apps/innovations/v1-innovation-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-info/transformation.dtos.ts
@@ -1,10 +1,79 @@
-import type {
+import {
   InnovationGroupedStatusEnum,
   InnovationStatusEnum,
   InnovationSupportStatusEnum,
   PhoneUserPreferenceEnum
 } from '@innovations/shared/enums';
-import type { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import { JoiHelper } from '@innovations/shared/helpers';
+import { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import Joi from 'joi';
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: JoiHelper.AppCustomJoi().string().uuid().required(),
+  name: Joi.string().required(),
+  description: Joi.string().allow(null).required(),
+  version: Joi.string().required(),
+  status: Joi.string()
+    .valid(...Object.values(InnovationStatusEnum))
+    .required(),
+  archivedStatus: Joi.string()
+    .valid(...Object.values(InnovationStatusEnum))
+    .optional(),
+  groupedStatus: Joi.string()
+    .valid(...Object.values(InnovationGroupedStatusEnum))
+    .required(),
+  hasBeenAssessed: Joi.boolean().required(),
+  statusUpdatedAt: Joi.date().required(),
+  submittedAt: Joi.date().allow(null).required(),
+  countryName: Joi.string().allow(null).required(),
+  postCode: Joi.string().allow(null).required(),
+  categories: Joi.array()
+    .items(Joi.string().valid(...Object.values(CurrentCatalogTypes.catalogCategory)))
+    .required(),
+  otherCategoryDescription: Joi.string().allow(null).required(),
+  owner: Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required(),
+    isActive: Joi.boolean().required(),
+    email: Joi.string().optional(),
+    contactByEmail: Joi.boolean().optional(),
+    contactByPhone: Joi.boolean().optional(),
+    contactByPhoneTimeFrame: Joi.string()
+      .valid(...Object.values(PhoneUserPreferenceEnum))
+      .allow(null)
+      .required(),
+    mobilePhone: Joi.string().allow(null).optional(),
+    lastLoginAt: Joi.date().allow(null).optional(),
+    organisation: Joi.object({
+      name: Joi.string().required(),
+      size: Joi.string().allow(null).required(),
+      registrationNumber: Joi.string().allow(null).required()
+    }).optional()
+  }).optional(),
+  lastEndSupportAt: Joi.date().allow(null).required(),
+  assessment: Joi.object({
+    id: Joi.string().uuid().required(),
+    createdAt: Joi.date().required(),
+    finishedAt: Joi.date().allow(null).required(),
+    assignedTo: Joi.object({
+      id: Joi.string().uuid().required(),
+      name: Joi.string().required(),
+      userRoleId: Joi.string().required()
+    }).optional()
+  }).optional(),
+  supports: Joi.array()
+    .items(
+      Joi.object({
+        id: Joi.string().uuid().required(),
+        status: Joi.string().valid(...Object.values(InnovationSupportStatusEnum)),
+        organisationUnitId: Joi.string().required()
+      })
+    )
+    .allow(null)
+    .optional(),
+  collaboratorId: Joi.string().required(),
+  createdAt: Joi.date().required()
+});
 
 export type ResponseDTO = {
   id: string;

--- a/apps/innovations/v1-innovation-notifications-dismiss/index.ts
+++ b/apps/innovations/v1-innovation-notifications-dismiss/index.ts
@@ -2,8 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { NotificationCategoryType } from '@innovations/shared/enums';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -48,51 +47,8 @@ export default openApi(
     patch: {
       operationId: 'v1-innovation-notifications-dismiss',
       description: 'Dismisses innovation notifications.',
-      parameters: [
-        {
-          name: 'innovationId',
-          in: 'path',
-          required: true,
-          description: 'Innovation ID',
-          schema: {
-            type: 'string',
-            format: 'uuid'
-          }
-        }
-      ],
-      requestBody: {
-        description: 'Dismiss innovation notifications request body.',
-        required: true,
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                notificationIds: {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                    format: 'uuid'
-                  }
-                },
-                notificationContext: {
-                  type: 'object',
-                  properties: {
-                    id: {
-                      type: 'string',
-                      format: 'uuid'
-                    },
-                    type: {
-                      type: 'string',
-                      enum: NotificationCategoryType
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+      requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'Dismiss innovation notifications request body.' }),
       responses: {
         204: { description: 'Success' },
         400: { description: 'Invalid payload' }

--- a/apps/innovations/v1-innovation-reassessment-request-create/index.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationAssessmentsService } from '../_services/innovation-assessments.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationReassessmentRequestCreate {
@@ -66,7 +66,9 @@ export default openApi(
         description: 'Create a reassessment request for an innovation.'
       }),
       responses: {
-        200: { description: 'Returns the reassessment request and the cloned assessment id' },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Returns the reassessment request and the cloned assessment id'
+        }),
         400: { description: 'Bad request' },
         401: { description: 'Unauthorized' },
         403: { description: 'Forbidden' },

--- a/apps/innovations/v1-innovation-reassessment-request-create/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-reassessment-request-create/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-section-info/index.ts
+++ b/apps/innovations/v1-innovation-section-info/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationSectionsService } from '../_services/innovation-sections.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType, QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class GetInnovationSectionInfo {
@@ -70,80 +70,9 @@ export default openApi(
       operationId: 'v1-innovation-section-info',
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
-          description: 'Innovation section info.',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string',
-                    description: 'Innovation section id.',
-                    example: '1'
-                  },
-                  section: {
-                    type: 'string',
-                    description: 'Innovation section key.',
-                    example: 'access'
-                  },
-                  status: {
-                    type: 'string',
-                    description: 'Innovation section status.',
-                    example: 'COMPLETED'
-                  },
-                  submittedAt: {
-                    type: 'string',
-                    description: 'Innovation section submission date.',
-                    example: '2021-01-01T00:00:00.000Z'
-                  },
-                  data: {
-                    type: 'object',
-                    description: 'Innovation section data.',
-                    properties: {
-                      name: {
-                        type: 'string',
-                        description: 'Innovation section name.',
-                        example: 'Access'
-                      },
-                      description: {
-                        type: 'string',
-                        description: 'Innovation section description.',
-                        example: 'Access description'
-                      },
-                      questions: {
-                        type: 'array',
-                        description: 'Innovation section questions.',
-                        items: {
-                          type: 'object',
-                          properties: {
-                            id: {
-                              type: 'string',
-                              description: 'Innovation section question id.',
-                              example: '1'
-                            },
-                            text: {
-                              type: 'string',
-                              description: 'Innovation section question text.',
-                              example: 'Question text'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  actionsIds: {
-                    type: 'array',
-                    items: {
-                      type: 'string',
-                      description: 'The id of the action.'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Innovation section info.'
+        }),
         401: {
           description: 'Unauthorized'
         },

--- a/apps/innovations/v1-innovation-section-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-section-info/transformation.dtos.ts
@@ -1,5 +1,6 @@
-import type { InnovationSectionStatusEnum } from '@innovations/shared/enums';
-import type { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import { InnovationSectionStatusEnum } from '@innovations/shared/enums';
+import { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: null | string;
@@ -10,3 +11,22 @@ export type ResponseDTO = {
   data: null | { [key: string]: any };
   tasksIds?: string[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().allow(null).required(),
+  section: Joi.string()
+    .valid(...Object.values(CurrentCatalogTypes.InnovationSections))
+    .required(),
+  status: Joi.string()
+    .valid(...Object.values(InnovationSectionStatusEnum))
+    .required(),
+  submittedAt: Joi.date().allow(null).required(),
+  submittedBy: Joi.object({
+    name: Joi.string().required(),
+    displayTag: Joi.string().required()
+  })
+    .allow(null)
+    .required(),
+  data: Joi.object().pattern(Joi.string, Joi.any).allow(null).required(),
+  tasksIds: Joi.array().items(Joi.string()).optional()
+});

--- a/apps/innovations/v1-innovation-section-submit/index.ts
+++ b/apps/innovations/v1-innovation-section-submit/index.ts
@@ -55,23 +55,6 @@ export default openApi(
       summary: 'Submit an innovation section.',
       operationId: 'v1-innovation-section-submit',
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
-      requestBody: {
-        description: 'Innovation section submit request body.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string',
-                  description: 'Innovation section id.',
-                  example: '1'
-                }
-              }
-            }
-          }
-        }
-      },
       responses: {
         200: {
           description: 'Innovation section submit response.'

--- a/apps/innovations/v1-innovation-section-submit/index.ts
+++ b/apps/innovations/v1-innovation-section-submit/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationSectionsService } from '../_services/innovation-sections.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationSectionSubmit {
@@ -56,9 +56,9 @@ export default openApi(
       operationId: 'v1-innovation-section-submit',
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
           description: 'Innovation section submit response.'
-        }
+        })
       }
     }
   }

--- a/apps/innovations/v1-innovation-section-submit/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-section-submit/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-section-update/index.ts
+++ b/apps/innovations/v1-innovation-section-update/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 
 import type { InnovationSectionsService } from '../_services/innovation-sections.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationSectionUpdate {
@@ -89,19 +89,9 @@ export default openApi(
         }
       },
       responses: {
-        200: {
-          description: 'Innovation section info updated successfully.',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  id: { type: 'string' }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Innovation section info updated successfully.'
+        }),
         400: { description: 'Bad request.' },
         401: { description: 'Unauthorized.' },
         403: { description: 'Forbidden.' },

--- a/apps/innovations/v1-innovation-section-update/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-section-update/transformation.dtos.ts
@@ -1,3 +1,9 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string | undefined;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().optional()
+});

--- a/apps/innovations/v1-innovation-sections-list/index.ts
+++ b/apps/innovations/v1-innovation-sections-list/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationSectionsService } from '../_services/innovation-sections.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationSectionsList {
@@ -66,55 +66,9 @@ export default openApi(V1InnovationSectionsList.httpTrigger as AzureFunction, '/
     operationId: 'v1-innovation-sections-list',
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string',
-                  description: 'Innovation id.'
-                },
-                name: {
-                  type: 'string',
-                  description: 'Innovation name.'
-                },
-                status: {
-                  type: 'string',
-                  description: 'Innovation status.'
-                },
-                sections: {
-                  type: 'array',
-                  description: 'Innovation sections.',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      id: {
-                        type: 'string',
-                        description: 'Innovation section id.'
-                      },
-                      section: {
-                        type: 'string',
-                        description: 'Innovation section name.'
-                      },
-                      status: {
-                        type: 'string',
-                        description: 'Innovation section status.'
-                      },
-                      submittedAt: {
-                        type: 'string',
-                        description: 'Innovation section submitted date.'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       401: {
         description: 'Unauthorized'
       },

--- a/apps/innovations/v1-innovation-sections-list/index.ts
+++ b/apps/innovations/v1-innovation-sections-list/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -64,7 +64,7 @@ export default openApi(V1InnovationSectionsList.httpTrigger as AzureFunction, '/
     tags: ['Innovation'],
     summary: 'Get an innovation sections list.',
     operationId: 'v1-innovation-sections-list',
-    parameters: [{ in: 'path', name: 'innovationId', required: true, schema: { type: 'string' } }],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
       200: {
         description: 'Success',

--- a/apps/innovations/v1-innovation-sections-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-sections-list/transformation.dtos.ts
@@ -1,5 +1,6 @@
-import type { InnovationSectionStatusEnum } from '@innovations/shared/enums';
-import type { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import { InnovationSectionStatusEnum } from '@innovations/shared/enums';
+import { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: null | string;
@@ -12,3 +13,19 @@ export type ResponseDTO = {
   };
   openTasksCount: number;
 }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    id: Joi.string().uuid().allow(null).required(),
+    section: Joi.string().valid(...CurrentCatalogTypes.InnovationSections),
+    status: Joi.string().valid(...Object.values(InnovationSectionStatusEnum)),
+    submittedAt: Joi.date().allow(null).required(),
+    submittedBy: Joi.object({
+      name: Joi.string().required(),
+      isOwner: Joi.boolean().optional()
+    })
+      .allow(null)
+      .required(),
+    openTasksCount: Joi.number().integer().required()
+  })
+);

--- a/apps/innovations/v1-innovation-shares-update/index.ts
+++ b/apps/innovations/v1-innovation-shares-update/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationsService } from '../_services/innovations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationSharesUpdate {
@@ -53,22 +53,9 @@ export default openApi(V1InnovationSharesUpdate.httpTrigger as AzureFunction, '/
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
-      200: {
-        description: 'OK',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string',
-                  description: 'The unique identifier of the innovation.'
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'OK'
+      }),
       401: {
         description: 'Unauthorized'
       },

--- a/apps/innovations/v1-innovation-shares-update/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-shares-update/transformation.dtos.ts
@@ -1,3 +1,9 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().description('The unique identifier of the innovation.').required()
+});

--- a/apps/innovations/v1-innovation-shares/index.ts
+++ b/apps/innovations/v1-innovation-shares/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -57,7 +57,7 @@ export default openApi(V1InnovationShares.httpTrigger as AzureFunction, '/v1/{in
     tags: ['Innovation'],
     summary: 'Get all the shares for an innovation.',
     operationId: 'v1-innovation-shares',
-    parameters: [{ in: 'path', name: 'innovationId', required: true, schema: { type: 'string' } }],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
       200: {
         description: 'OK',

--- a/apps/innovations/v1-innovation-shares/index.ts
+++ b/apps/innovations/v1-innovation-shares/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationsService } from '../_services/innovations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationShares {
@@ -59,57 +59,9 @@ export default openApi(V1InnovationShares.httpTrigger as AzureFunction, '/v1/{in
     operationId: 'v1-innovation-shares',
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'OK',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string',
-                    description: 'The unique identifier of the share.'
-                  },
-                  innovationId: {
-                    type: 'string',
-                    description: 'The unique identifier of the innovation.'
-                  },
-                  organisationId: {
-                    type: 'string',
-                    description: 'The unique identifier of the organisation.'
-                  },
-                  organisationName: {
-                    type: 'string',
-                    description: 'The name of the organisation.'
-                  },
-                  organisationUnitId: {
-                    type: 'string',
-                    description: 'The unique identifier of the organisation unit.'
-                  },
-                  organisationUnitName: {
-                    type: 'string',
-                    description: 'The name of the organisation unit.'
-                  },
-                  status: {
-                    type: 'string',
-                    description: 'The status of the share.'
-                  },
-                  createdAt: {
-                    type: 'string',
-                    description: 'The date and time when the share was created.'
-                  },
-                  updatedAt: {
-                    type: 'string',
-                    description: 'The date and time when the share was last updated.'
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'OK'
+      }),
       401: {
         description: 'Unauthorized'
       },

--- a/apps/innovations/v1-innovation-shares/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-shares/transformation.dtos.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   organisation: {
     id: string;
@@ -5,3 +7,13 @@ export type ResponseDTO = {
     acronym: null | string;
   };
 }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    organisation: Joi.object({
+      id: Joi.string().uuid().required(),
+      name: Joi.string().required(),
+      acronym: Joi.string().allow(null).required()
+    })
+  })
+);

--- a/apps/innovations/v1-innovation-submission-states/index.ts
+++ b/apps/innovations/v1-innovation-submission-states/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 
 import type { InnovationsService } from '../_services/innovations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationSubmissionStates {
@@ -51,7 +51,9 @@ export default openApi(V1InnovationSubmissionStates.httpTrigger as AzureFunction
     description: 'Get innovation submission states.',
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: { description: 'Success' },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: { description: 'Invalid innovation payload' }
     }
   }

--- a/apps/innovations/v1-innovation-submission-states/index.ts
+++ b/apps/innovations/v1-innovation-submission-states/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { Audit, JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import { ActionEnum, TargetEnum } from '@innovations/shared/services/integrations/audit.service';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -49,18 +49,7 @@ export default openApi(V1InnovationSubmissionStates.httpTrigger as AzureFunction
   get: {
     operationId: 'v1-innovation-submission-states',
     description: 'Get innovation submission states.',
-    parameters: [
-      {
-        name: 'innovationId',
-        in: 'path',
-        required: true,
-        description: 'Innovation ID',
-        schema: {
-          type: 'string',
-          format: 'uuid'
-        }
-      }
-    ],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
       200: { description: 'Success' },
       400: { description: 'Invalid innovation payload' }

--- a/apps/innovations/v1-innovation-submission-states/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-submission-states/transformation.dtos.ts
@@ -1,4 +1,11 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   submittedAllSections: boolean;
   submittedForNeedsAssessment: boolean;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  submittedAllSections: Joi.boolean().required(),
+  submittedForNeedsAssessment: Joi.boolean().required()
+});

--- a/apps/innovations/v1-innovation-submit/index.ts
+++ b/apps/innovations/v1-innovation-submit/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 
 import type { InnovationsService } from '../_services/innovations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationSubmit {
@@ -55,26 +55,9 @@ export default openApi(V1InnovationSubmit.httpTrigger as AzureFunction, '/v1/{in
     tags: ['Innovation'],
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'Innovation submitted successfully.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string',
-                  description: 'Innovation ID'
-                },
-                status: {
-                  type: 'string',
-                  description: 'Innovation status'
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Innovation submitted successfully.'
+      }),
       400: {
         description: 'Bad request.'
       },

--- a/apps/innovations/v1-innovation-submit/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-submit/transformation.dtos.ts
@@ -1,6 +1,14 @@
-import type { InnovationStatusEnum } from '@innovations/shared/enums';
+import { InnovationStatusEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
   status: InnovationStatusEnum;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().required(),
+  status: Joi.string()
+    .valid(...Object.values(InnovationStatusEnum))
+    .required()
+});

--- a/apps/innovations/v1-innovation-suggestions-create/index.ts
+++ b/apps/innovations/v1-innovation-suggestions-create/index.ts
@@ -3,7 +3,7 @@ import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationStatusEnum, ServiceRoleEnum } from '@innovations/shared/enums';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -54,16 +54,8 @@ export default openApi(V1InnovationSuggestionsCreate.httpTrigger as AzureFunctio
     description: 'Create suggestion for an Innovation',
     operationId: 'v1-innovation-suggestions-create',
     tags: ['Create Innovation Suggestion'],
-    parameters: [
-      {
-        in: 'path',
-        name: 'innovationId',
-        required: true,
-        schema: {
-          type: 'string'
-        }
-      }
-    ],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+    requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
       201: {
         description: 'Creates a suggestion.'

--- a/apps/innovations/v1-innovation-suggestions/index.ts
+++ b/apps/innovations/v1-innovation-suggestions/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -50,16 +50,7 @@ export default openApi(V1InnovationsSuggestionList.httpTrigger as AzureFunction,
     description: 'Get suggestions list of an Innovation',
     operationId: 'v1-innovation-suggestions',
     tags: ['Innovation Suggestions'],
-    parameters: [
-      {
-        in: 'path',
-        name: 'innovationId',
-        required: true,
-        schema: {
-          type: 'string'
-        }
-      }
-    ],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
       200: {
         description: 'OK'

--- a/apps/innovations/v1-innovation-support-available-status/index.ts
+++ b/apps/innovations/v1-innovation-support-available-status/index.ts
@@ -9,11 +9,10 @@ import { isAccessorDomainContextType, type CustomContextType } from '@innovation
 
 import { container } from '../_config';
 
-import { InnovationSupportStatusEnum } from '@innovations/shared/enums';
 import { BadRequestError, UserErrorsEnum } from '@innovations/shared/errors';
 import type { InnovationSupportsService } from '../_services/innovation-supports.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, type ParamsType } from './validation.schemas';
 
 class V1InnovationSupportAvailableStatus {
@@ -59,22 +58,9 @@ export default openApi(
       tags: ['[v1] Innovation Support'],
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
-          description: 'OK',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  availableStatus: {
-                    type: 'array',
-                    items: { type: 'string', enum: Object.keys(InnovationSupportStatusEnum) }
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'OK'
+        }),
         400: { description: 'Bad Request' },
         401: { description: 'Unauthorized' },
         403: { description: 'Forbidden' },

--- a/apps/innovations/v1-innovation-support-available-status/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-support-available-status/transformation.dtos.ts
@@ -1,5 +1,10 @@
-import type { InnovationSupportStatusEnum } from '@innovations/shared/enums';
+import { InnovationSupportStatusEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   availableStatus: InnovationSupportStatusEnum[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  availableStatus: Joi.array().items(Joi.string().valid(...Object.values(InnovationSupportStatusEnum)))
+});

--- a/apps/innovations/v1-innovation-support-change-request/index.ts
+++ b/apps/innovations/v1-innovation-support-change-request/index.ts
@@ -9,10 +9,9 @@ import type { CustomContextType } from '@innovations/shared/types';
 
 import { container } from '../_config';
 
-import { InnovationSupportStatusEnum } from '@innovations/shared/enums';
 import type { InnovationSupportsService } from '../_services/innovation-supports.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, ParamsSchema, type BodyType, type ParamsType } from './validation.schemas';
 
 class V1InnovationSupportChangeRequest {
@@ -63,23 +62,9 @@ export default openApi(
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       requestBody: SwaggerHelper.bodyJ2S(BodySchema),
       responses: {
-        '200': {
-          description: 'Innovation ID',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string',
-                    format: 'uuid'
-                  }
-                },
-                required: ['id']
-              }
-            }
-          }
-        }
+        '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Innovation ID'
+        })
       }
     }
   }

--- a/apps/innovations/v1-innovation-support-change-request/index.ts
+++ b/apps/innovations/v1-innovation-support-change-request/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -60,41 +60,8 @@ export default openApi(
       description: 'Request Change Support for a given innovation.',
       operationId: 'v1-innovation-support-change-request',
       tags: ['Innovation Support'],
-      parameters: [
-        {
-          in: 'path',
-          name: 'innovationId',
-          description: 'Unique innovation ID',
-          required: true
-        },
-        {
-          in: 'path',
-          name: 'supportId',
-          required: true
-        }
-      ],
-      requestBody: {
-        description: '',
-        required: true,
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                status: {
-                  type: 'string',
-                  enum: Object.values(InnovationSupportStatusEnum)
-                },
-                message: {
-                  type: 'string',
-                  maxLength: 400
-                }
-              },
-              required: ['status', 'message']
-            }
-          }
-        }
-      },
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+      requestBody: SwaggerHelper.bodyJ2S(BodySchema),
       responses: {
         '200': {
           description: 'Innovation ID',

--- a/apps/innovations/v1-innovation-support-change-request/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-support-change-request/transformation.dtos.ts
@@ -1,3 +1,9 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   success: boolean;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  success: Joi.boolean().required()
+});

--- a/apps/innovations/v1-innovation-support-info/index.ts
+++ b/apps/innovations/v1-innovation-support-info/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationSupportsService } from '../_services/innovation-supports.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, type ParamsType } from './validation.schemas';
 
 class V1InnovationSupportInfo {
@@ -49,9 +49,9 @@ export default openApi(
       tags: ['[v1] Innovation Support'],
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
           description: 'OK'
-        },
+        }),
         400: {
           description: 'Bad Request'
         },

--- a/apps/innovations/v1-innovation-support-info/index.ts
+++ b/apps/innovations/v1-innovation-support-info/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -47,24 +47,7 @@ export default openApi(
       description: 'Get supporting information for an Innovation',
       operationId: 'v1-innovation-support-info',
       tags: ['[v1] Innovation Support'],
-      parameters: [
-        {
-          in: 'path',
-          name: 'innovationId',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        },
-        {
-          in: 'path',
-          name: 'supportId',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        }
-      ],
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
         200: {
           description: 'OK'

--- a/apps/innovations/v1-innovation-support-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-support-info/transformation.dtos.ts
@@ -1,7 +1,20 @@
-import type { InnovationSupportStatusEnum } from '@innovations/shared/enums';
+import { InnovationSupportStatusEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
   status: InnovationSupportStatusEnum;
   engagingAccessors: { id: string; userRoleId: string; name: string }[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().required(),
+  status: Joi.string().valid(...Object.values(InnovationSupportStatusEnum)),
+  engagingAccessors: Joi.array().items(
+    Joi.object({
+      id: Joi.string().uuid().required(),
+      userRoleId: Joi.string().uuid().required(),
+      name: Joi.string().required()
+    })
+  )
+});

--- a/apps/innovations/v1-innovation-support-start/index.ts
+++ b/apps/innovations/v1-innovation-support-start/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 
 import type { InnovationSupportsService } from '../_services/innovation-supports.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationSupportStart {
@@ -57,10 +57,10 @@ export default openApi(V1InnovationSupportStart.httpTrigger as AzureFunction, '/
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
-      201: {
+      201: SwaggerHelper.responseJ2S(ResponseBodySchema, {
         description:
           'Creates a new innovation support request for the innovation identified by the supplied Innovation ID.'
-      },
+      }),
       401: {
         description: 'Unauthorised.'
       }

--- a/apps/innovations/v1-innovation-support-start/index.ts
+++ b/apps/innovations/v1-innovation-support-start/index.ts
@@ -3,7 +3,7 @@ import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationStatusEnum, ServiceRoleEnum } from '@innovations/shared/enums';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -54,16 +54,8 @@ export default openApi(V1InnovationSupportStart.httpTrigger as AzureFunction, '/
     description: 'Starts support in innovation.',
     operationId: 'v1-innovation-support-start',
     tags: ['[v1] Innovation Support'],
-    parameters: [
-      {
-        in: 'path',
-        name: 'innovationId',
-        required: true,
-        schema: {
-          type: 'string'
-        }
-      }
-    ],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+    requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
       201: {
         description:

--- a/apps/innovations/v1-innovation-support-start/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-support-start/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-support-update/index.ts
+++ b/apps/innovations/v1-innovation-support-update/index.ts
@@ -3,7 +3,7 @@ import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationStatusEnum, InnovationSupportStatusEnum, ServiceRoleEnum } from '@innovations/shared/enums';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -58,64 +58,8 @@ export default openApi(
       description: 'Update support on innovation.',
       operationId: 'v1-innovation-support-update',
       tags: ['[v1] Innovation Support'],
-      parameters: [
-        {
-          in: 'path',
-          name: 'innovationId',
-          description: 'Unique innovation ID',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        },
-        {
-          in: 'path',
-          name: 'supportId',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        }
-      ],
-      requestBody: {
-        description: '',
-        required: true,
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                status: {
-                  type: 'string',
-                  enum: Object.values(InnovationSupportStatusEnum)
-                },
-                message: {
-                  type: 'string',
-                  maxLength: 400
-                },
-                accessors: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      accessorId: {
-                        type: 'string',
-                        format: 'uuid'
-                      },
-                      organisationalUnitId: {
-                        type: 'string',
-                        format: 'uuid'
-                      }
-                    }
-                  }
-                }
-              },
-              required: ['status', 'message'],
-              additionalProperties: false
-            }
-          }
-        }
-      },
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+      requestBody: SwaggerHelper.bodyJ2S(BodySchema),
       responses: {
         '200': {
           description: 'Innovation ID',

--- a/apps/innovations/v1-innovation-support-update/index.ts
+++ b/apps/innovations/v1-innovation-support-update/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
-import { InnovationStatusEnum, InnovationSupportStatusEnum, ServiceRoleEnum } from '@innovations/shared/enums';
+import { InnovationStatusEnum, ServiceRoleEnum } from '@innovations/shared/enums';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -12,7 +12,7 @@ import { container } from '../_config';
 
 import type { InnovationSupportsService } from '../_services/innovation-supports.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, ParamsSchema, type BodyType, type ParamsType } from './validation.schemas';
 
 class V1InnovationSupportUpdate {
@@ -61,23 +61,9 @@ export default openApi(
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       requestBody: SwaggerHelper.bodyJ2S(BodySchema),
       responses: {
-        '200': {
-          description: 'Innovation ID',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string',
-                    format: 'uuid'
-                  }
-                },
-                required: ['id']
-              }
-            }
-          }
-        }
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Innovation ID'
+        })
       }
     }
   }

--- a/apps/innovations/v1-innovation-support-update/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-support-update/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-supports-list/index.ts
+++ b/apps/innovations/v1-innovation-supports-list/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationSupportsService } from '../_services/innovation-supports.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, QueryParamsSchema, type ParamsType, type QueryParamsType } from './validation.schemas';
 
 class V1InnovationSupportsList {
@@ -67,9 +67,9 @@ export default openApi(V1InnovationSupportsList.httpTrigger as AzureFunction, '/
     tags: ['[v1] Innovation Support'],
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
         description: 'Success'
-      },
+      }),
       404: {
         description: 'Not found'
       }

--- a/apps/innovations/v1-innovation-supports-list/index.ts
+++ b/apps/innovations/v1-innovation-supports-list/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -65,24 +65,7 @@ export default openApi(V1InnovationSupportsList.httpTrigger as AzureFunction, '/
     description: `Get a list with all Innovation's Supports.`,
     operationId: 'v1-innovations-supports-list',
     tags: ['[v1] Innovation Support'],
-    parameters: [
-      {
-        in: 'path',
-        name: 'innovationId',
-        required: true,
-        schema: {
-          type: 'string'
-        }
-      },
-      {
-        in: 'query',
-        name: 'status',
-        required: false,
-        schema: {
-          type: 'string'
-        }
-      }
-    ],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
       200: {
         description: 'Success'

--- a/apps/innovations/v1-innovation-supports-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-supports-list/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { InnovationSupportStatusEnum } from '@innovations/shared/enums';
+import { InnovationSupportStatusEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
@@ -11,3 +12,32 @@ export type ResponseDTO = {
   };
   engagingAccessors?: { id: string; userRoleId: string; name: string; isActive: boolean }[];
 }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    id: Joi.string().uuid().required(),
+    status: Joi.string()
+      .valid(...Object.values(InnovationSupportStatusEnum))
+      .required(),
+    organisation: Joi.object({
+      id: Joi.string().uuid().required(),
+      name: Joi.string().required(),
+      acronym: Joi.string().required(),
+      unit: Joi.object({
+        id: Joi.string().uuid().required(),
+        name: Joi.string().required(),
+        acronym: Joi.string().required()
+      })
+    }),
+    engagingAccessors: Joi.array()
+      .items(
+        Joi.object({
+          id: Joi.string().uuid().required(),
+          userRoleId: Joi.string().required(),
+          name: Joi.string().required(),
+          isActive: Joi.boolean().required()
+        })
+      )
+      .optional()
+  })
+);

--- a/apps/innovations/v1-innovation-task-create/index.ts
+++ b/apps/innovations/v1-innovation-task-create/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 import { InnovationStatusEnum } from '@innovations/shared/enums';
 import type { InnovationTasksService } from '../_services/innovation-tasks.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationTaskCreate {
@@ -62,24 +62,9 @@ export default openApi(V1InnovationTaskCreate.httpTrigger as AzureFunction, '/v1
       description: 'The innovation task to create.'
     }),
     responses: {
-      200: {
-        description: 'The innovation task has been created.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string',
-                  description: 'The innovation task id.',
-                  example: 'c0a80121-7ac0-464e-b8f6-27b88b0cda7f'
-                }
-              },
-              required: ['id']
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The innovation task has been created.'
+      }),
       400: {
         description: 'The innovation task could not be created.'
       },

--- a/apps/innovations/v1-innovation-task-create/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-task-create/transformation.dtos.ts
@@ -1,3 +1,13 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string()
+    .uuid()
+    .description('The innovation task id.')
+    .example('c0a80121-7ac0-464e-b8f6-27b88b0cda7f')
+    .required()
+});

--- a/apps/innovations/v1-innovation-task-info/index.ts
+++ b/apps/innovations/v1-innovation-task-info/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationTasksService } from '../_services/innovation-tasks.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationTaskInfo {
@@ -70,50 +70,9 @@ export default openApi(V1InnovationTaskInfo.httpTrigger as AzureFunction, '/v1/{
     tags: ['[v1] Innovation Tasks'],
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'The innovation task.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string',
-                  format: 'uuid'
-                },
-                displayId: {
-                  type: 'string'
-                },
-                status: {
-                  type: 'string',
-                  enum: ['OPEN', 'DONE', 'CANCELED', 'DECLINED']
-                },
-                description: {
-                  type: 'string'
-                },
-                section: {
-                  type: 'string'
-                },
-                createdAt: {
-                  type: 'string',
-                  format: 'date-time'
-                },
-                createdBy: {
-                  type: 'object',
-                  properties: {
-                    name: {
-                      type: 'string'
-                    },
-                    organisationUnit: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The innovation task.'
+      }),
       401: {
         description: 'Unauthorized'
       },

--- a/apps/innovations/v1-innovation-task-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-task-info/transformation.dtos.ts
@@ -1,5 +1,6 @@
-import type { InnovationTaskStatusEnum } from '@innovations/shared/enums';
-import type { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import { InnovationTaskStatusEnum } from '@innovations/shared/enums';
+import { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
@@ -19,3 +20,36 @@ export type ResponseDTO = {
   updatedBy: { name: string; displayTag: string };
   createdBy: { name: string; displayTag: string };
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().required(),
+  displayId: Joi.string().required(),
+  status: Joi.string()
+    .valid(...Object.values(InnovationTaskStatusEnum))
+    .required(),
+  section: Joi.string()
+    .valid(...CurrentCatalogTypes.InnovationSections)
+    .required(),
+  descriptions: Joi.array()
+    .items(
+      Joi.object({
+        description: Joi.string().required(),
+        createdAt: Joi.date().required(),
+        name: Joi.string().required(),
+        displayTag: Joi.string().required()
+      })
+    )
+    .required(),
+  sameOrganisation: Joi.boolean().required(),
+  threadId: Joi.string().uuid().required(),
+  createdAt: Joi.date().required(),
+  updatedAt: Joi.date().required(),
+  updatedBy: Joi.object({
+    name: Joi.string().required(),
+    displayTag: Joi.string().required()
+  }).required(),
+  createdBy: Joi.object({
+    name: Joi.string().required(),
+    displayTag: Joi.string().required()
+  }).required()
+});

--- a/apps/innovations/v1-innovation-task-update/index.ts
+++ b/apps/innovations/v1-innovation-task-update/index.ts
@@ -4,7 +4,7 @@ import type { AzureFunction, HttpRequest } from '@azure/functions';
 import { JwtDecoder } from '@innovations/shared/decorators';
 import { InnovationStatusEnum, ServiceRoleEnum } from '@innovations/shared/enums';
 import { BadRequestError, GenericErrorsEnum } from '@innovations/shared/errors';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -97,63 +97,8 @@ export default openApi(V1InnovationTaskUpdate.httpTrigger as AzureFunction, '/v1
     description: 'Update an innovation task.',
     operationId: 'v1-innovation-task-update',
     tags: ['[v1] Innovation Tasks'],
-    parameters: [
-      {
-        name: 'innovationId',
-        in: 'path',
-        description: 'The innovation id.',
-        required: true,
-        schema: {
-          type: 'string'
-        }
-      },
-      {
-        name: 'taskId',
-        in: 'path',
-        description: 'The innovation task id.',
-        required: true,
-        schema: {
-          type: 'string'
-        }
-      }
-    ],
-    requestBody: {
-      description: 'The innovation task data.',
-      required: true,
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              name: {
-                type: 'string',
-                description: 'The name of the task.'
-              },
-              description: {
-                type: 'string',
-                description: 'The description of the task.'
-              },
-              status: {
-                type: 'string',
-                description: 'The status of the task.'
-              },
-              assignee: {
-                type: 'string',
-                description: 'The assignee of the task.'
-              },
-              dueDate: {
-                type: 'string',
-                description: 'The due date of the task.'
-              },
-              comment: {
-                type: 'string',
-                description: 'The comment of the task.'
-              }
-            }
-          }
-        }
-      }
-    },
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+    requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'The innovation task data.' }),
     responses: {
       '200': {
         description: 'The innovation task has been updated.',

--- a/apps/innovations/v1-innovation-task-update/index.ts
+++ b/apps/innovations/v1-innovation-task-update/index.ts
@@ -13,7 +13,7 @@ import { container } from '../_config';
 
 import type { InnovationTasksService } from '../_services/innovation-tasks.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationTaskUpdate {
@@ -100,54 +100,9 @@ export default openApi(V1InnovationTaskUpdate.httpTrigger as AzureFunction, '/v1
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'The innovation task data.' }),
     responses: {
-      '200': {
-        description: 'The innovation task has been updated.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string',
-                  description: 'The innovation task id.'
-                },
-                name: {
-                  type: 'string',
-                  description: 'The name of the task.'
-                },
-                description: {
-                  type: 'string',
-                  description: 'The description of the task.'
-                },
-                status: {
-                  type: 'string',
-                  description: 'The status of the task.'
-                },
-                assignee: {
-                  type: 'string',
-                  description: 'The assignee of the task.'
-                },
-                dueDate: {
-                  type: 'string',
-                  description: 'The due date of the task.'
-                },
-                comment: {
-                  type: 'string',
-                  description: 'The comment of the task.'
-                },
-                createdAt: {
-                  type: 'string',
-                  description: 'The date when the task was created.'
-                },
-                updatedAt: {
-                  type: 'string',
-                  description: 'The date when the task was updated.'
-                }
-              }
-            }
-          }
-        }
-      },
+      '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The innovation task has been updated.'
+      }),
       '400': {
         description: 'The innovation task data is invalid.'
       },

--- a/apps/innovations/v1-innovation-task-update/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-task-update/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-tasks-list/index.ts
+++ b/apps/innovations/v1-innovation-tasks-list/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationTasksService } from '../_services/innovation-tasks.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1InnovationTasksList {
@@ -70,80 +70,9 @@ export default openApi(V1InnovationTasksList.httpTrigger as AzureFunction, '/v1/
     tags: ['[v1] Innovation Tasks'],
     parameters: SwaggerHelper.paramJ2S({ query: QueryParamsSchema }),
     responses: {
-      200: {
-        description: 'The list of innovation tasks.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                count: {
-                  type: 'integer',
-                  description: 'The total number of records.'
-                },
-                data: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      id: {
-                        type: 'string',
-                        description: 'The id of the task.'
-                      },
-                      displayId: {
-                        type: 'string',
-                        description: 'The display id of the task.'
-                      },
-                      status: {
-                        type: 'string',
-                        description: 'The status of the task.'
-                      },
-                      description: {
-                        type: 'string',
-                        description: 'The description of the task.'
-                      },
-                      section: {
-                        type: 'string',
-                        description: 'The section of the task.'
-                      },
-                      createdAt: {
-                        type: 'string',
-                        description: 'The date the task was created.'
-                      },
-                      updatedAt: {
-                        type: 'string',
-                        description: 'The date the task was last updated.'
-                      },
-                      innovation: {
-                        type: 'object',
-                        properties: {
-                          id: {
-                            type: 'string',
-                            description: 'The id of the innovation.'
-                          },
-                          name: {
-                            type: 'string',
-                            description: 'The name of the innovation.'
-                          }
-                        }
-                      },
-                      notifications: {
-                        type: 'object',
-                        properties: {
-                          count: {
-                            type: 'integer',
-                            description: 'The number of notifications for the task.'
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The list of innovation tasks.'
+      }),
       400: {
         description: 'The request is invalid.'
       },

--- a/apps/innovations/v1-innovation-tasks-list/index.ts
+++ b/apps/innovations/v1-innovation-tasks-list/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -68,74 +68,7 @@ export default openApi(V1InnovationTasksList.httpTrigger as AzureFunction, '/v1/
     description: 'Get a list of innovation tasks.',
     operationId: 'v1-innovation-tasks-list',
     tags: ['[v1] Innovation Tasks'],
-    parameters: [
-      {
-        name: 'skip',
-        in: 'query',
-        required: false,
-        description: 'The number of records to skip.',
-        schema: {
-          type: 'integer',
-          minimum: 0
-        }
-      },
-      {
-        name: 'take',
-        in: 'query',
-        required: false,
-        description: 'The number of records to take.',
-        schema: {
-          type: 'integer',
-          minimum: 1,
-          maximum: 100
-        }
-      },
-      {
-        name: 'order',
-        in: 'query',
-        required: false,
-        description: 'The order of the records.',
-        schema: {
-          type: 'string'
-        }
-      },
-      {
-        name: 'status',
-        in: 'query',
-        required: false,
-        description: 'The status of the task.',
-        schema: {
-          type: 'string'
-        }
-      },
-      {
-        name: 'section',
-        in: 'query',
-        required: false,
-        description: 'The section of the task.',
-        schema: {
-          type: 'string'
-        }
-      },
-      {
-        name: 'innovationId',
-        in: 'query',
-        required: false,
-        description: 'The innovation id of the task.',
-        schema: {
-          type: 'string'
-        }
-      },
-      {
-        name: 'innovationName',
-        in: 'query',
-        required: false,
-        description: 'The innovation name of the task.',
-        schema: {
-          type: 'string'
-        }
-      }
-    ],
+    parameters: SwaggerHelper.paramJ2S({ query: QueryParamsSchema }),
     responses: {
       200: {
         description: 'The list of innovation tasks.',

--- a/apps/innovations/v1-innovation-tasks-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-tasks-list/transformation.dtos.ts
@@ -1,5 +1,6 @@
-import type { InnovationTaskStatusEnum } from '@innovations/shared/enums';
-import type { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import { InnovationTaskStatusEnum } from '@innovations/shared/enums';
+import { CurrentCatalogTypes } from '@innovations/shared/schemas/innovation-record';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   count: number;
@@ -17,3 +18,33 @@ export type ResponseDTO = {
     updatedBy: { name: string; displayTag: string };
   }[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  count: Joi.number().integer().required(),
+  data: Joi.object({
+    id: Joi.string().uuid().required(),
+    displayId: Joi.string().required(),
+    innovation: Joi.object({
+      id: Joi.string().uuid().required(),
+      name: Joi.string().required()
+    }).required(),
+    status: Joi.string()
+      .valid(...Object.values(InnovationTaskStatusEnum))
+      .required(),
+    section: Joi.string()
+      .valid(...CurrentCatalogTypes.InnovationSections)
+      .required(),
+    sameOrganisation: Joi.boolean().required(),
+    notifications: Joi.number().integer().required(),
+    createdAt: Joi.date().required(),
+    createdBy: Joi.object({
+      name: Joi.string().required(),
+      displayTag: Joi.string().required()
+    }).required(),
+    updatedAt: Joi.date().required(),
+    updatedBy: Joi.object({
+      name: Joi.string().required(),
+      displayTag: Joi.string().required()
+    }).required()
+  })
+});

--- a/apps/innovations/v1-innovation-thread-available-recipients/index.ts
+++ b/apps/innovations/v1-innovation-thread-available-recipients/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -72,16 +72,7 @@ export default openApi(
       description: `Get a list with a list of thread recipients for a respective innovation.`,
       operationId: 'v1-innovations-threads-available-recipients',
       tags: ['[v1] Innovation Threads Available Recipients'],
-      parameters: [
-        {
-          in: 'path',
-          name: 'innovationId',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        }
-      ],
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
         200: {
           description: 'Success'

--- a/apps/innovations/v1-innovation-thread-available-recipients/index.ts
+++ b/apps/innovations/v1-innovation-thread-available-recipients/index.ts
@@ -10,7 +10,7 @@ import type { CustomContextType } from '@innovations/shared/types';
 import { container } from '../_config';
 
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, type ParamsType } from './validation.schemas';
 import type { InnovationsService } from '../_services/innovations.service';
 
@@ -74,9 +74,9 @@ export default openApi(
       tags: ['[v1] Innovation Threads Available Recipients'],
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
           description: 'Success'
-        },
+        }),
         404: {
           description: 'Not found'
         }

--- a/apps/innovations/v1-innovation-thread-available-recipients/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-thread-available-recipients/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { InnovationRelevantOrganisationsStatusEnum } from '@innovations/shared/enums';
+import { InnovationRelevantOrganisationsStatusEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
@@ -11,3 +12,24 @@ export type ResponseDTO = {
   };
   recipients: { id: string; roleId: string; name: string }[];
 }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    id: Joi.string().uuid().required(),
+    status: Joi.string().valid(...Object.values(InnovationRelevantOrganisationsStatusEnum)),
+    organisation: Joi.object({
+      id: Joi.string().uuid().required(),
+      name: Joi.string().required(),
+      acronym: Joi.string().required(),
+      unit: Joi.object({
+        id: Joi.string().uuid().required(),
+        name: Joi.string().required(),
+        acronym: Joi.string().required()
+      })
+    }).required(),
+    recipients: Joi.object({
+      id: Joi.string().uuid().required(),
+      name: Joi.string().required()
+    })
+  })
+);

--- a/apps/innovations/v1-innovation-thread-create/index.ts
+++ b/apps/innovations/v1-innovation-thread-create/index.ts
@@ -13,7 +13,7 @@ import { container } from '../_config';
 import { InnovationStatusEnum } from '@innovations/shared/enums';
 import type { InnovationThreadsService } from '../_services/innovation-threads.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationThreadCreate {
@@ -70,48 +70,9 @@ export default openApi(V1InnovationThreadCreate.httpTrigger as AzureFunction, '/
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'The thread details.' }),
     responses: {
-      '200': {
-        description: 'The thread was created successfully.',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                thread: {
-                  type: 'object',
-                  properties: {
-                    id: {
-                      type: 'string',
-                      description: 'The thread id.',
-                      example: '00000000-0000-0000-0000-000000000000'
-                    },
-                    subject: {
-                      type: 'string',
-                      description: 'The thread subject.',
-                      example: 'Subject'
-                    },
-                    createdBy: {
-                      type: 'object',
-                      properties: {
-                        id: {
-                          type: 'string',
-                          description: 'The user id.',
-                          example: '00000000-0000-0000-0000-000000000000'
-                        }
-                      }
-                    },
-                    createdAt: {
-                      type: 'string',
-                      description: 'The thread creation date.',
-                      example: '2021-01-01T00:00:00.000Z'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The thread was created successfully.'
+      }),
       '400': {
         description: 'The request was invalid.'
       },

--- a/apps/innovations/v1-innovation-thread-create/index.ts
+++ b/apps/innovations/v1-innovation-thread-create/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { Audit, JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import { ActionEnum, TargetEnum } from '@innovations/shared/services/integrations/audit.service';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -67,41 +67,8 @@ export default openApi(V1InnovationThreadCreate.httpTrigger as AzureFunction, '/
     description: 'Create a new editable thread.',
     tags: ['Innovation Threads'],
     operationId: 'v1-innovation-thread-create',
-    parameters: [
-      {
-        name: 'innovationId',
-        in: 'path',
-        description: 'The innovation id.',
-        required: true,
-        schema: {
-          type: 'string'
-        }
-      }
-    ],
-    requestBody: {
-      description: 'The thread details.',
-      required: true,
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              subject: {
-                type: 'string',
-                description: 'The thread subject.',
-                example: 'Subject'
-              },
-              message: {
-                type: 'string',
-                description: 'The thread message.',
-                example: 'Message'
-              }
-            },
-            required: ['subject', 'message']
-          }
-        }
-      }
-    },
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+    requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'The thread details.' }),
     responses: {
       '200': {
         description: 'The thread was created successfully.',

--- a/apps/innovations/v1-innovation-thread-create/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-thread-create/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-thread-followers/index.ts
+++ b/apps/innovations/v1-innovation-thread-followers/index.ts
@@ -10,7 +10,7 @@ import type { CustomContextType } from '@innovations/shared/types';
 
 import { container } from '../_config';
 
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import type { ParamsType } from './validation.schemas';
 import { ParamsSchema } from './validation.schemas';
 
@@ -71,46 +71,9 @@ export default openApi(
       operationId: 'v1-innovation-thread-followers',
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
-          description: 'Success',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  participants: {
-                    type: 'array',
-                    items: {
-                      type: 'object',
-                      properties: {
-                        id: {
-                          type: 'string'
-                        },
-                        name: {
-                          type: 'string'
-                        },
-                        type: {
-                          type: 'string'
-                        },
-                        organisationUnit: {
-                          type: 'object',
-                          properties: {
-                            id: {
-                              type: 'string'
-                            },
-                            acronym: {
-                              type: 'string'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Success'
+        }),
         401: {
           description: 'Unauthorized'
         },

--- a/apps/innovations/v1-innovation-thread-followers/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-thread-followers/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { ServiceRoleEnum } from '@innovations/shared/enums';
+import { ServiceRoleEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   followers: {
@@ -10,3 +11,27 @@ export type ResponseDTO = {
     organisationUnit: { id: string; name: string; acronym: string } | null;
   }[];
 };
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    followers: Joi.object({
+      id: Joi.string().uuid().required(),
+      name: Joi.string().required(),
+      isLocked: Joi.boolean().required(),
+      isOwner: Joi.boolean().optional(),
+      role: Joi.object({
+        id: Joi.string().uuid().required(),
+        role: Joi.string()
+          .valid(...Object.values(ServiceRoleEnum))
+          .required()
+      }),
+      organisationUnit: Joi.object({
+        id: Joi.string().uuid().required(),
+        name: Joi.string().required(),
+        acronym: Joi.string().required()
+      })
+        .allow(null)
+        .required()
+    })
+  })
+);

--- a/apps/innovations/v1-innovation-thread-info/index.ts
+++ b/apps/innovations/v1-innovation-thread-info/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 
 import type { InnovationThreadsService } from '../_services/innovation-threads.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import type { ParamsType } from './validation.schemas';
 import { ParamsSchema } from './validation.schemas';
 
@@ -64,41 +64,9 @@ export default openApi(V1InnovationThreadInfo.httpTrigger as AzureFunction, '/v1
     operationId: 'v1-innovation-thread-info',
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string'
-                },
-                subject: {
-                  type: 'string'
-                },
-                createdAt: {
-                  type: 'string'
-                },
-                createdBy: {
-                  type: 'object',
-                  properties: {
-                    id: {
-                      type: 'string'
-                    },
-                    name: {
-                      type: 'string'
-                    },
-                    type: {
-                      type: 'string'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       401: {
         description: 'Unauthorized'
       },

--- a/apps/innovations/v1-innovation-thread-info/index.ts
+++ b/apps/innovations/v1-innovation-thread-info/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { Audit, JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import { ActionEnum, TargetEnum } from '@innovations/shared/services/integrations/audit.service';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -62,26 +62,7 @@ export default openApi(V1InnovationThreadInfo.httpTrigger as AzureFunction, '/v1
     description: 'Get Innovation Thread Info',
     tags: ['Innovation Thread'],
     operationId: 'v1-innovation-thread-info',
-    parameters: [
-      {
-        name: 'innovationId',
-        in: 'path',
-        description: 'Innovation Id',
-        required: true,
-        schema: {
-          type: 'string'
-        }
-      },
-      {
-        name: 'threadId',
-        in: 'path',
-        description: 'Thread Id',
-        required: true,
-        schema: {
-          type: 'string'
-        }
-      }
-    ],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
       200: {
         description: 'Success',

--- a/apps/innovations/v1-innovation-thread-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-thread-info/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { ThreadContextTypeEnum } from '@innovations/shared/enums';
+import { ThreadContextTypeEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
@@ -13,3 +14,19 @@ export type ResponseDTO = {
     name: string;
   };
 };
+
+export const ResponseBodySchema = Joi.object({
+  id: Joi.string().uuid().required(),
+  subject: Joi.string().required(),
+  context: Joi.object({
+    type: Joi.string()
+      .valid(...Object.values(ThreadContextTypeEnum))
+      .required(),
+    id: Joi.string().uuid().required()
+  }).optional(),
+  createdAt: Joi.date().required(),
+  createdBy: Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required()
+  })
+});

--- a/apps/innovations/v1-innovation-thread-list/index.ts
+++ b/apps/innovations/v1-innovation-thread-list/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationThreadsService } from '../_services/innovation-threads.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, type ParamsType, QueryParamsSchema, type QueryParamsType } from './validation.schemas';
 
 class V1InnovationThreadCreate {
@@ -80,54 +80,9 @@ export default openApi(V1InnovationThreadCreate.httpTrigger as AzureFunction, '/
     operationId: 'v1-innovation-thread-list',
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema, query: QueryParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                count: {
-                  type: 'number'
-                },
-                data: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      id: { type: 'string' },
-                      subject: { type: 'string' },
-                      messageCount: { type: 'number' },
-                      hasUnreadNotifications: { type: 'boolean' },
-                      createdBy: {
-                        type: 'object',
-                        properties: {
-                          id: { type: 'string' },
-                          displayTeam: { type: 'string' }
-                        }
-                      },
-                      lastMessage: {
-                        type: 'object',
-                        properties: {
-                          id: { type: 'string' },
-                          createdAt: { type: 'string' },
-                          createdBy: {
-                            type: 'object',
-                            properties: {
-                              id: { type: 'string' },
-                              displayTeam: { type: 'string' }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       401: { description: 'Unauthorized' },
       403: { description: 'Forbidden' },
       404: { description: 'Not Found' },

--- a/apps/innovations/v1-innovation-thread-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-thread-list/transformation.dtos.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   count: number;
   data: {
@@ -13,3 +15,27 @@ export type ResponseDTO = {
     hasUnreadNotifications: boolean;
   }[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  count: Joi.number().integer().required(),
+  data: Joi.array().items(
+    Joi.object({
+      id: Joi.string().uuid().required(),
+      subject: Joi.string().required(),
+      createdBy: Joi.object({
+        id: Joi.string().uuid().required(),
+        displayTeam: Joi.string().optional()
+      }),
+      lastMessage: Joi.object({
+        id: Joi.string().uuid().required(),
+        createdAt: Joi.date().required(),
+        createdBy: Joi.object({
+          id: Joi.string().uuid().required(),
+          displayTeam: Joi.string().optional()
+        })
+      }),
+      messageCount: Joi.number().integer().required(),
+      hasUnreadNotifications: Joi.boolean().required()
+    })
+  )
+});

--- a/apps/innovations/v1-innovation-thread-message-create/index.ts
+++ b/apps/innovations/v1-innovation-thread-message-create/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { Audit, JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import { ActionEnum, TargetEnum } from '@innovations/shared/services/integrations/audit.service';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -75,43 +75,8 @@ export default openApi(
       description: 'Creates a new message in a thread.',
       operationId: 'v1-innovation-thread-message-create',
       tags: ['[v1] Innovation Threads'],
-      parameters: [
-        {
-          name: 'innovationId',
-          in: 'path',
-          description: 'Innovation ID',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        },
-        {
-          name: 'threadId',
-          in: 'path',
-          description: 'Thread ID',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        }
-      ],
-      requestBody: {
-        description: 'Message to be created.',
-        required: true,
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                message: {
-                  type: 'string',
-                  description: 'Message to be created.'
-                }
-              }
-            }
-          }
-        }
-      },
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+      requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'Message to be created.' }),
       responses: {
         200: {
           description: 'Message created.',

--- a/apps/innovations/v1-innovation-thread-message-create/index.ts
+++ b/apps/innovations/v1-innovation-thread-message-create/index.ts
@@ -13,7 +13,7 @@ import { container } from '../_config';
 import { InnovationStatusEnum } from '@innovations/shared/enums';
 import type { InnovationThreadsService } from '../_services/innovation-threads.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationThreadMessageCreate {
@@ -78,52 +78,9 @@ export default openApi(
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'Message to be created.' }),
       responses: {
-        200: {
-          description: 'Message created.',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  threadMessage: {
-                    type: 'object',
-                    properties: {
-                      id: {
-                        type: 'string',
-                        description: 'Message ID.'
-                      },
-                      message: {
-                        type: 'string',
-                        description: 'Message.'
-                      },
-                      createdBy: {
-                        type: 'object',
-                        properties: {
-                          id: {
-                            type: 'string',
-                            description: 'User ID.'
-                          },
-                          identityId: {
-                            type: 'string',
-                            description: 'User identity ID.'
-                          }
-                        }
-                      },
-                      createdAt: {
-                        type: 'string',
-                        description: 'Date when the message was created.'
-                      },
-                      isEditable: {
-                        type: 'boolean',
-                        description: 'Flag to indicate if the message can be edited.'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Message created.'
+        }),
         400: {
           description: 'Bad request.'
         },

--- a/apps/innovations/v1-innovation-thread-message-create/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-thread-message-create/transformation.dtos.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   threadMessage: {
     createdBy: {
@@ -10,3 +12,16 @@ export type ResponseDTO = {
     createdAt: Date;
   };
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  threadMessage: Joi.object({
+    createdBy: Joi.object({
+      id: Joi.string().uuid().required(),
+      identityId: Joi.string().required()
+    }),
+    id: Joi.string().uuid().required(),
+    message: Joi.string().required(),
+    isEditable: Joi.boolean().required(),
+    createdAt: Joi.date().required()
+  }).required()
+});

--- a/apps/innovations/v1-innovation-thread-message-info/index.ts
+++ b/apps/innovations/v1-innovation-thread-message-info/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationThreadsService } from '../_services/innovation-threads.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import type { ParamsType } from './validation.schemas';
 import { ParamsSchema } from './validation.schemas';
 
@@ -58,30 +58,9 @@ export default openApi(
       tags: ['[v1] Innovation Threads'],
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
-          description: 'Success',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string',
-                    description: 'Message ID'
-                  },
-                  message: {
-                    type: 'string',
-                    description: 'Message'
-                  },
-                  createdAt: {
-                    type: 'string',
-                    description: 'Message creation date'
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Success'
+        }),
         401: {
           description: 'Unauthorized'
         },

--- a/apps/innovations/v1-innovation-thread-message-info/index.ts
+++ b/apps/innovations/v1-innovation-thread-message-info/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -56,35 +56,7 @@ export default openApi(
       summary: 'Get a thread message info',
       description: 'Get a thread message info',
       tags: ['[v1] Innovation Threads'],
-      parameters: [
-        {
-          name: 'innovationId',
-          in: 'path',
-          description: 'Innovation ID',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        },
-        {
-          name: 'threadId',
-          in: 'path',
-          description: 'Thread ID',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        },
-        {
-          name: 'messageId',
-          in: 'path',
-          description: 'Message ID',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        }
-      ],
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
         200: {
           description: 'Success',

--- a/apps/innovations/v1-innovation-thread-message-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-thread-message-info/transformation.dtos.ts
@@ -1,5 +1,13 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
   message: string;
   createdAt: Date;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().required(),
+  message: Joi.string().required(),
+  createdAt: Joi.date().required()
+});

--- a/apps/innovations/v1-innovation-thread-message-list/index.ts
+++ b/apps/innovations/v1-innovation-thread-message-list/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationThreadsService } from '../_services/innovation-threads.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType, QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1InnovationThreadMessageList {
@@ -99,98 +99,9 @@ export default openApi(
       tags: ['[v1] Innovation Threads'],
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
-          description: 'Returns a list of messages from a thread',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  count: {
-                    type: 'number'
-                  },
-                  messages: {
-                    type: 'array',
-                    items: {
-                      type: 'object',
-                      properties: {
-                        id: {
-                          type: 'string'
-                        },
-                        createdAt: {
-                          type: 'string'
-                        },
-                        createdBy: {
-                          type: 'object',
-                          properties: {
-                            id: {
-                              type: 'string'
-                            },
-                            name: {
-                              type: 'string'
-                            },
-                            type: {
-                              type: 'string',
-                              enum: ['INNOVATOR', 'ASSESSOR', 'ACCESSOR']
-                            },
-                            organisationUnit: {
-                              type: 'object',
-                              properties: {
-                                id: {
-                                  type: 'string'
-                                },
-                                name: {
-                                  type: 'string'
-                                },
-                                acronym: {
-                                  type: 'string'
-                                }
-                              }
-                            },
-                            organisation: {
-                              type: 'object',
-                              properties: {
-                                id: {
-                                  type: 'string'
-                                },
-                                name: {
-                                  type: 'string'
-                                },
-                                acronym: {
-                                  type: 'string'
-                                }
-                              }
-                            }
-                          }
-                        },
-                        isEditable: {
-                          type: 'boolean'
-                        },
-                        isNew: {
-                          type: 'boolean'
-                        },
-                        message: {
-                          type: 'string'
-                        },
-                        file: {
-                          type: 'object',
-                          properties: {
-                            id: { type: 'string' },
-                            name: { type: 'string' },
-                            url: { type: 'string' }
-                          }
-                        },
-                        updatedAt: {
-                          type: 'string'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Returns a list of messages from a thread'
+        }),
         400: {
           description: 'Bad request'
         },

--- a/apps/innovations/v1-innovation-thread-message-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-thread-message-list/transformation.dtos.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   count: number;
   messages: {
@@ -18,3 +20,38 @@ export type ResponseDTO = {
     updatedAt: Date;
   }[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  count: Joi.number().integer().required(),
+  messages: Joi.array().items(
+    Joi.object({
+      id: Joi.string().uuid().required(),
+      message: Joi.string().required(),
+      file: Joi.object({
+        id: Joi.string().uuid().required(),
+        name: Joi.string().required(),
+        url: Joi.string().required()
+      }).optional(),
+      createdAt: Joi.date().required(),
+      isNew: Joi.boolean().required(),
+      isEditable: Joi.boolean().required(),
+      createdBy: Joi.object({
+        id: Joi.string().uuid().required(),
+        name: Joi.string().required(),
+        role: Joi.string().required(),
+        isOwner: Joi.boolean().required(),
+        organisation: Joi.object({
+          id: Joi.string().uuid().required(),
+          name: Joi.string().required(),
+          acronym: Joi.string().allow(null).required()
+        }).optional(),
+        organisationUnit: Joi.object({
+          id: Joi.string().uuid().required(),
+          name: Joi.string().required(),
+          acronym: Joi.string().allow(null).required()
+        }).optional()
+      }),
+      updatedAt: Joi.date().required()
+    })
+  )
+});

--- a/apps/innovations/v1-innovation-thread-message-update/index.ts
+++ b/apps/innovations/v1-innovation-thread-message-update/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -69,52 +69,8 @@ export default openApi(
       description: 'Update a thread message',
       tags: ['[v1] Innovation Threads'],
       operationId: 'v1-innovation-thread-message-update',
-      parameters: [
-        {
-          name: 'innovationId',
-          in: 'path',
-          description: 'Innovation Id',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        },
-        {
-          name: 'threadId',
-          in: 'path',
-          description: 'Thread Id',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        },
-        {
-          name: 'messageId',
-          in: 'path',
-          description: 'Message Id',
-          required: true,
-          schema: {
-            type: 'string'
-          }
-        }
-      ],
-      requestBody: {
-        description: 'Message',
-        required: true,
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                message: {
-                  type: 'string',
-                  description: 'Message'
-                }
-              }
-            }
-          }
-        }
-      },
+      parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+      requestBody: SwaggerHelper.bodyJ2S(BodySchema),
       responses: {
         '200': {
           description: 'Success',

--- a/apps/innovations/v1-innovation-thread-message-update/index.ts
+++ b/apps/innovations/v1-innovation-thread-message-update/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 import { InnovationStatusEnum } from '@innovations/shared/enums';
 import type { InnovationThreadsService } from '../_services/innovation-threads.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationThreadMessageUpdate {
@@ -72,22 +72,9 @@ export default openApi(
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       requestBody: SwaggerHelper.bodyJ2S(BodySchema),
       responses: {
-        '200': {
-          description: 'Success',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string',
-                    description: 'Message Id'
-                  }
-                }
-              }
-            }
-          }
-        },
+        '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Success'
+        }),
         '400': {
           description: 'Bad Request'
         },

--- a/apps/innovations/v1-innovation-thread-message-update/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-thread-message-update/transformation.dtos.ts
@@ -1,3 +1,9 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().description('Message Id').required()
+});

--- a/apps/innovations/v1-innovation-transfer-check/index.ts
+++ b/apps/innovations/v1-innovation-transfer-check/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, Context, HttpRequest } from '@azure/functions';
 
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 
 import { container } from '../_config';
 
@@ -33,7 +33,7 @@ export default openApi(V1InnovationTransferCheck.httpTrigger as AzureFunction, '
   get: {
     description: 'Get details of pending innovations transfers',
     operationId: 'v1-innovation-transfer-check',
-    parameters: [{ in: 'path', name: 'transferId', required: true, schema: { type: 'string' } }],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
       200: {
         description: 'Ok',

--- a/apps/innovations/v1-innovation-transfer-check/index.ts
+++ b/apps/innovations/v1-innovation-transfer-check/index.ts
@@ -7,7 +7,7 @@ import { container } from '../_config';
 
 import type { InnovationTransferService } from '../_services/innovation-transfer.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import type { ParamsType } from './validation.schemas';
 import { ParamsSchema } from './validation.schemas';
 
@@ -35,19 +35,9 @@ export default openApi(V1InnovationTransferCheck.httpTrigger as AzureFunction, '
     operationId: 'v1-innovation-transfer-check',
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'Ok',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                userExists: { type: 'boolean', description: 'User exists in service' }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Ok'
+      }),
       404: {
         description: 'The innovation transfer does not exist'
       }

--- a/apps/innovations/v1-innovation-transfer-check/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-transfer-check/transformation.dtos.ts
@@ -1,3 +1,9 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   userExists: boolean;
 };
+
+export const ResponseBodySchema = Joi.object({
+  userExists: Joi.boolean().required()
+});

--- a/apps/innovations/v1-innovation-transfer-create/index.ts
+++ b/apps/innovations/v1-innovation-transfer-create/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -57,15 +57,7 @@ export default openApi(CreateInnovationTransfer.httpTrigger as AzureFunction, '/
     description: 'Create an innovation transfer',
     operationId: 'createInnovationTransfer',
     parameters: [],
-    requestBody: {
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object'
-          }
-        }
-      }
-    },
+    requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
       200: {
         description: 'Success',

--- a/apps/innovations/v1-innovation-transfer-create/index.ts
+++ b/apps/innovations/v1-innovation-transfer-create/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationTransferService } from '../_services/innovation-transfer.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType } from './validation.schemas';
 
 class CreateInnovationTransfer {
@@ -59,16 +59,9 @@ export default openApi(CreateInnovationTransfer.httpTrigger as AzureFunction, '/
     parameters: [],
     requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object'
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: {
         description: 'Bad Request',
         content: {

--- a/apps/innovations/v1-innovation-transfer-create/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-transfer-create/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovation-transfer-info/index.ts
+++ b/apps/innovations/v1-innovation-transfer-info/index.ts
@@ -10,7 +10,7 @@ import type { CustomContextType } from '@innovations/shared/types';
 import { container } from '../_config';
 import type { InnovationTransferService } from '../_services/innovation-transfer.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class GetInnovationTransfer {
@@ -48,16 +48,9 @@ export default openApi(GetInnovationTransfer.httpTrigger as AzureFunction, '/v1/
     operationId: 'getInnovationTransfer',
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object'
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       404: {
         description: 'Not Found',
         content: {

--- a/apps/innovations/v1-innovation-transfer-info/index.ts
+++ b/apps/innovations/v1-innovation-transfer-info/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -46,16 +46,7 @@ export default openApi(GetInnovationTransfer.httpTrigger as AzureFunction, '/v1/
   get: {
     description: 'Get an innovation transfer',
     operationId: 'getInnovationTransfer',
-    parameters: [
-      {
-        name: 'transferId',
-        in: 'path',
-        required: true,
-        schema: {
-          type: 'string'
-        }
-      }
-    ],
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
       200: {
         description: 'Success',

--- a/apps/innovations/v1-innovation-transfer-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-transfer-info/transformation.dtos.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
   email: string;
@@ -7,3 +9,15 @@ export type ResponseDTO = {
     owner: { name: string };
   };
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().required(),
+  email: Joi.string().required(),
+  innovation: Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required(),
+    owner: Joi.object({
+      name: Joi.string().required()
+    }).required()
+  }).required()
+});

--- a/apps/innovations/v1-innovation-transfer-list/index.ts
+++ b/apps/innovations/v1-innovation-transfer-list/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationTransferService } from '../_services/innovation-transfer.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1InnovationTransferList {
@@ -45,19 +45,9 @@ export default openApi(V1InnovationTransferList.httpTrigger as AzureFunction, '/
     operationId: 'getInnovationTransferList',
     parameters: [],
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'array',
-              items: {
-                type: 'object'
-              }
-            }
-          }
-        }
-      }
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The innovation assessment has been created.'
+      })
     }
   }
 });

--- a/apps/innovations/v1-innovation-transfer-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-transfer-list/transformation.dtos.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
   email: string;
@@ -7,3 +9,15 @@ export type ResponseDTO = {
     owner?: string;
   };
 }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    id: Joi.string().uuid().required(),
+    email: Joi.string().required(),
+    innovation: Joi.object({
+      id: Joi.string().uuid().required(),
+      name: Joi.string().required(),
+      owner: Joi.string().optional()
+    }).required()
+  })
+);

--- a/apps/innovations/v1-innovation-transfer-update/index.ts
+++ b/apps/innovations/v1-innovation-transfer-update/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { ElasticSearchDocumentUpdate, JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -52,28 +52,8 @@ export default openApi(V1InnovationTransferUpdate.httpTrigger as AzureFunction, 
   patch: {
     description: 'Update an innovation transfer status',
     operationId: 'v1-innovation-transfer-update',
-    parameters: [
-      {
-        name: 'transferId',
-        in: 'path',
-        required: true,
-        description: 'The innovation transfer id',
-        schema: {
-          type: 'string'
-        }
-      }
-    ],
-    requestBody: {
-      description: 'The innovation transfer status',
-      required: true,
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object'
-          }
-        }
-      }
-    },
+    parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
+    requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'The innovation transfer status' }),
     responses: {
       204: {
         description: 'The innovation transfer status has been updated'

--- a/apps/innovations/v1-innovation-transfer-update/index.ts
+++ b/apps/innovations/v1-innovation-transfer-update/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationTransferService } from '../_services/innovation-transfer.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationTransferUpdate {
@@ -55,9 +55,9 @@ export default openApi(V1InnovationTransferUpdate.httpTrigger as AzureFunction, 
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     requestBody: SwaggerHelper.bodyJ2S(BodySchema, { description: 'The innovation transfer status' }),
     responses: {
-      204: {
+      204: SwaggerHelper.responseJ2S(ResponseBodySchema, {
         description: 'The innovation transfer status has been updated'
-      },
+      }),
       400: {
         description: 'The innovation transfer status is invalid'
       },

--- a/apps/innovations/v1-innovation-transfer-update/transformation.dtos.ts
+++ b/apps/innovations/v1-innovation-transfer-update/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovations-export-request-create/index.ts
+++ b/apps/innovations/v1-innovations-export-request-create/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationExportRequestService } from '../_services/innovation-export-request.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType, ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationsExportRequestsCreate {
@@ -54,17 +54,9 @@ export default openApi(
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       requestBody: SwaggerHelper.bodyJ2S(BodySchema),
       responses: {
-        201: {
-          description: 'Creates a new export request',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: { id: { type: 'string' } }
-              }
-            }
-          }
-        },
+        201: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Creates a new export request'
+        }),
         400: { description: 'The request is invalid.' },
         401: { description: 'The user is not authenticated.' },
         403: { description: 'The user is not authorized to access this resource.' },

--- a/apps/innovations/v1-innovations-export-request-create/transformation.dtos.ts
+++ b/apps/innovations/v1-innovations-export-request-create/transformation.dtos.ts
@@ -1,1 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = { id: string };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/innovations/v1-innovations-export-request-info/index.ts
+++ b/apps/innovations/v1-innovations-export-request-info/index.ts
@@ -9,10 +9,9 @@ import type { CustomContextType } from '@innovations/shared/types';
 
 import { container } from '../_config';
 
-import { InnovationExportRequestStatusEnum } from '@innovations/shared/enums';
 import type { InnovationExportRequestService } from '../_services/innovation-export-request.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1InnovationsExportRequestInfo {
@@ -55,36 +54,9 @@ export default openApi(
       tags: ['[v1] Innovation Export Requests'],
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: {
-          description: 'Success',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  id: { type: 'string', format: 'uuid' },
-                  status: { type: 'string', enum: Object.values(InnovationExportRequestStatusEnum) },
-                  requestReason: { type: 'string' },
-                  rejectReason: { type: 'string' },
-                  createdBy: {
-                    type: 'object',
-                    properties: {
-                      name: { type: 'string' },
-                      displayRole: { type: 'string' },
-                      displayTeam: { type: 'string' }
-                    }
-                  },
-                  createdAt: { type: 'string', format: 'date-time' },
-                  updatedBy: {
-                    type: 'object',
-                    properties: { name: { type: 'string' } }
-                  },
-                  updatedAt: { type: 'string', format: 'date-time' }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Success'
+        }),
         400: { description: 'The request is invalid.' },
         401: { description: 'The user is not authenticated.' },
         403: { description: 'The user is not authorized to access this resource.' },

--- a/apps/innovations/v1-innovations-export-request-info/transformation.dtos.ts
+++ b/apps/innovations/v1-innovations-export-request-info/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { InnovationExportRequestStatusEnum } from '@innovations/shared/enums';
+import { InnovationExportRequestStatusEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
@@ -14,3 +15,20 @@ export type ResponseDTO = {
   updatedBy: { name: string };
   updatedAt: Date;
 };
+
+export const ResponseBodySchema = Joi.object({
+  id: Joi.string().uuid().required(),
+  status: Joi.string().valid(...Object.values(InnovationExportRequestStatusEnum)),
+  requestReason: Joi.string().required(),
+  rejectReason: Joi.string().optional(),
+  createdBy: Joi.object({
+    name: Joi.string().required,
+    displayRole: Joi.string().optional(),
+    displayType: Joi.string().optional()
+  }),
+  createdAt: Joi.date().required(),
+  updatedBy: Joi.object({
+    name: Joi.string().required()
+  }),
+  updatedAt: Joi.date().required()
+});

--- a/apps/innovations/v1-innovations-export-request-list/index.ts
+++ b/apps/innovations/v1-innovations-export-request-list/index.ts
@@ -2,7 +2,6 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { InnovationExportRequestStatusEnum } from '@innovations/shared/enums';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
@@ -12,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationExportRequestService } from '../_services/innovation-export-request.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType, QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1InnovationsExportRequestList {
@@ -64,38 +63,9 @@ export default openApi(
       tags: ['[v1] Innovation Export Requests'],
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema, query: QueryParamsSchema }),
       responses: {
-        200: {
-          description: 'Success',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  count: { type: 'number' },
-                  data: {
-                    type: 'array',
-                    items: {
-                      type: 'object',
-                      properties: {
-                        id: { type: 'string', format: 'uuid' },
-                        status: { type: 'string', enum: Object.values(InnovationExportRequestStatusEnum) },
-                        createdBy: {
-                          type: 'object',
-                          properties: {
-                            name: { type: 'string' },
-                            displayRole: { type: 'string' },
-                            displayTeam: { type: 'string' }
-                          }
-                        },
-                        createdAt: { type: 'string', format: 'date-time' }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Success'
+        }),
         400: { description: 'The request is invalid.' },
         401: { description: 'The user is not authenticated.' },
         403: { description: 'The user is not authorized to access this resource.' },

--- a/apps/innovations/v1-innovations-export-request-list/transformation.dtos.ts
+++ b/apps/innovations/v1-innovations-export-request-list/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { InnovationExportRequestStatusEnum } from '@innovations/shared/enums';
+import { InnovationExportRequestStatusEnum } from '@innovations/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   count: number;
@@ -13,3 +14,19 @@ export type ResponseDTO = {
     createdAt: Date;
   }[];
 };
+
+export const ResponseBodySchema = Joi.array().items(
+  Joi.object({
+    count: Joi.number().integer().required(),
+    data: Joi.object({
+      id: Joi.string().uuid().required(),
+      status: Joi.string().valid(...Object.values(InnovationExportRequestStatusEnum)),
+      createdBy: Joi.object({
+        name: Joi.string().required(),
+        displayRole: Joi.string().optional(),
+        displayTeam: Joi.string().optional()
+      }),
+      createdAt: Joi.date().required()
+    })
+  })
+);

--- a/apps/innovations/v1-innovations-overdue-assessments/index.ts
+++ b/apps/innovations/v1-innovations-overdue-assessments/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@innovations/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { InnovationsService } from '../_services/innovations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1InnovationsOverdueAssessments {
@@ -46,19 +46,9 @@ export default openApi(V1InnovationsOverdueAssessments.httpTrigger as AzureFunct
     description: 'Get assessment overdue innovations',
     parameters: [],
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string', description: 'Unique identifier for innovation object' }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: { description: 'Invalid innovation payload' }
     }
   }

--- a/apps/innovations/v1-innovations-overdue-assessments/transformation.dtos.ts
+++ b/apps/innovations/v1-innovations-overdue-assessments/transformation.dtos.ts
@@ -1,3 +1,9 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   overdue: number;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  overdue: Joi.number().integer().required()
+});

--- a/apps/innovations/v1-innovations-validate/index.ts
+++ b/apps/innovations/v1-innovations-validate/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import SYMBOLS from '../_services/symbols';
 import type { ValidationService } from '../_services/validation.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType, QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1InnovationsValidate {
@@ -51,22 +51,9 @@ export default openApi(V1InnovationsValidate.httpTrigger as AzureFunction, '/v1/
     operationId: 'v1-innovations-validate',
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      '200': {
-        description: 'OK',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                validations: {
-                  type: 'object',
-                  description: 'Validation data.'
-                }
-              }
-            }
-          }
-        }
-      },
+      '200': SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'The innovation assessment has been created.'
+      }),
       '400': { description: 'Bad request.' },
       '401': { description: 'The user is not authorized to access validation data.' },
       '500': { description: 'An error occurred while fetching the validation data.' }

--- a/apps/innovations/v1-innovations-validate/transformation.dtos.ts
+++ b/apps/innovations/v1-innovations-validate/transformation.dtos.ts
@@ -1,5 +1,16 @@
-import type { ValidationResult } from '../_services/validation.service';
+import Joi from 'joi';
+import { type ValidationResult } from '../_services/validation.service';
 
 export type ResponseDTO = {
   validations: ValidationResult[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  validations: Joi.array().items(
+    Joi.object({
+      rule: Joi.string().required(),
+      valid: Joi.boolean().required(),
+      details: Joi.any().optional()
+    })
+  )
+});

--- a/apps/innovations/v1-ir-schema-info/index.ts
+++ b/apps/innovations/v1-ir-schema-info/index.ts
@@ -2,14 +2,14 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@innovations/shared/decorators';
-import { ResponseHelper } from '@innovations/shared/helpers';
+import { ResponseHelper, SwaggerHelper } from '@innovations/shared/helpers';
 import type { AuthorizationService, IRSchemaService } from '@innovations/shared/services';
 import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
 import type { CustomContextType } from '@innovations/shared/types';
 
 import { container } from '../_config';
 
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 
 class V1IrSchemaInfo {
   @JwtDecoder()
@@ -43,14 +43,9 @@ export default openApi(V1IrSchemaInfo.httpTrigger as AzureFunction, '/v1/ir-sche
     description: 'Get current ir schema',
     tags: ['[v1] IR Schema'],
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: { type: 'object', properties: {} }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: { description: 'Bad request' },
       401: { description: 'Not authorized' },
       403: { description: 'Forbidden' },

--- a/apps/innovations/v1-ir-schema-info/transformation.dtos.ts
+++ b/apps/innovations/v1-ir-schema-info/transformation.dtos.ts
@@ -1,3 +1,9 @@
 import type { IRSchemaType } from '@innovations/shared/models';
+import Joi from 'joi';
 
 export type ResponseDTO = { version: number; schema: IRSchemaType };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  version: Joi.number().integer().required(),
+  schema: Joi.object<IRSchemaType>().required()
+});

--- a/apps/users/.apim/swagger.yaml
+++ b/apps/users/.apim/swagger.yaml
@@ -303,21 +303,37 @@ paths:
                       format: uuid
                     title:
                       type: string
-                    userRoles:
-                      type: array
-                      items:
-                        type: string
-                        enum:
-                          - ADMIN
-                          - INNOVATOR
-                          - ACCESSOR
-                          - ASSESSMENT
-                          - QUALIFYING_ACCESSOR
-                    createdAt:
+                    startsAt:
                       type: string
                       format: date-time
+                    expiresAt:
+                      type: string
+                      format: date-time
+                      nullable: true
                     params:
                       type: object
+                      properties:
+                        content:
+                          type: string
+                        link:
+                          type: object
+                          properties:
+                            label:
+                              type: string
+                            url:
+                              type: string
+                          required:
+                            - label
+                            - url
+                          additionalProperties: false
+                      required:
+                        - content
+                      additionalProperties: false
+                      nullable: true
+                  required:
+                    - title
+                    - startsAt
+                  additionalProperties: false
   /v1/me:
     post:
       description: Create a new user on DB

--- a/apps/users/.apim/swagger.yaml
+++ b/apps/users/.apim/swagger.yaml
@@ -243,6 +243,29 @@ paths:
                 type: array
                 items:
                   type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    invitedAt:
+                      type: string
+                      format: date-time
+                    innovation:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        name:
+                          type: string
+                      required:
+                        - id
+                        - name
+                      additionalProperties: false
+                  required:
+                    - id
+                    - invitedAt
+                  additionalProperties: false
   /v1/me/announcements/{announcementId}/read:
     patch:
       operationId: v1-me-announcement-read
@@ -331,6 +354,7 @@ paths:
                       additionalProperties: false
                       nullable: true
                   required:
+                    - id
                     - title
                     - startsAt
                   additionalProperties: false
@@ -350,6 +374,10 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad request
           content:
@@ -378,44 +406,151 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  email:
-                    type: string
-                  displayName:
-                    type: string
-                  roles:
-                    type: array
-                    items:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
                       type: string
-                  contactByEmail:
-                    type: boolean
-                  contactByPhone:
-                    type: boolean
-                  contactByPhoneTimeframe:
-                    type: string
-                  contactDetails:
-                    type: string
-                  phone:
-                    type: string
-                  passwordResetAt:
-                    type: string
-                  firstTimeSignInAt:
-                    type: string
-                  termsOfUseAccepted:
-                    type: boolean
-                  hasInnovationTransfers:
-                    type: boolean
-                  hasInnovationCollaborations:
-                    type: boolean
-                  hasLoginAnnouncements:
-                    type: object
-                  organisations:
-                    type: array
-                    items:
+                      format: uuid
+                    email:
+                      type: string
+                    displayName:
+                      type: string
+                    roles:
                       type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        role:
+                          type: string
+                          enum:
+                            - ADMIN
+                            - INNOVATOR
+                            - ACCESSOR
+                            - ASSESSMENT
+                            - QUALIFYING_ACCESSOR
+                        isActive:
+                          type: boolean
+                        organisation:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                            name:
+                              type: string
+                            acronym:
+                              type: string
+                              nullable: true
+                          required:
+                            - id
+                            - name
+                            - acronym
+                          additionalProperties: false
+                        organisationUnit:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                            name:
+                              type: string
+                            acronym:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - acronym
+                          additionalProperties: false
+                      required:
+                        - id
+                        - isActive
+                      additionalProperties: false
+                    contactByEmail:
+                      type: boolean
+                    contactByPhone:
+                      type: boolean
+                    contactByPhoneTimeframe:
+                      type: string
+                      enum:
+                        - MORNING
+                        - AFTERNOON
+                        - DAILY
+                      nullable: true
+                    contactDetails:
+                      type: string
+                      nullable: true
+                    phone:
+                      type: string
+                      nullable: true
+                    termsOfUseAccepted:
+                      type: boolean
+                    hasInnovationTransfers:
+                      type: boolean
+                    hasInnovationCollaborations:
+                      type: boolean
+                    hasLoginAnnouncements:
+                      type: object
+                      properties: {}
+                      additionalProperties:
+                        type: boolean
+                    passwordResetAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    firstTimeSignInAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    organisations:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                          acronym:
+                            type: string
+                            nullable: true
+                          name:
+                            type: string
+                          isShadow:
+                            type: boolean
+                          size:
+                            type: string
+                            nullable: true
+                          description:
+                            type: string
+                            nullable: true
+                          registrationNumber:
+                            type: string
+                            nullable: true
+                        required:
+                          - id
+                          - acronym
+                          - name
+                          - isShadow
+                          - size
+                          - description
+                          - registrationNumber
+                        additionalProperties: false
+                  required:
+                    - id
+                    - email
+                    - displayName
+                    - contactByEmail
+                    - contactByPhone
+                    - contactDetails
+                    - phone
+                    - termsOfUseAccepted
+                    - hasInnovationTransfers
+                    - hasInnovationCollaborations
+                    - passwordResetAt
+                    - firstTimeSignInAt
+                  additionalProperties: false
         "400":
           description: Bad Request
         "401":
@@ -536,6 +671,10 @@ paths:
                 properties:
                   id:
                     type: string
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "400":
           description: Bad request
           content:
@@ -600,12 +739,21 @@ paths:
                   properties:
                     id:
                       type: string
+                      format: uuid
                     name:
                       type: string
                     collaboratorsCount:
-                      type: number
+                      type: integer
                     expirationTransferDate:
                       type: string
+                      format: date-time
+                      nullable: true
+                  required:
+                    - id
+                    - name
+                    - collaboratorsCount
+                    - expirationTransferDate
+                  additionalProperties: false
         "400":
           description: Bad request
   /v1/me/mfa:
@@ -630,6 +778,9 @@ paths:
                       - phone
                   phoneNumber:
                     type: string
+                required:
+                  - type
+                additionalProperties: false
         "400":
           description: Bad Request
         "401":
@@ -696,7 +847,10 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: Operation identifier
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
         "422":
           description: Unprocessable Entity
   /v1/me/terms-of-use:
@@ -709,6 +863,30 @@ paths:
       responses:
         "200":
           description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  name:
+                    type: string
+                  summary:
+                    type: string
+                  releasedAt:
+                    type: string
+                    format: date-time
+                  isAccepted:
+                    type: boolean
+                required:
+                  - id
+                  - name
+                  - summary
+                  - releasedAt
+                  - isAccepted
+                additionalProperties: false
         "404":
           description: Terms of use not found
   /v1/notifications/counters:
@@ -727,8 +905,11 @@ paths:
                 type: object
                 properties:
                   total:
-                    type: number
+                    type: integer
                     description: The total of active notifications
+                required:
+                  - total
+                additionalProperties: false
   /v1/notifications/{notificationId}:
     delete:
       description: Returns the id of the deleted notification
@@ -753,7 +934,10 @@ paths:
                 properties:
                   id:
                     type: string
-                    description: The notification id
+                    format: uuid
+                required:
+                  - id
+                additionalProperties: false
   /v1/notifications/dismiss:
     patch:
       description: Returns the number of affected notifications
@@ -896,8 +1080,11 @@ paths:
                 type: object
                 properties:
                   affected:
-                    type: number
+                    type: integer
                     description: The number of affected notifications
+                required:
+                  - affected
+                additionalProperties: false
   /v1/notifications:
     get:
       description: Returns the user notifications
@@ -969,8 +1156,7 @@ paths:
                 type: object
                 properties:
                   count:
-                    type: number
-                    description: The total number of notifications
+                    type: integer
                   data:
                     type: array
                     items:
@@ -979,17 +1165,14 @@ paths:
                         id:
                           type: string
                           format: uuid
-                          description: The notification ID
                         innovation:
                           type: object
                           properties:
                             id:
                               type: string
                               format: uuid
-                              description: The innovation ID
                             name:
                               type: string
-                              description: The innovation name
                             status:
                               type: string
                               enum:
@@ -999,7 +1182,14 @@ paths:
                                 - IN_PROGRESS
                                 - WITHDRAWN
                                 - ARCHIVED
-                              description: The innovation status
+                            ownerName:
+                              type: string
+                          required:
+                            - id
+                            - name
+                            - status
+                            - ownerName
+                          additionalProperties: false
                         contextType:
                           type: string
                           enum:
@@ -1015,7 +1205,6 @@ paths:
                             - AUTOMATIC
                             - NOTIFY_ME
                             - ANNOUNCEMENTS
-                          description: The notification context category
                         contextDetail:
                           type: string
                           enum:
@@ -1098,21 +1287,28 @@ paths:
                             - SUGGESTED_SUPPORT_UPDATED
                             - AP10_NEW_ANNOUNCEMENT
                             - AP11_NEW_ANNOUNCEMENT_WITH_INNOVATIONS_NAME
-                          description: The notification context detail
                         contextId:
                           type: string
-                          description: The notification context ID
                         createdAt:
                           type: string
                           format: date-time
-                          description: The notification creation date
                         readAt:
                           type: string
                           format: date-time
-                          description: The notification read date
+                          nullable: true
                         params:
                           type: object
-                          description: The notification params
+                          properties: {}
+                          additionalProperties: false
+                      required:
+                        - id
+                        - contextId
+                        - createdAt
+                        - readAt
+                      additionalProperties: false
+                required:
+                  - count
+                additionalProperties: false
   /v1/notify-me:
     delete:
       description: Notify me subscription delete
@@ -1317,6 +1513,29 @@ paths:
       responses:
         "200":
           description: List of user custom notifications
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    innovationId:
+                      type: string
+                      format: uuid
+                    name:
+                      type: string
+                    count:
+                      type: integer
+                    subscriptions:
+                      type: object
+                      properties: {}
+                      additionalProperties: false
+                  required:
+                    - innovationId
+                    - name
+                    - count
+                  additionalProperties: false
         "400":
           description: Bad Request
         "401":
@@ -1606,7 +1825,53 @@ paths:
             format: uuid
       responses:
         "200":
-          description: Success.
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        accessor:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            role:
+                              type: string
+                              enum:
+                                - ADMIN
+                                - INNOVATOR
+                                - ACCESSOR
+                                - ASSESSMENT
+                                - QUALIFYING_ACCESSOR
+                          required:
+                            - name
+                          additionalProperties: false
+                        innovations:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                                format: uuid
+                              name:
+                                type: string
+                            required:
+                              - id
+                              - name
+                            additionalProperties: false
+                      additionalProperties: false
+                required:
+                  - count
+                additionalProperties: false
         "400":
           description: Bad Request
         "401":
@@ -1659,6 +1924,38 @@ paths:
                 type: array
                 items:
                   type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    name:
+                      type: string
+                    acronym:
+                      type: string
+                    isActive:
+                      type: boolean
+                    organisationUnits:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        name:
+                          type: string
+                        acronym:
+                          type: string
+                        isActive:
+                          type: boolean
+                      required:
+                        - id
+                        - name
+                        - acronym
+                      additionalProperties: false
+                  required:
+                    - id
+                    - name
+                    - acronym
+                  additionalProperties: false
   /v1:
     head:
       operationId: v1-users-email-available

--- a/apps/users/.apim/swagger.yaml
+++ b/apps/users/.apim/swagger.yaml
@@ -425,77 +425,91 @@ paths:
               properties:
                 displayName:
                   type: string
-                  description: The display name of the user
-                  example: John Doe
                 mobilePhone:
                   type: string
-                  description: The mobile phone number of the user
-                  example: "07777777777"
+                  maxLength: 20
+                  nullable: true
+                contactByEmail:
+                  type: boolean
+                contactByPhone:
+                  type: boolean
+                contactByPhoneTimeframe:
+                  enum:
+                    - MORNING
+                    - AFTERNOON
+                    - DAILY
+                  nullable: true
+                contactDetails:
+                  type: string
+                  nullable: true
                 organisation:
                   type: object
                   properties:
                     id:
                       type: string
-                      description: The ID of the organisation
-                      example: 12345678-1234-1234-1234-123456789012
-                    name:
-                      type: string
-                      description: The name of the organisation
-                      example: Example Organisation
+                      format: uuid
                     isShadow:
                       type: boolean
-                      description: Whether the organisation is a shadow organisation
-                      example: false
+                    name:
+                      anyOf:
+                        - type: string
+                          maxLength: 100
+                          x-required: true
+                        - type: string
+                          nullable: true
                     size:
+                      anyOf:
+                        - type: string
+                          maxLength: 25
+                          x-required: true
+                        - type: string
+                          nullable: true
+                    description:
+                      anyOf:
+                        - type: string
+                          maxLength: 50
+                          x-required: true
+                        - type: string
+                          nullable: true
+                    registrationNumber:
                       type: string
-                      description: The size of the organisation
-                      example: small
+                      maxLength: 8
+                      nullable: true
+                  required:
+                    - id
+                    - isShadow
+                  additionalProperties: false
                 howDidYouFindUsAnswers:
                   type: object
                   properties:
                     event:
                       type: boolean
-                      description: Whether this field's checkbox was selected or not
-                      example: false
                     eventComment:
                       type: string
-                      description: Mandatory comment for "event" field, if selected
                     reading:
                       type: boolean
-                      description: Whether this field's checkbox was selected or not
-                      example: false
-                    redingComment:
+                    readingComment:
                       type: string
-                      description: Mandatory comment for "reading" field, if selected
-                      example: An article on Linkedin
                     recommendationColleague:
                       type: boolean
-                      description: Whether this field's checkbox was selected or not
-                      example: false
                     recommendationOrg:
                       type: boolean
-                      description: Whether this field's checkbox was selected or not
-                      example: false
                     recommendationOrgComment:
                       type: string
-                      description: Mandatory comment for "recommendationOrg" field, if selected
-                      example: Someone at NICE
                     searchEngine:
                       type: boolean
-                      description: Whether this field's checkbox was selected or not
-                      example: false
                     socialMedia:
                       type: boolean
-                      description: Whether this field's checkbox was selected or not
-                      example: false
                     other:
                       type: boolean
-                      description: Whether this field's checkbox was selected or not
-                      example: false
                     otherComment:
                       type: string
-                      description: Mandatory comment for "other" field, if selected
-                      example: Colleague who has used the service before
+                  additionalProperties: false
+              required:
+                - displayName
+                - organisation
+                - howDidYouFindUsAnswers
+              additionalProperties: false
       responses:
         "200":
           description: User information updated
@@ -1653,7 +1667,71 @@ paths:
       description: Get users list
       tags:
         - "[v1] Users"
-      parameters: []
+      parameters:
+        - name: skip
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: take
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 500
+            default: 20
+        - name: order
+          in: query
+          required: false
+          schema:
+            type: object
+            properties: {}
+            additionalProperties:
+              type: string
+              enum:
+                - ASC
+                - DESC
+            default:
+              default: DESC
+        - name: userTypes
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - ADMIN
+                - INNOVATOR
+                - ACCESSOR
+                - ASSESSMENT
+                - QUALIFYING_ACCESSOR
+            minItems: 1
+            description: Types of user to filter.
+        - name: organisationUnitId
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+            description: Id of the organisation unit the user belongs to.
+        - name: onlyActive
+          in: query
+          required: false
+          schema:
+            type: boolean
+            description: List only active users or all users.
+        - name: fields
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - email
+            description: Additional fields to display in response.
+            default: []
       responses:
         "200":
           description: Success
@@ -1672,17 +1750,19 @@ paths:
       tags:
         - "[v1] User Statistics"
       parameters:
-        - in: query
-          name: statistics
-          required: false
+        - name: statistics
+          in: query
+          required: true
           schema:
-            type: string
-            enum:
-              - WAITING_ASSESSMENT_COUNTER
-              - ASSIGNED_INNOVATIONS_COUNTER
-              - INNOVATIONS_ASSIGNED_TO_ME_COUNTER
-              - TASKS_RESPONDED_COUNTER
-              - INNOVATIONS_TO_REVIEW_COUNTER
+            type: array
+            items:
+              type: string
+              enum:
+                - WAITING_ASSESSMENT_COUNTER
+                - ASSIGNED_INNOVATIONS_COUNTER
+                - INNOVATIONS_ASSIGNED_TO_ME_COUNTER
+                - TASKS_RESPONDED_COUNTER
+                - INNOVATIONS_TO_REVIEW_COUNTER
       responses:
         "200":
           description: Ok

--- a/apps/users/v1-invites-list/index.ts
+++ b/apps/users/v1-invites-list/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction } from '@azure/functions';
 
 import { JwtDecoder } from '@users/shared/decorators';
-import { ResponseHelper } from '@users/shared/helpers';
+import { ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
 import type { CustomContextType } from '@users/shared/types';
@@ -10,7 +10,7 @@ import type { CustomContextType } from '@users/shared/types';
 import { container } from '../_config';
 import SYMBOLS from '../_services/symbols';
 import type { UsersService } from '../_services/users.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 
 class V1UserInvitesList {
   @JwtDecoder()
@@ -38,19 +38,9 @@ export default openApi(V1UserInvitesList.httpTrigger as AzureFunction, '/v1/invi
     operationId: 'v1-invites-list',
     parameters: [],
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'array',
-              items: {
-                type: 'object'
-              }
-            }
-          }
-        }
-      }
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      })
     }
   }
 });

--- a/apps/users/v1-invites-list/transformation.dtos.ts
+++ b/apps/users/v1-invites-list/transformation.dtos.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
   invitedAt: Date;
@@ -6,3 +8,14 @@ export type ResponseDTO = {
     name: string;
   };
 }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    id: Joi.string().uuid().required(),
+    invitedAt: Joi.date().required(),
+    innovation: Joi.object({
+      id: Joi.string().uuid().required(),
+      name: Joi.string().required()
+    })
+  })
+);

--- a/apps/users/v1-me-announcements/index.ts
+++ b/apps/users/v1-me-announcements/index.ts
@@ -2,7 +2,6 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@users/shared/decorators';
-import { ServiceRoleEnum } from '@users/shared/enums';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';

--- a/apps/users/v1-me-announcements/index.ts
+++ b/apps/users/v1-me-announcements/index.ts
@@ -12,7 +12,7 @@ import { container } from '../_config';
 import type { AnnouncementsService } from '../_services/announcements.service';
 import SYMBOLS from '../_services/symbols';
 
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { QueryParamsType, QueryParamsSchema } from '../v1-me-announcements/validation.schemas';
 
 class V1MeAnnouncements {
@@ -58,26 +58,7 @@ export default openApi(V1MeAnnouncements.httpTrigger as AzureFunction, '/v1/me/a
     tags: ['[v1] Announcements'],
     parameters: SwaggerHelper.paramJ2S({ query: QueryParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  id: { type: 'string', format: 'uuid' },
-                  title: { type: 'string' },
-                  userRoles: { type: 'array', items: { type: 'string', enum: Object.keys(ServiceRoleEnum) } },
-                  createdAt: { type: 'string', format: 'date-time' },
-                  params: { type: 'object' }
-                }
-              }
-            }
-          }
-        }
-      }
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, { description: 'Success' })
     }
   }
 });

--- a/apps/users/v1-me-announcements/transformation.dtos.ts
+++ b/apps/users/v1-me-announcements/transformation.dtos.ts
@@ -10,9 +10,9 @@ export type ResponseDTO = {
   innovations?: string[];
 }[];
 
-export const ResponseBodySchema = Joi.array().items(
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
   Joi.object({
-    id: Joi.string().guid(),
+    id: Joi.string().uuid().required(),
     title: Joi.string().required(),
     startsAt: Joi.date().required(),
     expiresAt: Joi.date().allow(null),

--- a/apps/users/v1-me-announcements/transformation.dtos.ts
+++ b/apps/users/v1-me-announcements/transformation.dtos.ts
@@ -1,4 +1,5 @@
 import type { AnnouncementParamsType } from '@users/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   id: string;
@@ -8,3 +9,19 @@ export type ResponseDTO = {
   params: null | AnnouncementParamsType;
   innovations?: string[];
 }[];
+
+export const ResponseBodySchema = Joi.array().items(
+  Joi.object({
+    id: Joi.string().guid(),
+    title: Joi.string().required(),
+    startsAt: Joi.date().required(),
+    expiresAt: Joi.date().allow(null),
+    params: Joi.object<AnnouncementParamsType>({
+      content: Joi.string().required(),
+      link: Joi.object({
+        label: Joi.string().required(),
+        url: Joi.string().required()
+      }).optional()
+    }).allow(null)
+  })
+);

--- a/apps/users/v1-me-create/index.ts
+++ b/apps/users/v1-me-create/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction } from '@azure/functions';
 
-import { ResponseHelper } from '@users/shared/helpers';
+import { ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 
 import { container } from '../_config';
 
@@ -9,7 +9,7 @@ import { JwtDecoder } from '@users/shared/decorators';
 import type { CustomContextType } from '@users/shared/types';
 import SYMBOLS from '../_services/symbols';
 import type { UsersService } from '../_services/users.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 
 class V1MeCreate {
   @JwtDecoder()
@@ -34,19 +34,9 @@ export default openApi(V1MeCreate.httpTrigger as AzureFunction, '/v1/me', {
     operationId: 'v1-me-create',
     tags: ['[v1] Users'],
     responses: {
-      200: {
-        description: 'User created',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string' }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'User created'
+      }),
       400: {
         description: 'Bad request',
         content: {

--- a/apps/users/v1-me-create/transformation.dtos.ts
+++ b/apps/users/v1-me-create/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/users/v1-me-info/index.ts
+++ b/apps/users/v1-me-info/index.ts
@@ -15,7 +15,7 @@ import SYMBOLS from '../_services/symbols';
 import type { TermsOfUseService } from '../_services/terms-of-use.service';
 import type { UsersService } from '../_services/users.service';
 
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { QueryParamsSchema, QueryParamsType } from './validation.schema';
 
 class V1MeInfo {
@@ -110,34 +110,9 @@ export default openApi(V1MeInfo.httpTrigger as AzureFunction, '/v1/me', {
     tags: ['[v1] Users'],
     parameters: SwaggerHelper.paramJ2S({ path: QueryParamsSchema }),
     responses: {
-      200: {
-        description: 'Successful operation',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string' },
-                email: { type: 'string' },
-                displayName: { type: 'string' },
-                roles: { type: 'array', items: { type: 'string' } },
-                contactByEmail: { type: 'boolean' },
-                contactByPhone: { type: 'boolean' },
-                contactByPhoneTimeframe: { type: 'string' },
-                contactDetails: { type: 'string' },
-                phone: { type: 'string' },
-                passwordResetAt: { type: 'string' },
-                firstTimeSignInAt: { type: 'string' },
-                termsOfUseAccepted: { type: 'boolean' },
-                hasInnovationTransfers: { type: 'boolean' },
-                hasInnovationCollaborations: { type: 'boolean' },
-                hasLoginAnnouncements: { type: 'object' },
-                organisations: { type: 'array', items: { type: 'object' } }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Successful operation'
+      }),
       400: { description: 'Bad Request' },
       401: { description: 'Unauthorized' },
       403: { description: 'Forbidden' },

--- a/apps/users/v1-me-info/transformation.dtos.ts
+++ b/apps/users/v1-me-info/transformation.dtos.ts
@@ -1,5 +1,7 @@
-import type { PhoneUserPreferenceEnum } from '@users/shared/enums';
+import { PhoneUserPreferenceEnum } from '@users/shared/enums';
 import type { RoleType } from '@users/shared/types';
+import Joi from 'joi';
+import { ServiceRoleEnum } from 'libs/shared/enums/user.enums';
 
 export type ResponseDTO = {
   id: string;
@@ -28,3 +30,54 @@ export type ResponseDTO = {
     organisationUnits: { id: string; name: string; acronym: string }[];
   }[];
 };
+
+const organisationsSchema = Joi.array().items(
+  Joi.object({
+    id: Joi.string().uuid().required(),
+    acronym: Joi.string().allow(null).required(),
+    name: Joi.string().required(),
+    isShadow: Joi.boolean().required(),
+    size: Joi.string().allow(null).required(),
+    description: Joi.string().allow(null).required(),
+    registrationNumber: Joi.string().allow(null).required()
+  })
+);
+
+const rolesTypeSchema = {
+  id: Joi.string().uuid().required(),
+  role: Joi.string().valid(...Object.values(ServiceRoleEnum)),
+  isActive: Joi.boolean().required(),
+  organisation: Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required(),
+    acronym: Joi.string().allow(null).required()
+  }).optional(),
+  organisationUnit: Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required(),
+    acronym: Joi.string().required()
+  }).optional()
+};
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    id: Joi.string().uuid().required(),
+    email: Joi.string().required(),
+    displayName: Joi.string().required(),
+    roles: rolesTypeSchema,
+    contactByEmail: Joi.boolean().required(),
+    contactByPhone: Joi.boolean().required(),
+    contactByPhoneTimeframe: Joi.string()
+      .valid(...Object.values(PhoneUserPreferenceEnum))
+      .allow(null),
+    contactDetails: Joi.string().allow(null).required(),
+    phone: Joi.string().allow(null).required(),
+    termsOfUseAccepted: Joi.boolean().required(),
+    hasInnovationTransfers: Joi.boolean().required(),
+    hasInnovationCollaborations: Joi.boolean().required(),
+    hasLoginAnnouncements: Joi.object().pattern(Joi.string(), Joi.boolean()),
+    passwordResetAt: Joi.date().allow(null).required(),
+    firstTimeSignInAt: Joi.date().allow(null).required(),
+    organisations: organisationsSchema
+  })
+);

--- a/apps/users/v1-me-info/transformation.dtos.ts
+++ b/apps/users/v1-me-info/transformation.dtos.ts
@@ -1,7 +1,7 @@
 import { PhoneUserPreferenceEnum } from '@users/shared/enums';
 import type { RoleType } from '@users/shared/types';
 import Joi from 'joi';
-import { ServiceRoleEnum } from 'libs/shared/enums/user.enums';
+import { ServiceRoleEnum } from '@users/shared/enums';
 
 export type ResponseDTO = {
   id: string;

--- a/apps/users/v1-me-innovations/index.ts
+++ b/apps/users/v1-me-innovations/index.ts
@@ -1,13 +1,13 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction } from '@azure/functions';
 import { JwtDecoder } from '@users/shared/decorators';
-import { ResponseHelper } from '@users/shared/helpers';
+import { ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService, DomainService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
 import type { CustomContextType } from '@users/shared/types';
 
 import { container } from '../_config';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 
 class V1MeInnovationsInfo {
   @JwtDecoder()
@@ -36,33 +36,9 @@ export default openApi(V1MeInnovationsInfo.httpTrigger as AzureFunction, '/v1/me
     tags: ['[v1] Owned innovations information'],
     parameters: [],
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string'
-                  },
-                  name: {
-                    type: 'string'
-                  },
-                  collaboratorsCount: {
-                    type: 'number'
-                  },
-                  expirationTransferDate: {
-                    type: 'string'
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: { description: 'Bad request' }
     }
   }

--- a/apps/users/v1-me-innovations/transformation.dtos.ts
+++ b/apps/users/v1-me-innovations/transformation.dtos.ts
@@ -1,6 +1,17 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
   name: string;
   collaboratorsCount: number;
   expirationTransferDate: Date | null;
 }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required(),
+    collaboratorsCount: Joi.number().integer().required(),
+    expirationTransferDate: Joi.date().allow(null).required()
+  })
+);

--- a/apps/users/v1-me-mfa-info/index.ts
+++ b/apps/users/v1-me-mfa-info/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@users/shared/decorators';
-import {  ResponseHelper } from '@users/shared/helpers';
+import { ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
 import type { CustomContextType } from '@users/shared/types';
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import SYMBOLS from '../_services/symbols';
 import type { UsersService } from '../_services/users.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 
 class V1MeMfaInfo {
   @JwtDecoder()
@@ -20,12 +20,13 @@ class V1MeMfaInfo {
     const usersService = container.get<UsersService>(SYMBOLS.UsersService);
 
     try {
-      const auth = await authorizationService.validate(context)
-      .checkInnovatorType()
-      .checkAssessmentType()
-      .checkAccessorType()
-      .checkAdminType()
-      .verify();
+      const auth = await authorizationService
+        .validate(context)
+        .checkInnovatorType()
+        .checkAssessmentType()
+        .checkAccessorType()
+        .checkAdminType()
+        .verify();
 
       const result = await usersService.getUserMfaInfo(auth.getContext());
 
@@ -44,20 +45,9 @@ export default openApi(V1MeMfaInfo.httpTrigger as AzureFunction, '/v1/me/mfa', {
     operationId: 'v1-me-mfa-info',
     tags: ['[v1] Users'],
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                type: { type: 'string', enum: ['none', 'email', 'phone'] },
-                phoneNumber: { type: 'string' },
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      }),
       400: { description: 'Bad Request' },
       401: { description: 'Unauthorized' },
       403: { description: 'Forbidden' },

--- a/apps/users/v1-me-mfa-info/transformation.dtos.ts
+++ b/apps/users/v1-me-mfa-info/transformation.dtos.ts
@@ -1,1 +1,8 @@
+import Joi from 'joi';
+
 export type ResponseDTO = { type: 'none' } | { type: 'email' } | { type: 'phone'; phoneNumber?: string };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  type: Joi.string().valid('none', 'email', 'phone').required(),
+  phoneNumber: Joi.string().optional()
+});

--- a/apps/users/v1-me-terms-of-use-accept/index.ts
+++ b/apps/users/v1-me-terms-of-use-accept/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction } from '@azure/functions';
 
 import { JwtDecoder } from '@users/shared/decorators';
-import { ResponseHelper } from '@users/shared/helpers';
+import { ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
 import type { CustomContextType } from '@users/shared/types';
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import SYMBOLS from '../_services/symbols';
 import type { TermsOfUseService } from '../_services/terms-of-use.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 
 class V1MeTermsOfUseAccept {
   @JwtDecoder()
@@ -51,19 +51,9 @@ export default openApi(V1MeTermsOfUseAccept.httpTrigger as AzureFunction, '/v1/m
     tags: ['[v1] Terms of Use'],
     parameters: [],
     responses: {
-      200: {
-        description: 'Successful operation',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string', description: 'Operation identifier' }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Successful operation'
+      }),
       422: { description: 'Unprocessable Entity' }
     }
   }

--- a/apps/users/v1-me-terms-of-use-accept/transformation.dtos.ts
+++ b/apps/users/v1-me-terms-of-use-accept/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/users/v1-me-terms-of-use-info/index.ts
+++ b/apps/users/v1-me-terms-of-use-info/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction } from '@azure/functions';
 
 import { JwtDecoder } from '@users/shared/decorators';
-import { ResponseHelper } from '@users/shared/helpers';
+import { ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
 import type { CustomContextType } from '@users/shared/types';
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import SYMBOLS from '../_services/symbols';
 import type { TermsOfUseService } from '../_services/terms-of-use.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 
 class V1MeTermsOfUseInfo {
   @JwtDecoder()
@@ -57,7 +57,9 @@ export default openApi(V1MeTermsOfUseInfo.httpTrigger as AzureFunction, '/v1/me/
     tags: ['[v1] Terms of Use'],
     parameters: [],
     responses: {
-      200: { description: 'Successful operation' },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Successful operation'
+      }),
       404: { description: 'Terms of use not found' }
     }
   }

--- a/apps/users/v1-me-terms-of-use-info/transformation.dtos.ts
+++ b/apps/users/v1-me-terms-of-use-info/transformation.dtos.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
   name: string;
@@ -5,3 +7,11 @@ export type ResponseDTO = {
   releasedAt: null | Date;
   isAccepted: boolean;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().required(),
+  name: Joi.string().required(),
+  summary: Joi.string().required(),
+  releasedAt: Joi.date().required(),
+  isAccepted: Joi.boolean().required()
+});

--- a/apps/users/v1-me-update/index.ts
+++ b/apps/users/v1-me-update/index.ts
@@ -4,7 +4,7 @@ import type { AzureFunction, HttpRequest } from '@azure/functions';
 import { JwtDecoder } from '@users/shared/decorators';
 import { ServiceRoleEnum } from '@users/shared/enums';
 import { BadRequestError, GenericErrorsEnum } from '@users/shared/errors';
-import { JoiHelper, ResponseHelper } from '@users/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
 import type { CustomContextType } from '@users/shared/types';
@@ -95,112 +95,7 @@ export default openApi(V1MeUpdate.httpTrigger as AzureFunction, '/v1/me', {
     operationId: 'v1-me-update',
     tags: ['[v1] Users'],
     parameters: [],
-    requestBody: {
-      required: true,
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              displayName: {
-                type: 'string',
-                description: 'The display name of the user',
-                example: 'John Doe'
-              },
-              mobilePhone: {
-                type: 'string',
-                description: 'The mobile phone number of the user',
-                example: '07777777777'
-              },
-              organisation: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string',
-                    description: 'The ID of the organisation',
-                    example: '12345678-1234-1234-1234-123456789012'
-                  },
-                  name: {
-                    type: 'string',
-                    description: 'The name of the organisation',
-                    example: 'Example Organisation'
-                  },
-                  isShadow: {
-                    type: 'boolean',
-                    description: 'Whether the organisation is a shadow organisation',
-                    example: false
-                  },
-                  size: {
-                    type: 'string',
-                    description: 'The size of the organisation',
-                    example: 'small'
-                  }
-                }
-              },
-              howDidYouFindUsAnswers: {
-                type: 'object',
-                properties: {
-                  event: {
-                    type: 'boolean',
-                    description: "Whether this field's checkbox was selected or not",
-                    example: false
-                  },
-                  eventComment: {
-                    type: 'string',
-                    description: 'Mandatory comment for "event" field, if selected'
-                  },
-                  reading: {
-                    type: 'boolean',
-                    description: "Whether this field's checkbox was selected or not",
-                    example: false
-                  },
-                  redingComment: {
-                    type: 'string',
-                    description: 'Mandatory comment for "reading" field, if selected',
-                    example: 'An article on Linkedin'
-                  },
-                  recommendationColleague: {
-                    type: 'boolean',
-                    description: "Whether this field's checkbox was selected or not",
-                    example: false
-                  },
-                  recommendationOrg: {
-                    type: 'boolean',
-                    description: "Whether this field's checkbox was selected or not",
-                    example: false
-                  },
-                  recommendationOrgComment: {
-                    type: 'string',
-                    description: 'Mandatory comment for "recommendationOrg" field, if selected',
-                    example: 'Someone at NICE'
-                  },
-                  searchEngine: {
-                    type: 'boolean',
-                    description: "Whether this field's checkbox was selected or not",
-                    example: false
-                  },
-                  socialMedia: {
-                    type: 'boolean',
-                    description: "Whether this field's checkbox was selected or not",
-                    example: false
-                  },
-                  other: {
-                    type: 'boolean',
-                    description: "Whether this field's checkbox was selected or not",
-                    example: false
-                  },
-                  otherComment: {
-                    type: 'string',
-                    description: 'Mandatory comment for "other" field, if selected',
-                    example: 'Colleague who has used the service before'
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
+    requestBody: SwaggerHelper.bodyJ2S(InnovatorBodySchema),
     responses: {
       200: {
         description: 'User information updated',

--- a/apps/users/v1-me-update/index.ts
+++ b/apps/users/v1-me-update/index.ts
@@ -13,7 +13,7 @@ import { container } from '../_config';
 
 import SYMBOLS from '../_services/symbols';
 import type { UsersService } from '../_services/users.service';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import {
   DefaultUserBodySchema,
   DefaultUserBodyType,
@@ -97,19 +97,9 @@ export default openApi(V1MeUpdate.httpTrigger as AzureFunction, '/v1/me', {
     parameters: [],
     requestBody: SwaggerHelper.bodyJ2S(InnovatorBodySchema),
     responses: {
-      200: {
-        description: 'User information updated',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string' }
-              }
-            }
-          }
-        }
-      },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'User information updated'
+      }),
       400: {
         description: 'Bad request',
         content: {

--- a/apps/users/v1-me-update/transformation.dtos.ts
+++ b/apps/users/v1-me-update/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/users/v1-notifications-counters/index.ts
+++ b/apps/users/v1-notifications-counters/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@users/shared/decorators';
-import { ResponseHelper } from '@users/shared/helpers';
+import { ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
 import type { CustomContextType } from '@users/shared/types';
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { NotificationsService } from '../_services/notifications.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 
 class V1UserNotificationsCounter {
   @JwtDecoder()
@@ -40,22 +40,9 @@ export default openApi(V1UserNotificationsCounter.httpTrigger as AzureFunction, 
     tags: ['[v1] Notifications'],
     parameters: [],
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                total: {
-                  type: 'number',
-                  description: 'The total of active notifications'
-                }
-              }
-            }
-          }
-        }
-      }
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      })
     }
   }
 });

--- a/apps/users/v1-notifications-counters/transformation.dtos.ts
+++ b/apps/users/v1-notifications-counters/transformation.dtos.ts
@@ -1,3 +1,9 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   total: number;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  total: Joi.number().integer().description('The total of active notifications').required()
+});

--- a/apps/users/v1-notifications-delete/index.ts
+++ b/apps/users/v1-notifications-delete/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { NotificationsService } from '../_services/notifications.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 
 class V1UserNotificationsDelete {
@@ -50,19 +50,9 @@ export default openApi(V1UserNotificationsDelete.httpTrigger as AzureFunction, '
     tags: ['[v1] Notifications'],
     parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                id: { type: 'string', description: 'The notification id' }
-              }
-            }
-          }
-        }
-      }
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      })
     }
   }
 });

--- a/apps/users/v1-notifications-delete/transformation.dtos.ts
+++ b/apps/users/v1-notifications-delete/transformation.dtos.ts
@@ -1,3 +1,7 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({ id: Joi.string().uuid().required() });

--- a/apps/users/v1-notifications-dismiss/index.ts
+++ b/apps/users/v1-notifications-dismiss/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { NotificationsService } from '../_services/notifications.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { BodySchema, BodyType } from './validation.schemas';
 
 class V1UserNotificationsDismiss {
@@ -49,19 +49,9 @@ export default openApi(V1UserNotificationsDismiss.httpTrigger as AzureFunction, 
     tags: ['[v1] Notifications'],
     requestBody: SwaggerHelper.bodyJ2S(BodySchema),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                affected: { type: 'number', description: 'The number of affected notifications' }
-              }
-            }
-          }
-        }
-      }
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      })
     }
   }
 });

--- a/apps/users/v1-notifications-dismiss/transformation.dtos.ts
+++ b/apps/users/v1-notifications-dismiss/transformation.dtos.ts
@@ -1,3 +1,9 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   affected: number;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  affected: Joi.number().integer().description('The number of affected notifications').required()
+});

--- a/apps/users/v1-notifications-list/index.ts
+++ b/apps/users/v1-notifications-list/index.ts
@@ -2,7 +2,6 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@users/shared/decorators';
-import { InnovationStatusEnum, NotificationCategoryType, NotificationDetailType } from '@users/shared/enums';
 import { JoiHelper, ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
@@ -12,7 +11,7 @@ import { container } from '../_config';
 
 import type { NotificationsService } from '../_services/notifications.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1UserNotifications {
@@ -71,82 +70,9 @@ export default openApi(V1UserNotifications.httpTrigger as AzureFunction, '/v1/no
     tags: ['[v1] Notifications'],
     parameters: SwaggerHelper.paramJ2S({ query: QueryParamsSchema }),
     responses: {
-      200: {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                count: {
-                  type: 'number',
-                  description: 'The total number of notifications'
-                },
-                data: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      id: {
-                        type: 'string',
-                        format: 'uuid',
-                        description: 'The notification ID'
-                      },
-                      innovation: {
-                        type: 'object',
-                        properties: {
-                          id: {
-                            type: 'string',
-                            format: 'uuid',
-                            description: 'The innovation ID'
-                          },
-                          name: {
-                            type: 'string',
-                            description: 'The innovation name'
-                          },
-                          status: {
-                            type: 'string',
-                            enum: Object.keys(InnovationStatusEnum),
-                            description: 'The innovation status'
-                          }
-                        }
-                      },
-                      contextType: {
-                        type: 'string',
-                        enum: NotificationCategoryType,
-                        description: 'The notification context category'
-                      },
-                      contextDetail: {
-                        type: 'string',
-                        enum: NotificationDetailType,
-                        description: 'The notification context detail'
-                      },
-                      contextId: {
-                        type: 'string',
-                        description: 'The notification context ID'
-                      },
-                      createdAt: {
-                        type: 'string',
-                        format: 'date-time',
-                        description: 'The notification creation date'
-                      },
-                      readAt: {
-                        type: 'string',
-                        format: 'date-time',
-                        description: 'The notification read date'
-                      },
-                      params: {
-                        type: 'object',
-                        description: 'The notification params'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Success'
+      })
     }
   }
 });

--- a/apps/users/v1-notifications-list/transformation.dtos.ts
+++ b/apps/users/v1-notifications-list/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { InnovationStatusEnum, NotificationCategoryType, NotificationDetailType } from '@users/shared/enums';
+import { InnovationStatusEnum, NotificationCategoryType, NotificationDetailType } from '@users/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   count: number;
@@ -13,3 +14,26 @@ export type ResponseDTO = {
     params: Record<string, unknown>; // used to be NotificationParamsType in legacy API;
   }[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  count: Joi.number().integer().required(),
+  data: Joi.array().items(
+    Joi.object({
+      id: Joi.string().uuid().required(),
+      innovation: Joi.object({
+        id: Joi.string().uuid().required(),
+        name: Joi.string().required(),
+        status: Joi.string()
+          .valid(...Object.values(InnovationStatusEnum))
+          .required(),
+        ownerName: Joi.string().required()
+      }),
+      contextType: Joi.string().valid(...NotificationCategoryType),
+      contextDetail: Joi.string().valid(...NotificationDetailType),
+      contextId: Joi.string().required(),
+      createdAt: Joi.date().required(),
+      readAt: Joi.date().allow(null).required(),
+      params: Joi.object()
+    })
+  )
+});

--- a/apps/users/v1-notify-me-subscription-list/index.ts
+++ b/apps/users/v1-notify-me-subscription-list/index.ts
@@ -2,7 +2,7 @@ import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-open
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@users/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@users/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
 import type { CustomContextType } from '@users/shared/types';
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { NotifyMeService } from '../_services/notify-me.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { QuerySchema, type QueryType } from './validation.schemas';
 
 class V1NotifyMeSubscriptionList {
@@ -41,7 +41,9 @@ export default openApi(V1NotifyMeSubscriptionList.httpTrigger as AzureFunction, 
     operationId: 'v1-notify-me-subscription-list',
     tags: ['[v1] Notify Me'],
     responses: {
-      200: { description: 'List of user custom notifications' },
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'List of user custom notifications'
+      }),
       400: { description: 'Bad Request' },
       401: { description: 'Unauthorized' },
       403: { description: 'Forbidden' },

--- a/apps/users/v1-notify-me-subscription-list/transformation.dtos.ts
+++ b/apps/users/v1-notify-me-subscription-list/transformation.dtos.ts
@@ -1,3 +1,4 @@
+import Joi from 'joi';
 import type { SubscriptionResponseDTO } from '../_types/notify-me.types';
 
 export type ResponseDTO = {
@@ -6,3 +7,12 @@ export type ResponseDTO = {
   count: number;
   subscriptions?: SubscriptionResponseDTO[];
 }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    innovationId: Joi.string().uuid().required(),
+    name: Joi.string().required(),
+    count: Joi.number().integer().required(),
+    subscriptions: Joi.object().optional()
+  })
+);

--- a/apps/users/v1-organisation-unit-accessors/index.ts
+++ b/apps/users/v1-organisation-unit-accessors/index.ts
@@ -11,7 +11,7 @@ import { container } from '../_config';
 
 import type { OrganisationsService } from '../_services/organisations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { ParamsSchema, ParamsType } from './validation.schemas';
 import { ServiceRoleEnum } from '@users/shared/enums';
 
@@ -24,7 +24,10 @@ class V1OrganisationUnitAccessors {
     try {
       const params = JoiHelper.Validate<ParamsType>(ParamsSchema, request.params);
 
-      const auth = await authorizationService.validate(context).checkAccessorType({ organisationRole: [ServiceRoleEnum.QUALIFYING_ACCESSOR] }).verify();
+      const auth = await authorizationService
+        .validate(context)
+        .checkAccessorType({ organisationRole: [ServiceRoleEnum.QUALIFYING_ACCESSOR] })
+        .verify();
 
       const result = await organisationsService.getAccessorAndInnovations(auth.getContext(), params.organisationUnitId);
 
@@ -46,7 +49,9 @@ export default openApi(
       operationId: 'v1-organisation-unit-accessors',
       parameters: SwaggerHelper.paramJ2S({ path: ParamsSchema }),
       responses: {
-        200: { description: 'Success.' },
+        200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+          description: 'Success'
+        }),
         400: { description: 'Bad Request' },
         401: { description: 'Unauthorized' },
         403: { description: 'Forbidden' },

--- a/apps/users/v1-organisation-unit-accessors/transformation.dtos.ts
+++ b/apps/users/v1-organisation-unit-accessors/transformation.dtos.ts
@@ -1,4 +1,5 @@
-import type { ServiceRoleEnum } from '@users/shared/enums';
+import { ServiceRoleEnum } from '@users/shared/enums';
+import Joi from 'joi';
 
 export type ResponseDTO = {
   count: number;
@@ -7,3 +8,21 @@ export type ResponseDTO = {
     innovations: { id: string; name: string }[];
   }[];
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  count: Joi.number().integer().required(),
+  data: Joi.array().items(
+    Joi.object({
+      accessor: Joi.object({
+        name: Joi.string().required(),
+        role: Joi.string().valid(...Object.values(ServiceRoleEnum))
+      }),
+      innovations: Joi.array().items(
+        Joi.object({
+          id: Joi.string().uuid().required(),
+          name: Joi.string().required()
+        })
+      )
+    })
+  )
+});

--- a/apps/users/v1-organisation-unit-info/transformation.dtos.ts
+++ b/apps/users/v1-organisation-unit-info/transformation.dtos.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
   name: string;
@@ -5,3 +7,11 @@ export type ResponseDTO = {
   isActive: boolean;
   canActivate: boolean;
 };
+
+export const ResponseBodySchema = Joi.object<ResponseDTO>({
+  id: Joi.string().uuid().required(),
+  name: Joi.string().required(),
+  acronym: Joi.string().required(),
+  isActive: Joi.boolean().required(),
+  canActivate: Joi.boolean().required()
+});

--- a/apps/users/v1-organisations-list/index.ts
+++ b/apps/users/v1-organisations-list/index.ts
@@ -3,7 +3,7 @@ import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@users/shared/decorators';
 import { ServiceRoleEnum } from '@users/shared/enums';
-import { JoiHelper, ResponseHelper } from '@users/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
 import type { CustomContextType } from '@users/shared/types';
@@ -12,7 +12,7 @@ import { container } from '../_config';
 
 import type { OrganisationsService } from '../_services/organisations.service';
 import SYMBOLS from '../_services/symbols';
-import type { ResponseDTO } from './transformation.dtos';
+import { ResponseBodySchema, type ResponseDTO } from './transformation.dtos';
 import { QueryParamsSchema, QueryParamsType } from './validation.schemas';
 
 class V1OrganisationsList {
@@ -74,19 +74,9 @@ export default openApi(V1OrganisationsList.httpTrigger as AzureFunction, '/v1/or
     tags: ['[v1] Organisations'],
     parameters: [],
     responses: {
-      200: {
-        description: 'Ok',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'array',
-              items: {
-                type: 'object'
-              }
-            }
-          }
-        }
-      }
+      200: SwaggerHelper.responseJ2S(ResponseBodySchema, {
+        description: 'Ok'
+      })
     }
   }
 });

--- a/apps/users/v1-organisations-list/transformation.dtos.ts
+++ b/apps/users/v1-organisations-list/transformation.dtos.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 export type ResponseDTO = {
   id: string;
   name: string;
@@ -5,3 +7,18 @@ export type ResponseDTO = {
   isActive?: boolean;
   organisationUnits?: { id: string; name: string; acronym: string; isActive?: boolean }[];
 }[];
+
+export const ResponseBodySchema = Joi.array<ResponseDTO>().items(
+  Joi.object({
+    id: Joi.string().uuid().required(),
+    name: Joi.string().required(),
+    acronym: Joi.string().required(),
+    isActive: Joi.boolean().optional(),
+    organisationUnits: Joi.object({
+      id: Joi.string().uuid().required(),
+      name: Joi.string().required(),
+      acronym: Joi.string().required(),
+      isActive: Joi.boolean().optional()
+    }).optional()
+  })
+);

--- a/apps/users/v1-users-list/index.ts
+++ b/apps/users/v1-users-list/index.ts
@@ -3,7 +3,7 @@ import type { AzureFunction, HttpRequest } from '@azure/functions';
 
 import { JwtDecoder } from '@users/shared/decorators';
 import { ServiceRoleEnum } from '@users/shared/enums';
-import { JoiHelper, ResponseHelper } from '@users/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
 import type { CustomContextType } from '@users/shared/types';
@@ -68,7 +68,7 @@ export default openApi(V1UsersList.httpTrigger as AzureFunction, '/v1', {
     operationId: 'v1-users-list',
     description: 'Get users list',
     tags: ['[v1] Users'],
-    parameters: [], // TODO: Add query params. Swagger helper doesn't support Joi.alternatives()
+    parameters: SwaggerHelper.paramJ2S({ query: QueryParamsSchema }),
     responses: {
       200: {
         description: 'Success',

--- a/apps/users/v1-users-statistics/index.ts
+++ b/apps/users/v1-users-statistics/index.ts
@@ -7,7 +7,6 @@ import SHARED_SYMBOLS from '@users/shared/services/symbols';
 import type { CustomContextType } from '@users/shared/types';
 
 import { container } from '../_config';
-import { UserStatisticsEnum } from '../_enums/user.enums';
 import { StatisticsHandlersHelper } from '../_helpers/handlers.helper';
 import type { ResponseDTO } from './transformation.dtos';
 import { QuerySchema, QueryType } from './validation.schemas';

--- a/apps/users/v1-users-statistics/index.ts
+++ b/apps/users/v1-users-statistics/index.ts
@@ -1,7 +1,7 @@
 import { mapOpenApi3 as openApi } from '@aaronpowell/azure-functions-nodejs-openapi';
 import type { AzureFunction, HttpRequest } from '@azure/functions';
 import { JwtDecoder } from '@users/shared/decorators';
-import { JoiHelper, ResponseHelper } from '@users/shared/helpers';
+import { JoiHelper, ResponseHelper, SwaggerHelper } from '@users/shared/helpers';
 import type { AuthorizationService } from '@users/shared/services';
 import SHARED_SYMBOLS from '@users/shared/services/symbols';
 import type { CustomContextType } from '@users/shared/types';
@@ -45,14 +45,7 @@ export default openApi(GetUserStatistics.httpTrigger as AzureFunction, '/v1/stat
     description: 'Get an user statistics',
     operationId: 'v1-users-statistics',
     tags: ['[v1] User Statistics'],
-    parameters: [
-      {
-        in: 'query',
-        name: 'statistics',
-        required: false,
-        schema: { type: 'string', enum: Object.keys(UserStatisticsEnum) }
-      }
-    ],
+    parameters: SwaggerHelper.paramJ2S({ query: QuerySchema }),
     responses: {
       200: {
         description: 'Ok',

--- a/libs/shared/helpers/swagger.helper.ts
+++ b/libs/shared/helpers/swagger.helper.ts
@@ -71,4 +71,21 @@ export class SwaggerHelper {
       }
     };
   };
+
+  /**
+   * conver joi schema for response body into a swagger schema
+   *
+   */
+  static responseJ2S = (data: Schema, options: { description: string }): OpenAPIV3.ResponseObject => {
+    const swaggerSchema = j2s(data).swagger;
+
+    return {
+      description: options.description,
+      content: {
+        'application/json': {
+          schema: swaggerSchema
+        }
+      }
+    };
+  };
 }


### PR DESCRIPTION
Description: 
  - Updates all endpoints' openApi `parameters` and `requestBody` properties to use `SwaggerHelper` helper.
  - Adds new method to `SwaggerHelper` to convert Joi validation schema to swagger for `responses` property.
  - Adds `ResponseBodySchema` Joi schema on all endpoints' `transformation.dto` files.

US:
[AB#177060](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/177060)

Tasks:
[AB#177495](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/177495)
[AB#177496](https://dev.azure.com/NHSiDev/InnovatorService/_workitems/edit/177496)