### PR TITLE
Task/create survey on close support

### DIFF
--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -2603,6 +2603,7 @@ paths:
                             - SUGGESTED
                             - ENGAGING
                             - WAITING
+                            - UNASSIGNED
                             - UNSUITABLE
                             - CLOSED
                         organisationUnitId:
@@ -3645,12 +3646,12 @@ paths:
                   enum:
                     - ENGAGING
                     - WAITING
-                    - UNASSIGNED
                     - UNSUITABLE
                     - CLOSED
                   not:
                     enum:
                       - SUGGESTED
+                      - UNASSIGNED
                 message:
                   type: string
                   maxLength: 2000
@@ -3707,6 +3708,7 @@ paths:
                       - SUGGESTED
                       - ENGAGING
                       - WAITING
+                      - UNASSIGNED
                       - UNSUITABLE
                       - CLOSED
                   engagingAccessors:
@@ -3764,7 +3766,6 @@ paths:
                   enum:
                     - ENGAGING
                     - WAITING
-                    - UNASSIGNED
                     - UNSUITABLE
                     - CLOSED
                 message:
@@ -3937,6 +3938,7 @@ paths:
                         - SUGGESTED
                         - ENGAGING
                         - WAITING
+                        - UNASSIGNED
                         - UNSUITABLE
                         - CLOSED
                     organisation:

--- a/apps/innovations/_config/inversify.ts
+++ b/apps/innovations/_config/inversify.ts
@@ -1,5 +1,7 @@
 import { container } from '@innovations/shared/config/inversify.config';
 
+import SYMBOLS from '../_services/symbols';
+
 import { ExportFileService } from '../_services/export-file-service';
 import { InnovationAssessmentsService } from '../_services/innovation-assessments.service';
 import { InnovationCollaboratorsService } from '../_services/innovation-collaborators.service';
@@ -15,7 +17,7 @@ import { InnovationsService } from '../_services/innovations.service';
 import { StatisticsService } from '../_services/statistics.service';
 import { SearchService } from '../_services/search.service';
 import { ValidationService } from '../_services/validation.service';
-import SYMBOLS from '../_services/symbols';
+import { SurveysService } from '../_services/surveys.service';
 
 // Specific inversify container configuration.
 container.bind<InnovationTasksService>(SYMBOLS.InnovationTasksService).to(InnovationTasksService).inSingletonScope();
@@ -57,5 +59,6 @@ container.bind<ExportFileService>(SYMBOLS.ExportFileService).to(ExportFileServic
 container.bind<StatisticsService>(SYMBOLS.StatisticsService).to(StatisticsService).inSingletonScope();
 container.bind<ValidationService>(SYMBOLS.ValidationService).to(ValidationService).inSingletonScope();
 container.bind<SearchService>(SYMBOLS.SearchService).to(SearchService).inSingletonScope();
+container.bind<SurveysService>(SYMBOLS.SurveysService).to(SurveysService).inSingletonScope();
 
 export { container };

--- a/apps/innovations/_services/innovation-supports.service.ts
+++ b/apps/innovations/_services/innovation-supports.service.ts
@@ -58,6 +58,7 @@ import type { InnovationFileService } from './innovation-file.service';
 import type { InnovationThreadsService } from './innovation-threads.service';
 import SYMBOLS from './symbols';
 import type { ValidationService } from './validation.service';
+import { SurveysService } from './surveys.service';
 
 type UnitSupportInformationType = {
   id: string;
@@ -101,7 +102,8 @@ export class InnovationSupportsService extends BaseService {
     @inject(SHARED_SYMBOLS.NotifierService) private notifierService: NotifierService,
     @inject(SYMBOLS.InnovationThreadsService) private innovationThreadsService: InnovationThreadsService,
     @inject(SYMBOLS.InnovationFileService) private innovationFileService: InnovationFileService,
-    @inject(SYMBOLS.ValidationService) private validationService: ValidationService
+    @inject(SYMBOLS.ValidationService) private validationService: ValidationService,
+    @inject(SYMBOLS.SurveysService) private surveysService: SurveysService
   ) {
     super();
   }
@@ -951,6 +953,11 @@ export class InnovationSupportsService extends BaseService {
 
       return { id: savedSupport.id, newAssignedAccessors: new Set(newAssignedAccessors), threadId: thread.thread.id };
     });
+
+    // Create satisfaction survey if the support was closed
+    if (data.status === InnovationSupportStatusEnum.CLOSED) {
+      await this.surveysService.createSurvey('SUPPORT_END', innovationId, result.id, connection);
+    }
 
     // Notify the innovator
     await this.notifierService.send(domainContext, NotifierTypeEnum.SUPPORT_STATUS_UPDATE, {

--- a/apps/innovations/_services/innovation-supports.service.ts
+++ b/apps/innovations/_services/innovation-supports.service.ts
@@ -951,13 +951,13 @@ export class InnovationSupportsService extends BaseService {
         transaction
       );
 
+      // Create satisfaction survey if the support was closed
+      if (data.status === InnovationSupportStatusEnum.CLOSED) {
+        await this.surveysService.createSurvey('SUPPORT_END', innovationId, savedSupport.id, transaction);
+      }
+
       return { id: savedSupport.id, newAssignedAccessors: new Set(newAssignedAccessors), threadId: thread.thread.id };
     });
-
-    // Create satisfaction survey if the support was closed
-    if (data.status === InnovationSupportStatusEnum.CLOSED) {
-      await this.surveysService.createSurvey('SUPPORT_END', innovationId, result.id, connection);
-    }
 
     // Notify the innovator
     await this.notifierService.send(domainContext, NotifierTypeEnum.SUPPORT_STATUS_UPDATE, {

--- a/apps/innovations/_services/surveys.service.spec.ts
+++ b/apps/innovations/_services/surveys.service.spec.ts
@@ -49,15 +49,4 @@ describe('Innovations / _services / surveys.service.ts suite', () => {
       ]);
     });
   });
-
-  describe('getInnovationInnovatorsRoleId', () => {
-    it('should return all active collaborators and owner of innovation', async () => {
-      const john = scenario.users.johnInnovator;
-      const jane = scenario.users.janeInnovator;
-
-      const targets = await sut['getInnovationInnovatorsRoleId'](john.innovations.johnInnovation.id, em);
-
-      expect(targets).toMatchObject([john.roles.innovatorRole.id, jane.roles.innovatorRole.id]);
-    });
-  });
 });

--- a/apps/innovations/_services/surveys.service.spec.ts
+++ b/apps/innovations/_services/surveys.service.spec.ts
@@ -1,0 +1,63 @@
+import { type EntityManager } from 'typeorm';
+
+import { TestsHelper } from '@innovations/shared/tests';
+
+import { container } from '../_config';
+import SYMBOLS from './symbols';
+import { SurveysService } from './surveys.service';
+import { randUuid } from '@ngneat/falso';
+import { InnovationSurveyEntity } from '@innovations/shared/entities';
+
+describe('Innovations / _services / surveys.service.ts suite', () => {
+  let sut: SurveysService;
+
+  let em: EntityManager;
+
+  const testsHelper = new TestsHelper();
+  const scenario = testsHelper.getCompleteScenario();
+
+  beforeAll(async () => {
+    sut = container.get<SurveysService>(SYMBOLS.SurveysService);
+    await testsHelper.init();
+  });
+
+  beforeEach(async () => {
+    em = await testsHelper.getQueryRunnerEntityManager();
+  });
+
+  afterEach(async () => {
+    await testsHelper.releaseQueryRunnerEntityManager();
+  });
+
+  describe('createSurvey', () => {
+    it('should create surveys for multiple users', async () => {
+      const john = scenario.users.johnInnovator;
+      const jane = scenario.users.janeInnovator;
+      const innovation = john.innovations.johnInnovation;
+
+      await sut.createSurvey('SUPPORT_END', innovation.id, randUuid(), em);
+
+      const dbSurveys = await em
+        .createQueryBuilder(InnovationSurveyEntity, 'survey')
+        .select('survey.targetUserRoleId', 'target')
+        .where('survey.innovation_id = :innovationId', { innovationId: innovation.id })
+        .getRawMany();
+
+      expect(dbSurveys).toMatchObject([
+        { target: john.roles.innovatorRole.id },
+        { target: jane.roles.innovatorRole.id }
+      ]);
+    });
+  });
+
+  describe('getInnovationInnovatorsRoleId', () => {
+    it('should return all active collaborators and owner of innovation', async () => {
+      const john = scenario.users.johnInnovator;
+      const jane = scenario.users.janeInnovator;
+
+      const targets = await sut['getInnovationInnovatorsRoleId'](john.innovations.johnInnovation.id, em);
+
+      expect(targets).toMatchObject([john.roles.innovatorRole.id, jane.roles.innovatorRole.id]);
+    });
+  });
+});

--- a/apps/innovations/_services/surveys.service.ts
+++ b/apps/innovations/_services/surveys.service.ts
@@ -1,15 +1,16 @@
-import { injectable } from 'inversify';
-import { Brackets, EntityManager } from 'typeorm';
+import { inject, injectable } from 'inversify';
+import { EntityManager } from 'typeorm';
 
 import { BaseService } from './base.service';
 
 import { InnovationSurveyEntity, SurveyType } from '@innovations/shared/entities/innovation/innovation-survey.entity';
 import { InnovationEntity, UserRoleEntity } from '@innovations/shared/entities';
-import { InnovationCollaboratorStatusEnum } from '@innovations/shared/enums';
+import SHARED_SYMBOLS from '@innovations/shared/services/symbols';
+import { DomainService } from '@innovations/shared/services';
 
 @injectable()
 export class SurveysService extends BaseService {
-  constructor() {
+  constructor(@inject(SHARED_SYMBOLS.DomainService) private domainService: DomainService) {
     super();
   }
 
@@ -26,7 +27,7 @@ export class SurveysService extends BaseService {
   ): Promise<void> {
     const em = entityManager ?? this.sqlConnection.manager;
 
-    const targets = await this.getInnovationInnovatorsRoleId(innovationId, em);
+    const targets = await this.domainService.innovations.getInnovationInnovatorsRoleId(innovationId, em);
 
     await em.save(
       InnovationSurveyEntity,
@@ -39,34 +40,5 @@ export class SurveysService extends BaseService {
         })
       )
     );
-  }
-
-  // NOTE: This method could be usefull to be in domain-innovations.
-  private async getInnovationInnovatorsRoleId(innovationId: string, entityManager?: EntityManager): Promise<string[]> {
-    const em = entityManager ?? this.sqlConnection.manager;
-
-    const users = await em
-      .createQueryBuilder(UserRoleEntity, 'role')
-      .select(['role.id'])
-      .innerJoinAndMapOne(
-        'innovation',
-        InnovationEntity,
-        'innovation',
-        'innovation.id = :innovationId AND innovation.deleted_at IS NULL',
-        { innovationId }
-      )
-      .leftJoin('innovation.collaborators', 'collaborator', 'collaborator.status = :activeStatus', {
-        activeStatus: InnovationCollaboratorStatusEnum.ACTIVE
-      })
-      .where('role.isActive = 1')
-      .andWhere(
-        new Brackets(qp => {
-          qp.where('role.user_id = innovation.owner_id');
-          qp.orWhere('role.user_id = collaborator.user_id');
-        })
-      )
-      .getMany();
-
-    return users.map(r => r.id);
   }
 }

--- a/apps/innovations/_services/surveys.service.ts
+++ b/apps/innovations/_services/surveys.service.ts
@@ -1,0 +1,72 @@
+import { injectable } from 'inversify';
+import { Brackets, EntityManager } from 'typeorm';
+
+import { BaseService } from './base.service';
+
+import { InnovationSurveyEntity, SurveyType } from '@innovations/shared/entities/innovation/innovation-survey.entity';
+import { InnovationEntity, UserRoleEntity } from '@innovations/shared/entities';
+import { InnovationCollaboratorStatusEnum } from '@innovations/shared/enums';
+
+@injectable()
+export class SurveysService extends BaseService {
+  constructor() {
+    super();
+  }
+
+  /**
+   * Method that creates surveys for a innovation.
+   * Currently we are assuming that a survey is always for all the Innovators (Owner + Collaborators), if this assumption
+   * changes, a `target` should be passed to filter the users.
+   */
+  async createSurvey(
+    type: SurveyType,
+    innovationId: string,
+    contextId: string,
+    entityManager?: EntityManager
+  ): Promise<void> {
+    const em = entityManager ?? this.sqlConnection.manager;
+
+    const targets = await this.getInnovationInnovatorsRoleId(innovationId, em);
+
+    await em.save(
+      InnovationSurveyEntity,
+      targets.map(roleId =>
+        InnovationSurveyEntity.new({
+          type,
+          contextId,
+          innovation: InnovationEntity.new({ id: innovationId }),
+          targetUserRoleId: UserRoleEntity.new({ id: roleId })
+        })
+      )
+    );
+  }
+
+  // NOTE: This method could be usefull to be in domain-innovations.
+  private async getInnovationInnovatorsRoleId(innovationId: string, entityManager?: EntityManager): Promise<string[]> {
+    const em = entityManager ?? this.sqlConnection.manager;
+
+    const users = await em
+      .createQueryBuilder(UserRoleEntity, 'role')
+      .select(['role.id'])
+      .innerJoinAndMapOne(
+        'innovation',
+        InnovationEntity,
+        'innovation',
+        'innovation.id = :innovationId AND innovation.deleted_at IS NULL',
+        { innovationId }
+      )
+      .leftJoin('innovation.collaborators', 'collaborator', 'collaborator.status = :activeStatus', {
+        activeStatus: InnovationCollaboratorStatusEnum.ACTIVE
+      })
+      .where('role.isActive = 1')
+      .andWhere(
+        new Brackets(qp => {
+          qp.where('role.user_id = innovation.owner_id');
+          qp.orWhere('role.user_id = collaborator.user_id');
+        })
+      )
+      .getMany();
+
+    return users.map(r => r.id);
+  }
+}

--- a/apps/innovations/_services/symbols.ts
+++ b/apps/innovations/_services/symbols.ts
@@ -13,7 +13,8 @@ export const SYMBOLS = {
   ExportFileService: Symbol.for('ExportFileService'),
   StatisticsService: Symbol.for('StatisticsService'),
   ValidationService: Symbol.for('ValidationService'),
-  SearchService: Symbol.for('SearchService')
+  SearchService: Symbol.for('SearchService'),
+  SurveysService: Symbol.for('SurveysService')
 };
 
 export default SYMBOLS;

--- a/libs/data-access/migrations/1730997335528-create-innovation-survey-table.ts
+++ b/libs/data-access/migrations/1730997335528-create-innovation-survey-table.ts
@@ -1,0 +1,30 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class createInnovationSurveyTable1730997335528 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "innovation_survey"
+      (
+          "created_at" datetime2 NOT NULL CONSTRAINT "df_innovation_survey_created_at" DEFAULT GETDATE(),
+          "updated_at" datetime2 NOT NULL CONSTRAINT "df_innovation_survey_updated_at" DEFAULT GETDATE(),
+          "deleted_at" datetime2 NULL,
+
+          "id" uniqueidentifier NOT NULL CONSTRAINT "df_innovation_survey_id" DEFAULT NEWSEQUENTIALID(),
+          "type" nvarchar(50) NOT NULL,
+          "context_id" UNIQUEIDENTIFIER NOT NULL,
+          "target_user_role_id" UNIQUEIDENTIFIER NOT NULL,
+          "innovation_id" uniqueidentifier NOT NULL,
+          "answers" nvarchar(MAX),
+
+          CONSTRAINT "pk_innovation_survey_id" PRIMARY KEY ("id"),
+          CONSTRAINT "fk_innovation_survey_target_user_role_id" FOREIGN KEY ("target_user_role_id") REFERENCES "user_role"("id") ON DELETE NO ACTION ON UPDATE NO ACTION,
+          CONSTRAINT "fk_innovation_survey_innovation_id" FOREIGN KEY ("innovation_id") REFERENCES "innovation"("id") ON DELETE NO ACTION ON UPDATE NO ACTION,
+          CONSTRAINT "CK_innovation_survey_is_json" CHECK (ISJSON(answers)=1),
+      );
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "innovation_survey"`);
+  }
+}

--- a/libs/shared/entities/index.ts
+++ b/libs/shared/entities/index.ts
@@ -27,6 +27,7 @@ import { InnovationTransferEntity } from './innovation/innovation-transfer.entit
 import { InnovationUserTestEntity } from './innovation/innovation-user-test.entity';
 import { InnovationEntity } from './innovation/innovation.entity';
 import { InnovationRecordSchemaEntity } from './innovation/innovation-record-schema.entity';
+import { InnovationSurveyEntity } from './innovation/innovation-survey.entity';
 export { ActivityLogEntity } from './innovation/activity-log.entity';
 export { InnovationTaskEntity } from './innovation/innovation-task.entity';
 export { InnovationAssessmentEntity } from './innovation/innovation-assessment.entity';
@@ -47,6 +48,7 @@ export { InnovationTransferEntity } from './innovation/innovation-transfer.entit
 export { InnovationUserTestEntity } from './innovation/innovation-user-test.entity';
 export { InnovationEntity } from './innovation/innovation.entity';
 export { InnovationRecordSchemaEntity } from './innovation/innovation-record-schema.entity';
+export { InnovationSurveyEntity } from './innovation/innovation-survey.entity';
 
 // Organisation.
 import { OrganisationUnitEntity } from './organisation/organisation-unit.entity';
@@ -117,7 +119,8 @@ export const INNOVATION_ENTITIES = [
   InnovationTransferEntity,
   InnovationUserTestEntity,
   InnovationEntity,
-  InnovationRecordSchemaEntity
+  InnovationRecordSchemaEntity,
+  InnovationSurveyEntity
 ];
 export const ORGANISATION_ENTITIES = [OrganisationUnitEntity, OrganisationEntity];
 export const USER_ENTITIES = [

--- a/libs/shared/entities/innovation/innovation-survey.entity.ts
+++ b/libs/shared/entities/innovation/innovation-survey.entity.ts
@@ -1,0 +1,66 @@
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+import { UserRoleEntity } from '../user/user-role.entity';
+import { InnovationEntity } from './innovation.entity';
+
+type SurveysMapperType = {
+  SUPPORT_END: {
+    supportSatisfaction: string;
+    ideaOnHowToProceed: string;
+    howLikelyWouldYouRecommendIS: string;
+    comment: string;
+  };
+};
+export type SurveyType = keyof SurveysMapperType;
+export type SurveyAnswersType = SurveysMapperType[SurveyType];
+
+@Entity('innovation_survey')
+export class InnovationSurveyEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'nvarchar', length: 50 })
+  type: SurveyType;
+
+  /**
+   * Type to ContextId mapping:
+   * - SUPPORT_END -> supportId
+   */
+  @Column({ name: 'context_id', type: 'nvarchar', length: 100 })
+  contextId: string;
+
+  // NOTE: If we need to make this general in the feature we can transform this entity into survey and this field to be nullable.
+  @ManyToOne(() => InnovationEntity)
+  @JoinColumn({ name: 'innovation_id' })
+  innovation: InnovationEntity;
+
+  @Column({ type: 'simple-json', nullable: true })
+  answers: null | SurveyAnswersType;
+
+  @ManyToOne(() => UserRoleEntity)
+  @JoinColumn({ name: 'target_user_role_id' })
+  targetUserRoleId: UserRoleEntity;
+
+  @CreateDateColumn({ name: 'created_at', type: 'datetime2', update: false })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'datetime2' })
+  updatedAt: Date;
+
+  @DeleteDateColumn({ name: 'deleted_at', type: 'datetime2', nullable: true })
+  deletedAt: Date;
+
+  static new(data: Partial<InnovationSurveyEntity>): InnovationSurveyEntity {
+    const instance = new InnovationSurveyEntity();
+    Object.assign(instance, data);
+    return instance;
+  }
+}

--- a/libs/shared/services/domain/domain-innovations.service.spec.ts
+++ b/libs/shared/services/domain/domain-innovations.service.spec.ts
@@ -133,6 +133,17 @@ describe('Shared / services / innovations suite', () => {
     });
   });
 
+  describe('getInnovationInnovatorsRoleId', () => {
+    it('should return all active collaborators and owner of innovation', async () => {
+      const john = scenario.users.johnInnovator;
+      const jane = scenario.users.janeInnovator;
+
+      const targets = await sut.getInnovationInnovatorsRoleId(john.innovations.johnInnovation.id, em);
+
+      expect(targets).toMatchObject([john.roles.innovatorRole.id, jane.roles.innovatorRole.id]);
+    });
+  });
+
   describe('getInnovationsFiltered', () => {
     it.each([
       ['all', false],

--- a/libs/shared/services/domain/domain-innovations.service.ts
+++ b/libs/shared/services/domain/domain-innovations.service.ts
@@ -1,5 +1,5 @@
 import type { DataSource, EntityManager, Repository } from 'typeorm';
-import { In } from 'typeorm';
+import { In, Brackets } from 'typeorm';
 
 import { cloneDeep } from 'lodash';
 import { EXPIRATION_DATES } from '../../constants';
@@ -1029,6 +1029,35 @@ export class DomainInnovationsService {
       .getRawMany(); // Using raw to avoid needless columns and Promise.all cause of lazy
 
     return res.map(r => r.unit_id);
+  }
+
+  // NOTE: For now is just retorning roleId, but can be further extended for other things if needed.
+  async getInnovationInnovatorsRoleId(innovationId: string, entityManager?: EntityManager): Promise<string[]> {
+    const em = entityManager ?? this.sqlConnection.manager;
+
+    const users = await em
+      .createQueryBuilder(UserRoleEntity, 'role')
+      .select(['role.id'])
+      .innerJoinAndMapOne(
+        'innovation',
+        InnovationEntity,
+        'innovation',
+        'innovation.id = :innovationId AND innovation.deleted_at IS NULL',
+        { innovationId }
+      )
+      .leftJoin('innovation.collaborators', 'collaborator', 'collaborator.status = :activeStatus', {
+        activeStatus: InnovationCollaboratorStatusEnum.ACTIVE
+      })
+      .where('role.isActive = 1')
+      .andWhere(
+        new Brackets(qp => {
+          qp.where('role.user_id = innovation.owner_id');
+          qp.orWhere('role.user_id = collaborator.user_id');
+        })
+      )
+      .getMany();
+
+    return users.map(r => r.id);
   }
 
   /**


### PR DESCRIPTION
**Description:**
This PR introduces a new structure to store innovation surveys.

A new table, `innovation_survey`, has been created to hold all the surveys for a specific innovation. Currently, we only have one type of survey, SUPPORT_END, but the structure is designed to support different types of surveys in the future.

Additionally, a new service, `surveys.service.ts`, has been created, which contains the logic for adding a new survey to an innovation. This method has already been used to create a survey for all the innovators from an innovation when support is closed.

**Related tickets:**
- Closes [AB#177810](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/177810)
- Closes [AB#177843](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/177843)