### PR TITLE
tests: add surveys to complete scenario

### DIFF
--- a/apps/innovations/_services/surveys.service.spec.ts
+++ b/apps/innovations/_services/surveys.service.spec.ts
@@ -5,17 +5,10 @@ import { TestsHelper } from '@innovations/shared/tests';
 import { container } from '../_config';
 import SYMBOLS from './symbols';
 import type { SurveysService } from './surveys.service';
-import { InnovationSupportEntity, InnovationSurveyEntity } from '@innovations/shared/entities';
+import { InnovationSurveyEntity } from '@innovations/shared/entities';
 import { DTOsHelper } from '@innovations/shared/tests/helpers/dtos.helper';
-import {
-  InnovationSurveyBuilder,
-  type TestInnovationSurveyType
-} from '@innovations/shared/tests/builders/innovation-survey.builder';
-import { InnovationSupportStatusEnum } from '@innovations/shared/enums';
 import { randText, randUuid } from '@ngneat/falso';
 import { ForbiddenError, ConflictError, InnovationErrorsEnum, NotFoundError } from '@innovations/shared/errors';
-
-// TODO: Move some of this surveys to complete scenario
 
 describe('Innovations / _services / surveys.service.ts suite', () => {
   let sut: SurveysService;
@@ -60,34 +53,10 @@ describe('Innovations / _services / surveys.service.ts suite', () => {
   });
 
   describe('answerSurvey', () => {
-    const john = scenario.users.johnInnovator;
-    const innovation = john.innovations.johnInnovation;
-    const support = innovation.supports.supportByHealthOrgUnit;
-    const closedDate = new Date();
-
-    let unansweredSurvey: TestInnovationSurveyType;
-    let answeredSurvey: TestInnovationSurveyType;
-
-    beforeEach(async () => {
-      await em.update(
-        InnovationSupportEntity,
-        { id: support.id },
-        { finishedAt: closedDate, status: InnovationSupportStatusEnum.CLOSED }
-      );
-
-      answeredSurvey = await new InnovationSurveyBuilder(em)
-        .setTarget(john.roles.innovatorRole.id)
-        .setTypeAndContext('SUPPORT_END', randUuid())
-        .setInnovation(innovation.id)
-        .setAnswers({} as any)
-        .save();
-
-      unansweredSurvey = await new InnovationSurveyBuilder(em)
-        .setTarget(john.roles.innovatorRole.id)
-        .setTypeAndContext('SUPPORT_END', support.id)
-        .setInnovation(innovation.id)
-        .save();
-    });
+    const otto = scenario.users.ottoOctaviusInnovator;
+    const innovation = otto.innovations.tentaclesInnovation;
+    const unansweredSurvey = innovation.surveys.unansweredSurveyToOtto;
+    const answeredSurvey = innovation.surveys.answeredSurveyToOtto;
 
     it('should save the answer of the survey', async () => {
       const expected = {
@@ -96,7 +65,7 @@ describe('Innovations / _services / surveys.service.ts suite', () => {
         supportSatisfaction: '1',
         howLikelyWouldYouRecommendIS: '10'
       };
-      await sut.answerSurvey(DTOsHelper.getUserRequestContext(john), unansweredSurvey.id, expected, em);
+      await sut.answerSurvey(DTOsHelper.getUserRequestContext(otto), unansweredSurvey.id, expected, em);
 
       const dbSurvey = await em
         .createQueryBuilder(InnovationSurveyEntity, 'survey')
@@ -109,13 +78,13 @@ describe('Innovations / _services / surveys.service.ts suite', () => {
 
     it("should give error when the survey doesn't exist", async () => {
       await expect(() =>
-        sut.answerSurvey(DTOsHelper.getUserRequestContext(john), randUuid(), {} as any, em)
+        sut.answerSurvey(DTOsHelper.getUserRequestContext(otto), randUuid(), {} as any, em)
       ).rejects.toThrow(new NotFoundError(InnovationErrorsEnum.INNOVATION_SURVEY_NOT_FOUND));
     });
 
     it('should give error when the survey is already answered', async () => {
       await expect(() =>
-        sut.answerSurvey(DTOsHelper.getUserRequestContext(john), answeredSurvey.id, {} as any, em)
+        sut.answerSurvey(DTOsHelper.getUserRequestContext(otto), answeredSurvey.id, {} as any, em)
       ).rejects.toThrow(new ConflictError(InnovationErrorsEnum.INNOVATION_SURVEY_ALREADY_ANSWERED));
     });
 
@@ -132,48 +101,23 @@ describe('Innovations / _services / surveys.service.ts suite', () => {
   });
 
   describe('getUnansweredSurveys', () => {
-    const john = scenario.users.johnInnovator;
-    const innovation = john.innovations.johnInnovation;
-    const support = innovation.supports.supportByHealthOrgUnit;
-    const closedDate = new Date();
-
-    let survey: TestInnovationSurveyType;
-
-    beforeEach(async () => {
-      await em.update(
-        InnovationSupportEntity,
-        { id: support.id },
-        { finishedAt: closedDate, status: InnovationSupportStatusEnum.CLOSED }
-      );
-
-      // One survey that was answered.
-      await new InnovationSurveyBuilder(em)
-        .setTarget(john.roles.innovatorRole.id)
-        .setTypeAndContext('SUPPORT_END', randUuid())
-        .setInnovation(innovation.id)
-        .setAnswers({} as any)
-        .save();
-
-      // One that is unanswered
-      survey = await new InnovationSurveyBuilder(em)
-        .setTarget(john.roles.innovatorRole.id)
-        .setTypeAndContext('SUPPORT_END', support.id)
-        .setInnovation(innovation.id)
-        .save();
-    });
-
     it('should return all unanswered surveys for an innovation', async () => {
-      const surveys = await sut.getUnansweredSurveys(DTOsHelper.getUserRequestContext(john), innovation.id, em);
+      const otto = scenario.users.ottoOctaviusInnovator;
+      const innovation = otto.innovations.tentaclesInnovation;
+      const support = innovation.supports.tentaclesInnovationSupportClosed;
+      const survey = innovation.surveys.unansweredSurveyToOtto;
+
+      const surveys = await sut.getUnansweredSurveys(DTOsHelper.getUserRequestContext(otto), innovation.id, em);
 
       expect(surveys).toMatchObject([
         {
           id: survey.id,
-          createdAt: survey.createdAt,
+          createdAt: new Date(survey.createdAt),
           info: {
             type: 'SUPPORT_END',
             supportId: support.id,
-            supportUnit: scenario.organisations.healthOrg.organisationUnits.healthOrgUnit.name,
-            supportFinishedAt: closedDate
+            supportUnit: scenario.organisations.innovTechOrg.organisationUnits.innovTechHeavyOrgUnit.name,
+            supportFinishedAt: expect.any(Date)
           }
         }
       ]);

--- a/libs/shared/tests/scenarios/complete-scenario.builder.ts
+++ b/libs/shared/tests/scenarios/complete-scenario.builder.ts
@@ -43,6 +43,7 @@ import { NotifyMeSubscriptionBuilder } from '../builders/notify-me-subscription.
 import { OrganisationUnitBuilder } from '../builders/organisation-unit.builder';
 import { OrganisationBuilder } from '../builders/organisation.builder';
 import { type TestUserType, UserBuilder } from '../builders/user.builder';
+import { InnovationSurveyBuilder } from '../builders/innovation-survey.builder';
 
 export type CompleteScenarioType = Awaited<ReturnType<CompleteScenarioBuilder['createScenario']>>;
 
@@ -943,6 +944,33 @@ export class CompleteScenarioBuilder {
         .setCreatedAndUpdatedBy(aliceQualifyingAccessor.id, aliceQualifyingAccessor.roles['qaRole']!.id)
         .save();
 
+      // closed support on tentaclesInnovation by innovTechHeavy
+      const tentaclesInnovationClosedSupport = await new InnovationSupportBuilder(entityManager)
+        .setStatus(InnovationSupportStatusEnum.CLOSED)
+        .setInnovation(tentaclesInnovation.id)
+        .setMajorAssessment(tentaclesInnovationAssessmentByPaul.id)
+        .setOrganisationUnit(innovTechHeavyOrgUnit.id)
+        .setCreatedAndUpdatedBy(paulNeedsAssessor.id, paulNeedsAssessor.roles['assessmentRole']!.id)
+        .setFinishedAt(new Date())
+        .save();
+
+      const tentaclesInnovationEndSupportUnansweredSurvey = await new InnovationSurveyBuilder(entityManager)
+        .setTarget(ottoOctaviusInnovator.roles['innovatorRole']!.id)
+        .setTypeAndContext('SUPPORT_END', tentaclesInnovationClosedSupport.id)
+        .setInnovation(tentaclesInnovation.id)
+        .save();
+      const tentaclesInnovationEndSupportAnsweredSurvey = await new InnovationSurveyBuilder(entityManager)
+        .setTarget(ottoOctaviusInnovator.roles['innovatorRole']!.id)
+        .setTypeAndContext('SUPPORT_END', tentaclesInnovationClosedSupport.id)
+        .setInnovation(tentaclesInnovation.id)
+        .setAnswers({
+          comment: randText(),
+          ideaOnHowToProceed: 'YES',
+          supportSatisfaction: '10',
+          howLikelyWouldYouRecommendIS: '10'
+        })
+        .save();
+
       const brainComputerInterfaceInnovation = await new InnovationBuilder(entityManager)
         .setName('Brain Computer Interface')
         .setOwner(ottoOctaviusInnovator.id)
@@ -1272,7 +1300,14 @@ export class CompleteScenarioBuilder {
               },
               tentaclesInnovation: {
                 ...tentaclesInnovation,
-                supports: { tentaclesInnovationSupport: tentaclesInnovationSupport }
+                supports: {
+                  tentaclesInnovationSupport: tentaclesInnovationSupport,
+                  tentaclesInnovationSupportClosed: tentaclesInnovationClosedSupport
+                },
+                surveys: {
+                  unansweredSurveyToOtto: tentaclesInnovationEndSupportUnansweredSurvey,
+                  answeredSurveyToOtto: tentaclesInnovationEndSupportAnsweredSurvey
+                }
               },
               brainComputerInterfaceInnovation: {
                 ...brainComputerInterfaceInnovation,


### PR DESCRIPTION
**Description:**
To make development faster, surveys were previously created directly in `surveys.service.spec.ts`. This PR extracts and adds them to the complete scenario, as they may be useful for other tests.

**Related tickets:**
- US: [AB#177473](https://nhsidev.visualstudio.com/7f3e8d94-c48d-41cc-b5aa-0aee0596a809/_workitems/edit/177473)