### PR TITLE
Added dynamic computed lastSupportGivenAt

### DIFF
--- a/apps/innovations/.apim/swagger.yaml
+++ b/apps/innovations/.apim/swagger.yaml
@@ -1525,6 +1525,7 @@ paths:
                 - support.status
                 - support.updatedAt
                 - support.updatedBy
+                - lastSupportGivenAt
                 - owner.id
                 - owner.name
                 - owner.companyName
@@ -6600,6 +6601,7 @@ paths:
                 - support.status
                 - support.updatedAt
                 - support.updatedBy
+                - lastSupportGivenAt
                 - owner.id
                 - owner.name
                 - owner.companyName

--- a/apps/innovations/_services/innovations.service.ts
+++ b/apps/innovations/_services/innovations.service.ts
@@ -48,7 +48,7 @@ import {
   UnprocessableEntityError
 } from '@innovations/shared/errors';
 import type { PaginationQueryParamsType } from '@innovations/shared/helpers';
-import { TranslationHelper } from '@innovations/shared/helpers';
+import { TranslationHelper, TypeORMHelper } from '@innovations/shared/helpers';
 import { DomainService, IRSchemaService, NotifierService } from '@innovations/shared/services';
 import {
   type ActivityLogListParamsType,
@@ -125,6 +125,7 @@ export const InnovationListSelectType = [
   'support.status',
   'support.updatedAt',
   'support.updatedBy',
+  'lastSupportGivenAt',
   'owner.id',
   'owner.name',
   'owner.companyName',
@@ -141,6 +142,7 @@ export type InnovationListSelectType =
   | 'assessment.isExempt'
   | `support.${keyof Pick<InnovationSupportEntity, 'id' | 'status' | 'updatedAt' | 'updatedBy' | 'closeReason'>}`
   | 'support.isShared'
+  // | 'lastSupportGivenAt'
   | 'owner.id'
   | 'owner.name'
   | 'owner.companyName'
@@ -165,6 +167,7 @@ export type InnovationListFullResponseType = Omit<InnovationListViewFields, 'eng
     closeReason: InnovationSupportCloseReasonEnum | null;
     isShared: boolean;
   } | null;
+  lastSupportGivenAt: Date | null;
   suggestion: {
     suggestedBy: string[];
     suggestedOn: Date;
@@ -293,6 +296,8 @@ export class InnovationsService extends BaseService {
     },
     em?: EntityManager
   ): Promise<{ count: number; data: InnovationListResponseType<S>[] }> {
+    const COMPUTED_FIELDS = ['lastSupportGivenAt'] as const;
+
     // TODO allow selection within JSON fields, ie: only fetch engagingOrganisations.organisationId
 
     // Some sanity checks
@@ -329,13 +334,26 @@ export class InnovationsService extends BaseService {
     );
 
     const connection = em ?? this.sqlConnection.manager;
-    const query = connection
-      .createQueryBuilder(InnovationListView, 'innovation')
-      // currently I'm only handling the root selects here, might change in the future. ie: withSupports add the selects
-      .select(params.fields.filter(item => !item.includes('.')).map(item => `innovation.${item}`));
+
+    const query = connection.createQueryBuilder(InnovationListView, 'innovation');
+    // currently I'm only handling the root selects here, might change in the future. ie: withSupports add the selects
+      // added logic to remove auto-included computed fields to avoid alias duplication
+    query.select(
+      params.fields
+        .filter(item => !item.includes('.') && !COMPUTED_FIELDS.includes(item as any))
+        .map(item => `innovation.${item}`)
+    );
 
     // Special role constraints (maybe make handler in the future)
     if (isAccessorDomainContextType(domainContext)) {
+      // Dynamically add lastSupportGivenAt
+      if (
+        (params.fields as S[]).includes('lastSupportGivenAt' as S) &&
+        !query.expressionMap.selects.some(s => s.aliasName === 'lastSupportGivenAt')
+      ) {
+        TypeORMHelper.addLastSupportGivenAtSubquery(query, domainContext.organisation.organisationUnit.id);
+      }
+
       // support is required for A/QAs access check
       if (!nestedObjects.has('support')) {
         nestedObjects.add('support');
@@ -430,14 +448,33 @@ export class InnovationsService extends BaseService {
             throw new NotImplementedError(GenericErrorsEnum.NOT_IMPLEMENTED_ERROR, {
               message: 'Sort by name is not allowed'
             });
-
+          case 'lastSupportGivenAt':
+            query.addOrderBy('lastSupportGivenAt', value);
+            break;
           default:
             query.addOrderBy(key.includes('.') ? key : `innovation.${key}`, value);
         }
       }
     });
 
-    const queryResult = await query.getManyAndCount();
+    let queryResult: [InnovationListView[], number] = [[], 0];
+
+    // if computed fields present, we need to manually map those to the view results
+    if (COMPUTED_FIELDS.length) {
+      const { raw, entities } = await query.getRawAndEntities();
+      // Manually hydrate computed fields
+      entities.forEach((entity, index) => {
+        if ('lastSupportGivenAt' in raw[index]) {
+          (entity as any).lastSupportGivenAt = raw[index].lastSupportGivenAt;
+        }
+      });
+
+      const count = await query.getCount();
+
+      queryResult = [entities, count];
+    } else {
+      queryResult = await query.getManyAndCount();
+    }
 
     // postHandlers - optimize to only fetch once. This means that the fields handled here aren't sortable but it would
     // be really bad performant otherwise and for the names even worse.
@@ -1467,7 +1504,7 @@ export class InnovationsService extends BaseService {
     }
 
     const [innovations, count] = await query.getManyAndCount();
-
+    
     return {
       innovations: innovations.map(innovation => ({
         id: innovation.id,

--- a/libs/shared/entities/views/innovation-list-view.entity.ts
+++ b/libs/shared/entities/views/innovation-list-view.entity.ts
@@ -97,6 +97,9 @@ export class InnovationListView {
   @Column({ name: 'areas' })
   areas: catalogAreas[] | null;
 
+  @Column({ select: false, nullable: true })
+  lastSupportGivenAt?: Date;
+
   @OneToOne(() => InnovationAssessmentEntity)
   @JoinColumn({ name: 'current_assessment_id' })
   currentAssessment: InnovationAssessmentEntity | null;

--- a/libs/shared/helpers/index.ts
+++ b/libs/shared/helpers/index.ts
@@ -4,3 +4,4 @@ export { JoiHelper, PaginationQueryParamsType } from './joi.helper';
 export { SwaggerHelper } from './swagger.helper';
 export { TranslationHelper } from './translation.helper';
 export { ValidationsHelper } from './validations.helper';
+export { TypeORMHelper } from './type-orm.helper';

--- a/libs/shared/helpers/type-orm.helper.ts
+++ b/libs/shared/helpers/type-orm.helper.ts
@@ -1,17 +1,50 @@
 // import { Connection, EntityTarget } from 'typeorm';
+import type { SelectQueryBuilder } from 'typeorm';
 
-// export class TypeORMHelper {
+export class TypeORMHelper {
+  //   static getEntityColumnList(connection: Connection, entity: EntityTarget<any>): string[] {
 
-//   static getEntityColumnList(connection: Connection, entity: EntityTarget<any>): string[] {
+  //     return connection.getMetadata(entity).ownColumns.map(c => c.propertyName);
 
-//     return connection.getMetadata(entity).ownColumns.map(c => c.propertyName);
+  //   }
 
-//   }
+  //   static getEntityRelationColumnsList(connection: Connection, entity: EntityTarget<any>): string[] {
 
-//   static getEntityRelationColumnsList(connection: Connection, entity: EntityTarget<any>): string[] {
+  //     return connection.getMetadata(entity).ownRelations.map(c => c.propertyName)
 
-//     return connection.getMetadata(entity).ownRelations.map(c => c.propertyName)
+  //   }
 
-//   }
+  static addLastSupportGivenAtSubquery(query: SelectQueryBuilder<any>, organisationUnitID: string) {
+    // Subquery for latest message
+    const lastMsgSubquery = query
+      .subQuery()
+      .select('TOP 1 m.created_at', 'last_activity')
+      .from('innovation_thread_message', 'm')
+      .innerJoin('innovation_thread', 't', `m.innovation_thread_id = t.id AND t.innovation_id = innovation.id`)
+      .where('m.deleted_at IS NULL')
+      .andWhere('m.author_organisation_unit_id = :organisationUnitID', { organisationUnitID })
+      .orderBy('m.created_at', 'DESC');
 
-// }
+    // Subquery for latest support log
+    const lastSupportSubquery = query
+      .subQuery()
+      .select('TOP 1 sl.created_at', 'last_activity')
+      .from('innovation_support_log', 'sl')
+      .where(`sl.innovation_id = innovation.id`)
+      .andWhere('sl.deleted_at IS NULL')
+      .andWhere(
+        '(sl.organisation_unit_id = :organisationUnitID)',
+        { organisationUnitID }
+      )
+      .orderBy('sl.created_at', 'DESC');
+
+    // Combine them using derived table and MAX
+    query
+      .addSelect(subQuery => {
+        return subQuery
+          .select('MAX(x.last_activity)', 'lastSupportGivenAt')
+          .from(`(${lastMsgSubquery.getQuery()} UNION ALL ${lastSupportSubquery.getQuery()})`, 'x');
+      }, 'lastSupportGivenAt')
+      .setParameter('organisationUnitID', organisationUnitID);
+  }
+}


### PR DESCRIPTION
Updates `innovations.service.getInnovationsList()` to return a new computed field `lastSupportGivenAt`, needed for an change made to the Support Updated column on innovations table page, for QA/A roles.
This field returns the latest entry between last innovation_support_log entry, or latest message sent from the supporting unit to the innovator.